### PR TITLE
feat: 記録詳細画面と比較ビューを統合

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,40 +1,5 @@
+﻿import { RecordDetailPage } from "./components/RecordDetailPage";
+
 export default function App() {
-  return (
-    <main className="min-h-screen bg-[radial-gradient(circle_at_top,_#1a243a,_#09090b_60%)] text-zinc-100">
-      <div className="mx-auto flex min-h-screen max-w-5xl flex-col justify-center px-6 py-16">
-        <div className="inline-flex w-fit rounded-full border border-emerald-400/30 bg-emerald-400/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-emerald-200">
-          elite-run-db
-        </div>
-        <h1 className="mt-6 max-w-3xl text-4xl font-semibold tracking-tight text-white sm:text-5xl">
-          Vite + React + TypeScript scaffold is ready.
-        </h1>
-        <p className="mt-4 max-w-2xl text-base leading-7 text-zinc-300 sm:text-lg">
-          The real app can now be developed under <code>src/</code>. Treat{" "}
-          <code>docs/mocks/submit-page-ui-prototype.html</code> as the temporary migration reference, not the final implementation target.
-        </p>
-        <div className="mt-10 grid gap-4 sm:grid-cols-2">
-          <section className="rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-zinc-300">
-              Available now
-            </h2>
-            <ul className="mt-4 space-y-2 text-sm text-zinc-200">
-              <li>`npm run dev` for local development</li>
-              <li>`npm run build` for production build checks</li>
-              <li>`npm run preview` for built output review</li>
-            </ul>
-          </section>
-          <section className="rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur">
-            <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-zinc-300">
-              Next migration target
-            </h2>
-            <ul className="mt-4 space-y-2 text-sm text-zinc-200">
-              <li>Move the current prototype flow into semantic React components</li>
-              <li>Keep `docs/mocks/*.mock.tsx` as layout references only</li>
-              <li>Start with submission flow and shared data models</li>
-            </ul>
-          </section>
-        </div>
-      </div>
-    </main>
-  );
+  return <RecordDetailPage />;
 }

--- a/src/components/CharacterIcon.tsx
+++ b/src/components/CharacterIcon.tsx
@@ -1,0 +1,111 @@
+﻿import { useEffect, useMemo, useState } from "react";
+
+const AMBR_NAME_MAP: Record<string, string> = {
+  amber: "Ambor",
+  bennett: "Bennett",
+  citlali: "Citlali",
+  collei: "Collei",
+  furina: "Furina",
+  keqing: "Keqing",
+  mav: "Mavuika",
+  xiangling: "Xiangling",
+  xilonen: "Xilonen",
+  xingqiu: "Xingqiu",
+  zhongli: "Zhongli",
+};
+
+const UI_MIRRORS = [
+  "https://api.ambr.top/assets/UI/",
+  "https://enka.network/ui/",
+  "http://file.microgg.cn/ui/",
+] as const;
+
+const IMAGE_PATTERNS = {
+  circle: (name: string) => `UI_AvatarIcon_${name}_Circle.png`,
+  icon: (name: string) => `UI_AvatarIcon_${name}.png`,
+};
+
+const VARIANT_FALLBACKS = {
+  circle: ["circle", "icon"],
+  icon: ["icon"],
+} as const;
+
+type CharacterIconVariant = keyof typeof VARIANT_FALLBACKS;
+
+function getAmbrName(characterId: string) {
+  return AMBR_NAME_MAP[characterId] ?? "Traveler";
+}
+
+function getCharacterImageCandidates(characterId: string, variant: CharacterIconVariant) {
+  const ambrName = getAmbrName(characterId);
+  const urls: string[] = [];
+
+  VARIANT_FALLBACKS[variant].forEach((currentVariant) => {
+    const pattern = IMAGE_PATTERNS[currentVariant];
+    UI_MIRRORS.forEach((base) => {
+      urls.push(`${base}${pattern(ambrName)}`);
+    });
+  });
+
+  return urls;
+}
+
+export function CharacterIcon({
+  alt,
+  characterId,
+  className = "",
+  fallbackLabel,
+  size,
+  variant = "circle",
+}: {
+  alt: string;
+  characterId: string;
+  className?: string;
+  fallbackLabel?: string;
+  size: number;
+  variant?: CharacterIconVariant;
+}) {
+  const [index, setIndex] = useState(0);
+  const [hidden, setHidden] = useState(false);
+  const urls = useMemo(() => getCharacterImageCandidates(characterId, variant), [characterId, variant]);
+  const fallbackText = Array.from(fallbackLabel ?? alt ?? characterId).slice(0, 2).join("");
+
+  useEffect(() => {
+    setIndex(0);
+    setHidden(false);
+  }, [characterId, variant]);
+
+  if (hidden || urls.length === 0) {
+    return (
+      <div
+        className={`flex shrink-0 items-center justify-center rounded-full bg-black/10 text-[#909399] ${className}`}
+        style={{ width: size, height: size, fontSize: Math.max(10, Math.round(size * 0.28)) }}
+        aria-hidden="true"
+      >
+        {fallbackText}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={urls[index]}
+      alt={alt}
+      className={`shrink-0 rounded-full object-cover ${className}`}
+      style={{ width: size, height: size }}
+      referrerPolicy="no-referrer"
+      loading="lazy"
+      decoding="async"
+      onError={() => {
+        const nextIndex = index + 1;
+
+        if (nextIndex < urls.length) {
+          setIndex(nextIndex);
+          return;
+        }
+
+        setHidden(true);
+      }}
+    />
+  );
+}

--- a/src/components/RecordDetailPage.tsx
+++ b/src/components/RecordDetailPage.tsx
@@ -218,16 +218,16 @@ function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.R
   const partyLoadout = getPartyLoadout(run);
 
   return (
-    <div className="flex min-h-full flex-col gap-[16px] bg-white px-4 py-4">
+    <div className="flex min-h-full flex-col gap-[16px] bg-white px-3 py-3 md:px-4 md:py-4 lg:px-5 lg:py-5">
       <VideoFrame title={run.title} videoUrl={run.videoUrl} iframeRef={iframeRef} mute />
 
       <div className="flex flex-col gap-[12px]">
         <div className="flex flex-col gap-[12px]">
-          <div className="text-[20px] font-bold leading-none text-black md:text-[24px]">{run.title}</div>
+          <div className="text-[16px] font-bold leading-none text-black md:text-[18px]">{run.title}</div>
           <div className="flex items-center justify-between gap-[12px]">
             <div className="flex min-w-0 items-center gap-[12px]">
               <CircleAvatar label={run.userName} size={40} />
-              <div className="truncate text-[18px] leading-none text-black md:text-[20px]">{run.userName}</div>
+              <div className="truncate text-[16px] font-bold leading-none text-black md:text-[18px]">{run.userName}</div>
             </div>
             <div className="shrink-0 rounded-[42px] bg-[#f2f2f2] px-[10px] py-[5px] text-[12px] text-black md:text-[13px]">
               {run.platform}
@@ -335,7 +335,7 @@ function CompareDrawer({
   return (
     <div className="fixed inset-y-0 right-0 z-50 hidden lg:block" aria-modal="false" role="complementary">
       <div className="flex h-full w-[50vw] flex-col border-l border-[#ebebeb] bg-white shadow-[-12px_0_24px_rgba(0,0,0,0.08)]">
-        <div className="flex min-h-[52px] items-center justify-between border-b border-[#ebebeb] px-4 py-2 md:px-5">
+        <div className="flex min-h-[52px] items-center justify-between border-b border-[#ebebeb] px-3 py-2 md:px-4 lg:px-5">
           <div className="min-w-0">
             <div className="text-[16px] font-semibold text-black md:text-[18px]">比較ビュー</div>
           </div>
@@ -543,7 +543,7 @@ export function RecordDetailPage() {
         <nav className="sticky top-0 z-40 border-b border-[#ebebeb] bg-white shadow-[0_1px_0_rgba(0,0,0,0.02)]">
           <div className={`header-font mx-auto flex max-w-[1600px] items-center justify-between px-4 py-2 ${forceMobileLayout ? "min-h-[52px]" : "md:px-6 md:py-3"}`}>
             <div className={`flex items-center ${forceMobileLayout ? "gap-3" : "gap-4 md:gap-6"}`}>
-              <h1 className={`font-semibold tracking-tight text-black ${forceMobileLayout ? "text-[24px]" : "text-[26px] md:text-[38px]"}`}>精鋭狩りDB仮</h1>
+              <h1 className={`font-semibold tracking-tight text-black ${forceMobileLayout ? "text-[24px]" : "text-[26px] md:text-[38px]"}`}>精鋭狩りDB</h1>
               <div className="relative">
                 <select
                   className={`appearance-none rounded-full border border-black/30 bg-white py-1.5 pl-3 pr-10 font-medium text-black ${forceMobileLayout ? "text-[15px]" : "text-[16px] md:pl-4 md:pr-12 md:text-[20px]"}`}
@@ -577,17 +577,17 @@ export function RecordDetailPage() {
           </div>
         </nav>
 
-        <div className={`mx-auto flex w-full max-w-[1600px] flex-col gap-[12px] px-4 py-4 ${forceMobileLayout ? "" : "md:px-6 md:py-5 lg:py-6"} ${compareOpen ? "lg:items-stretch" : "lg:flex-row lg:items-start lg:gap-[14px]"}`}>
+        <div className={`mx-auto flex w-full max-w-[1600px] flex-col gap-[12px] px-3 py-3 ${forceMobileLayout ? "" : "md:px-4 md:py-4 lg:px-5 lg:py-5"} ${compareOpen ? "lg:items-stretch" : "lg:flex-row lg:items-start lg:gap-[14px]"}`}>
           <section className={`flex min-w-0 flex-1 flex-col gap-[18px] ${compareOpen ? "lg:flex-none" : "lg:flex-[1_1_auto]"}`}>
             <VideoFrame title={currentRun.title} videoUrl={currentRun.videoUrl} iframeRef={mainVideoIframeRef} autoplay mute />
 
             <div className="flex flex-col gap-[12px]">
               <div className="flex flex-col gap-[12px]">
-                <div className={`font-bold leading-none text-black ${forceMobileLayout ? "text-[20px]" : "text-[20px] md:text-[24px]"}`}>{currentRun.title}</div>
+                <div className="text-[16px] font-bold leading-none text-black md:text-[18px]">{currentRun.title}</div>
                 <div className={`flex gap-[12px] ${compareOpen ? "flex-col items-start" : "items-center justify-between"}`}>
                   <div className="flex min-w-0 items-center gap-[12px]">
                     <CircleAvatar label={currentRun.userName} size={40} />
-                    <div className={`truncate leading-none text-black ${forceMobileLayout ? "text-[18px]" : "text-[18px] md:text-[20px]"}`}>{currentRun.userName}</div>
+                    <div className="truncate text-[16px] font-bold leading-none text-black md:text-[18px]">{currentRun.userName}</div>
                   </div>
                   <div className={`flex gap-[12px] md:gap-[12px] ${compareOpen ? "w-full shrink min-w-0 flex-wrap" : "shrink-0 flex-nowrap"}`}>
                     <PillButton active={liked} onClick={() => setLiked((previous) => !previous)} className="min-h-[36px] min-w-[92px]">
@@ -764,6 +764,12 @@ export function RecordDetailPage() {
     </>
   );
 }
+
+
+
+
+
+
 
 
 

--- a/src/components/RecordDetailPage.tsx
+++ b/src/components/RecordDetailPage.tsx
@@ -17,6 +17,7 @@ import {
   weaponDb,
 } from "../data/mockRuns";
 import { getSimilarRuns } from "../lib/getSimilarRuns";
+import { CharacterIcon } from "./CharacterIcon";
 
 const collapsedCopyStyle: CSSProperties = {
   display: "-webkit-box",
@@ -110,6 +111,7 @@ function getPartyLoadout(run: RunRecord) {
 
     return {
       slot: index + 1,
+      characterId: member.characterId,
       characterName: character?.name ?? member.characterId,
       cons: member.cons,
       weaponName: weapon?.name ?? weaponLoadout.weaponId,
@@ -197,7 +199,7 @@ function VideoFrame({
   const embedUrl = getYouTubeEmbedUrl(videoUrl, { autoplay, mute, enableJsApi: true });
 
   return (
-    <div className="aspect-[669/380] w-full overflow-hidden rounded-[16px] bg-[#d9d9d9] shadow-[0_2px_10px_rgba(0,0,0,0.04)]">
+    <div className="aspect-[669/380] w-full overflow-hidden rounded-[12px] border border-[#ebebeb] bg-[#d9d9d9] shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
       {embedUrl ? (
         <iframe
           ref={iframeRef}
@@ -233,7 +235,7 @@ function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.R
           </div>
         </div>
 
-        <div className="w-full rounded-[16px] bg-[#f2f2f2] p-[12px] shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]">
+        <div className="w-full rounded-[12px] border border-[#ebebeb] bg-[#f5f6f8] p-[12px]">
           <div className="flex items-center gap-x-[16px] overflow-x-auto whitespace-nowrap text-[13px] text-black md:gap-x-[18px] md:text-[14px]">
             <span>ver : {run.versionLabel}</span>
             <span>{run.postedLabel}</span>
@@ -253,13 +255,13 @@ function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.R
         </div>
       </div>
 
-      <section className="w-full rounded-[16px] border border-[#f1f3f5] bg-white p-[12px]">
+      <section className="w-full rounded-[12px] border border-[#ebebeb] bg-white p-[12px] shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
         <div className="flex flex-col gap-[20px]">
           <SectionTitle>使用編成</SectionTitle>
           <div className="flex flex-col gap-[18px] md:gap-[20px]">
             {partyLoadout.map((entry) => (
               <div key={`${run.id}-${entry.characterName}-${entry.slot}`} className="flex items-center gap-[12px]">
-                <CircleAvatar label={entry.characterName} size={60} />
+                <CharacterIcon characterId={entry.characterId} alt={entry.characterName} fallbackLabel={entry.characterName} size={60} />
                 <div className="flex min-w-0 flex-1 items-center justify-between gap-[12px]">
                   <div className="min-w-0">
                     <div className="truncate text-[17px] font-medium leading-none text-black md:text-[18px]">{entry.characterName}</div>
@@ -332,7 +334,7 @@ function CompareDrawer({
 
   return (
     <div className="fixed inset-y-0 right-0 z-50 hidden lg:block" aria-modal="false" role="complementary">
-      <div className="flex h-full w-[50vw] flex-col border-l border-[#ececec] bg-white shadow-[-18px_0_48px_rgba(0,0,0,0.12)]">
+      <div className="flex h-full w-[50vw] flex-col border-l border-[#ebebeb] bg-white shadow-[-12px_0_24px_rgba(0,0,0,0.08)]">
         <div className="flex min-h-[52px] items-center justify-between border-b border-[#ebebeb] px-4 py-2 md:px-5">
           <div className="min-w-0">
             <div className="text-[16px] font-semibold text-black md:text-[18px]">比較ビュー</div>
@@ -395,7 +397,7 @@ function SimilarActionMenu({
         </svg>
       </button>
       {isOpen ? (
-        <div className="absolute right-0 top-full z-20 mt-2 w-[168px] rounded-[12px] border border-[#e5e5e5] bg-white p-2 shadow-[0_8px_24px_rgba(0,0,0,0.08)]">
+        <div className="absolute right-0 top-full z-20 mt-2 w-[168px] rounded-[12px] border border-[#ebebeb] bg-white p-2 shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
           <button
             type="button"
             className="block w-full rounded-[8px] px-3 py-2 text-left text-[13px] text-black hover:bg-[#f2f2f2]"
@@ -598,7 +600,7 @@ export function RecordDetailPage() {
                 </div>
               </div>
 
-              <div className="w-full rounded-[16px] bg-[#f2f2f2] p-[12px] shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]">
+              <div className="w-full rounded-[12px] border border-[#ebebeb] bg-[#f5f6f8] p-[12px]">
                 <div className={`flex gap-[16px] ${compareOpen ? "flex-col items-start whitespace-normal" : "items-center justify-between whitespace-nowrap"}`}>
                   <div className={`flex min-w-0 gap-x-[16px] text-[13px] text-black md:gap-x-[18px] md:text-[14px] ${compareOpen ? "flex-wrap items-center gap-y-[6px]" : "items-center"}`}>
                     <span>ver : {currentRun.versionLabel}</span>
@@ -673,13 +675,13 @@ export function RecordDetailPage() {
           </section>
 
           <aside className={`flex w-full shrink-0 flex-col gap-[18px] ${compareOpen ? "lg:w-full xl:w-full" : "lg:w-[360px] xl:w-[372px]"}`}>
-            <section className="w-full rounded-[16px] border border-[#f1f3f5] bg-white p-[12px]">
+            <section className="w-full rounded-[12px] border border-[#ebebeb] bg-white p-[12px] shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
               <div className="flex flex-col gap-[20px]">
                 <SectionTitle>使用編成</SectionTitle>
                 <div className="flex flex-col gap-[18px] md:gap-[20px]">
                   {partyLoadout.map((entry) => (
                     <div key={`${entry.characterName}-${entry.slot}`} className="flex items-center gap-[12px]">
-                      <CircleAvatar label={entry.characterName} size={60} />
+                      <CharacterIcon characterId={entry.characterId} alt={entry.characterName} fallbackLabel={entry.characterName} size={60} />
                       <div className="flex min-w-0 flex-1 items-center justify-between gap-[12px]">
                         <div className="min-w-0">
                           <div className="truncate text-[17px] font-medium leading-none text-black md:text-[18px]">{entry.characterName}</div>
@@ -696,7 +698,7 @@ export function RecordDetailPage() {
               </div>
             </section>
 
-            <section className="w-full rounded-[16px] border border-[#f1f3f5] bg-white p-[12px]">
+            <section className="w-full rounded-[12px] border border-[#ebebeb] bg-white p-[12px] shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
               <div className="flex flex-col gap-[20px]">
                 <SectionTitle>類似編成の記録</SectionTitle>
                 <div className="flex flex-col gap-[18px] md:gap-[20px]">
@@ -706,13 +708,13 @@ export function RecordDetailPage() {
                     const isCompareQueued = compareQueuedRunId === match.run.id;
 
                     return (
-                      <div key={match.run.id} className={isCompareQueued ? "rounded-[12px] bg-[#f7f7f7] px-[8px] py-[8px]" : "rounded-[10px] px-[4px] py-[4px] transition-colors hover:bg-[#fafafa]"}>
+                      <div key={match.run.id} className={isCompareQueued ? "rounded-[12px] bg-[#f7f7f7] px-[8px] py-[8px]" : "rounded-[12px] px-[4px] py-[4px] transition-colors hover:bg-[#fafafa]"}>
                         <div className="flex flex-col items-end gap-[10px]">
                           <div className="h-[40px] w-full px-[8px]">
                             <div className="flex h-[40px] items-center justify-between gap-[4px]">
                               {match.run.party.map((member) => {
                                 const characterName = characterDb[member.characterId]?.name ?? member.characterId;
-                                return <CircleAvatar key={`${match.run.id}-${member.characterId}`} label={characterName} size={32} dark />;
+                                return <CharacterIcon key={`${match.run.id}-${member.characterId}`} characterId={member.characterId} alt={characterName} fallbackLabel={characterName} size={32} />;
                               })}
                             </div>
                           </div>
@@ -762,6 +764,8 @@ export function RecordDetailPage() {
     </>
   );
 }
+
+
 
 
 

--- a/src/components/RecordDetailPage.tsx
+++ b/src/components/RecordDetailPage.tsx
@@ -218,7 +218,7 @@ function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.R
   const partyLoadout = getPartyLoadout(run);
 
   return (
-    <div className="flex min-h-full flex-col gap-[16px] bg-white px-3 py-3 md:px-4 md:py-4 lg:px-5 lg:py-5">
+    <div className="flex min-h-full flex-col gap-[16px] bg-white px-3 py-3">
       <VideoFrame title={run.title} videoUrl={run.videoUrl} iframeRef={iframeRef} mute />
 
       <div className="flex flex-col gap-[12px]">
@@ -335,7 +335,7 @@ function CompareDrawer({
   return (
     <div className="fixed inset-y-0 right-0 z-50 hidden lg:block" aria-modal="false" role="complementary">
       <div className="flex h-full w-[50vw] flex-col border-l border-[#ebebeb] bg-white shadow-[-12px_0_24px_rgba(0,0,0,0.08)]">
-        <div className="flex min-h-[52px] items-center justify-between border-b border-[#ebebeb] px-3 py-2 md:px-4 lg:px-5">
+        <div className="flex min-h-[52px] items-center justify-between border-b border-[#ebebeb] px-4 py-2">
           <div className="min-w-0">
             <div className="text-[16px] font-semibold text-black md:text-[18px]">比較ビュー</div>
           </div>

--- a/src/components/RecordDetailPage.tsx
+++ b/src/components/RecordDetailPage.tsx
@@ -1,0 +1,777 @@
+﻿import {
+  type CSSProperties,
+  type FormEvent,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import {
+  type RunRecord,
+  characterDb,
+  defaultRunId,
+  getRunById,
+  mockRuns,
+  weaponDb,
+} from "../data/mockRuns";
+import { getSimilarRuns } from "../lib/getSimilarRuns";
+
+const collapsedCopyStyle: CSSProperties = {
+  display: "-webkit-box",
+  overflow: "hidden",
+  WebkitBoxOrient: "vertical",
+  WebkitLineClamp: 3,
+};
+
+function getYouTubeVideoId(videoUrl: string) {
+  try {
+    const parsed = new URL(videoUrl);
+    const host = parsed.hostname.replace(/^www\./, "");
+
+    if (host === "youtu.be") {
+      return parsed.pathname.slice(1) || null;
+    }
+
+    if (host.endsWith("youtube.com")) {
+      const fromSearch = parsed.searchParams.get("v");
+
+      if (fromSearch) {
+        return fromSearch;
+      }
+
+      if (parsed.pathname.startsWith("/embed/")) {
+        return parsed.pathname.split("/")[2] ?? null;
+      }
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function getYouTubeEmbedUrl(
+  videoUrl: string,
+  options?: {
+    autoplay?: boolean;
+    mute?: boolean;
+    enableJsApi?: boolean;
+  },
+) {
+  const videoId = getYouTubeVideoId(videoUrl);
+
+  if (!videoId) {
+    return null;
+  }
+
+  const params = new URLSearchParams({
+    rel: "0",
+    modestbranding: "1",
+    playsinline: "1",
+  });
+
+  if (options?.autoplay) {
+    params.set("autoplay", "1");
+  }
+
+  if (options?.mute) {
+    params.set("mute", "1");
+  }
+
+  if (options?.enableJsApi) {
+    params.set("enablejsapi", "1");
+  }
+
+  return `https://www.youtube.com/embed/${videoId}?${params.toString()}`;
+}
+
+function postYouTubeCommand(iframe: HTMLIFrameElement | null, command: "playVideo" | "pauseVideo") {
+  iframe?.contentWindow?.postMessage(
+    JSON.stringify({
+      event: "command",
+      func: command,
+      args: [],
+    }),
+    "https://www.youtube.com",
+  );
+}
+
+function getInitials(label: string) {
+  return label.slice(0, 2).toUpperCase();
+}
+
+function getPartyLoadout(run: RunRecord) {
+  return run.party.map((member, index) => {
+    const character = characterDb[member.characterId];
+    const weaponLoadout = run.weapons[index];
+    const weapon = weaponDb[weaponLoadout.weaponId];
+
+    return {
+      slot: index + 1,
+      characterName: character?.name ?? member.characterId,
+      cons: member.cons,
+      weaponName: weapon?.name ?? weaponLoadout.weaponId,
+      refine: weaponLoadout.refine,
+    };
+  });
+}
+
+function CircleAvatar({
+  label,
+  size,
+  dark = false,
+  bordered = false,
+}: {
+  label: string;
+  size: number;
+  dark?: boolean;
+  bordered?: boolean;
+}) {
+  const fontSize = Math.max(9, Math.round(size * 0.2));
+
+  return (
+    <div
+      className={`grid shrink-0 place-items-center rounded-full ${
+        dark ? "bg-[#333333] text-white" : "bg-[#d9d9d9] text-[#666666]"
+      } ${bordered ? "border border-black/30 bg-white text-black" : ""}`}
+      style={{ width: size, height: size, fontSize }}
+    >
+      <span className="font-medium tracking-[0.04em]">{bordered ? "" : getInitials(label)}</span>
+    </div>
+  );
+}
+
+function PillButton({
+  children,
+  dark = false,
+  active = false,
+  onClick,
+  className = "",
+}: {
+  children: ReactNode;
+  dark?: boolean;
+  active?: boolean;
+  onClick?: () => void;
+  className?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center justify-center gap-2 rounded-[42px] px-[14px] py-[7px] text-[14px] font-medium leading-none transition duration-150 hover:-translate-y-[1px] hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)] md:text-[15px] ${
+        dark || active ? "bg-[#333333] text-white" : "bg-[#f2f2f2] text-black"
+      } ${className}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function TinyBadge({ label }: { label: string }) {
+  return (
+    <div className="w-full rounded-[4px] bg-[rgba(248,196,163,0.25)] px-[4px] py-[3px] text-center text-[11px] leading-none text-[#f09e78] md:text-[12px]">
+      {label}
+    </div>
+  );
+}
+
+function SectionTitle({ children }: { children: ReactNode }) {
+  return <div className="text-[16px] font-bold leading-none text-black md:text-[18px]">{children}</div>;
+}
+
+function VideoFrame({
+  title,
+  videoUrl,
+  iframeRef,
+  autoplay = false,
+  mute = false,
+}: {
+  title: string;
+  videoUrl: string;
+  iframeRef?: React.RefObject<HTMLIFrameElement | null>;
+  autoplay?: boolean;
+  mute?: boolean;
+}) {
+  const embedUrl = getYouTubeEmbedUrl(videoUrl, { autoplay, mute, enableJsApi: true });
+
+  return (
+    <div className="aspect-[669/380] w-full overflow-hidden rounded-[16px] bg-[#d9d9d9] shadow-[0_2px_10px_rgba(0,0,0,0.04)]">
+      {embedUrl ? (
+        <iframe
+          ref={iframeRef}
+          title={title}
+          src={embedUrl}
+          className="h-full w-full"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.RefObject<HTMLIFrameElement | null> }) {
+  const partyLoadout = getPartyLoadout(run);
+
+  return (
+    <div className="flex min-h-full flex-col gap-[16px] bg-white px-4 py-4">
+      <VideoFrame title={run.title} videoUrl={run.videoUrl} iframeRef={iframeRef} mute />
+
+      <div className="flex flex-col gap-[12px]">
+        <div className="flex flex-col gap-[12px]">
+          <div className="text-[20px] font-bold leading-none text-black md:text-[24px]">{run.title}</div>
+          <div className="flex items-center justify-between gap-[12px]">
+            <div className="flex min-w-0 items-center gap-[12px]">
+              <CircleAvatar label={run.userName} size={40} />
+              <div className="truncate text-[18px] leading-none text-black md:text-[20px]">{run.userName}</div>
+            </div>
+            <div className="shrink-0 rounded-[42px] bg-[#f2f2f2] px-[10px] py-[5px] text-[12px] text-black md:text-[13px]">
+              {run.platform}
+            </div>
+          </div>
+        </div>
+
+        <div className="w-full rounded-[16px] bg-[#f2f2f2] p-[12px] shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]">
+          <div className="flex items-center gap-x-[16px] overflow-x-auto whitespace-nowrap text-[13px] text-black md:gap-x-[18px] md:text-[14px]">
+            <span>ver : {run.versionLabel}</span>
+            <span>{run.postedLabel}</span>
+            <span>{run.platform}のSVD</span>
+            <span>{run.platform}</span>
+          </div>
+          <div className="mt-[12px] space-y-[12px]">
+            <p className="whitespace-pre-line text-[14px] leading-[1.75] text-black md:text-[15px]">{run.summary}</p>
+            <div className="flex flex-wrap gap-[10px] md:gap-[12px]">
+              {run.tags.map((tag) => (
+                <span key={`${run.id}-${tag}`} className="rounded-[42px] bg-white px-[10px] py-[5px] text-[12px] text-black md:px-[12px] md:py-[6px] md:text-[13px]">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <section className="w-full rounded-[16px] border border-[#f1f3f5] bg-white p-[12px]">
+        <div className="flex flex-col gap-[20px]">
+          <SectionTitle>使用編成</SectionTitle>
+          <div className="flex flex-col gap-[18px] md:gap-[20px]">
+            {partyLoadout.map((entry) => (
+              <div key={`${run.id}-${entry.characterName}-${entry.slot}`} className="flex items-center gap-[12px]">
+                <CircleAvatar label={entry.characterName} size={60} />
+                <div className="flex min-w-0 flex-1 items-center justify-between gap-[12px]">
+                  <div className="min-w-0">
+                    <div className="truncate text-[17px] font-medium leading-none text-black md:text-[18px]">{entry.characterName}</div>
+                    <div className="mt-[4px] truncate text-[12px] text-[#9999b1] md:text-[13px]">{entry.weaponName}</div>
+                  </div>
+                  <div className="flex w-[30px] shrink-0 flex-col gap-[6px] pb-[2px] pt-[4px]">
+                    <TinyBadge label={`C${entry.cons}`} />
+                    <TinyBadge label={`R${entry.refine}`} />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function CompareDrawer({
+  baseIframeRef,
+  comparedRun,
+  isOpen,
+  syncPlaying,
+  onClose,
+  onToggleSync,
+}: {
+  baseIframeRef: React.RefObject<HTMLIFrameElement | null>;
+  comparedRun: RunRecord | null;
+  isOpen: boolean;
+  syncPlaying: boolean;
+  onClose: () => void;
+  onToggleSync: () => void;
+}) {
+  const comparedIframeRef = useRef<HTMLIFrameElement | null>(null);
+
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (!isOpen || !comparedRun) {
+      return;
+    }
+
+    const command = syncPlaying ? "playVideo" : "pauseVideo";
+    const timerId = window.setTimeout(() => {
+      postYouTubeCommand(baseIframeRef.current, command);
+      postYouTubeCommand(comparedIframeRef.current, command);
+    }, 800);
+
+    return () => window.clearTimeout(timerId);
+  }, [baseIframeRef, comparedRun, isOpen, syncPlaying]);
+
+  if (!isOpen || !comparedRun) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-y-0 right-0 z-50 hidden lg:block" aria-modal="false" role="complementary">
+      <div className="flex h-full w-[50vw] flex-col border-l border-[#ececec] bg-white shadow-[-18px_0_48px_rgba(0,0,0,0.12)]">
+        <div className="flex min-h-[52px] items-center justify-between border-b border-[#ebebeb] px-4 py-2 md:px-5">
+          <div className="min-w-0">
+            <div className="text-[16px] font-semibold text-black md:text-[18px]">比較ビュー</div>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onToggleSync}
+              className="inline-flex h-9 items-center justify-center rounded-[42px] bg-[#f2f2f2] px-4 text-[13px] font-medium text-black transition hover:bg-[#e8e8e8]"
+            >
+              {syncPlaying ? "同期停止" : "同期再生"}
+            </button>
+            <button
+              type="button"
+              aria-label="比較ビューを閉じる"
+              onClick={onClose}
+              className="grid h-9 w-9 place-items-center rounded-full bg-[#f2f2f2] text-black transition hover:bg-[#e8e8e8]"
+            >
+              <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <path d="M6 6l12 12" />
+                <path d="M18 6l-12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto bg-[#fbfbfb]">
+          <CompareRunPane run={comparedRun} iframeRef={comparedIframeRef} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SimilarActionMenu({
+  isOpen,
+  liked,
+  shared,
+  onToggle,
+  onAction,
+}: {
+  isOpen: boolean;
+  liked: boolean;
+  shared: boolean;
+  onToggle: () => void;
+  onAction: (action: "like" | "share" | "compare") => void;
+}) {
+  return (
+    <div className="relative shrink-0">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-label="類似記録の操作"
+        className="grid h-8 w-8 place-items-center rounded-full bg-[#f2f2f2] text-black transition hover:bg-[#e7e7e7]"
+      >
+        <svg viewBox="0 0 24 24" className="h-4 w-4" fill="currentColor" aria-hidden="true">
+          <circle cx="12" cy="5" r="1.8" />
+          <circle cx="12" cy="12" r="1.8" />
+          <circle cx="12" cy="19" r="1.8" />
+        </svg>
+      </button>
+      {isOpen ? (
+        <div className="absolute right-0 top-full z-20 mt-2 w-[168px] rounded-[12px] border border-[#e5e5e5] bg-white p-2 shadow-[0_8px_24px_rgba(0,0,0,0.08)]">
+          <button
+            type="button"
+            className="block w-full rounded-[8px] px-3 py-2 text-left text-[13px] text-black hover:bg-[#f2f2f2]"
+            onClick={() => onAction("like")}
+          >
+            {liked ? "いいね解除" : "いいねSVD"}
+          </button>
+          <button
+            type="button"
+            className="block w-full rounded-[8px] px-3 py-2 text-left text-[13px] text-black hover:bg-[#f2f2f2]"
+            onClick={() => onAction("share")}
+          >
+            {shared ? "共有解除" : "共有SVD"}
+          </button>
+          <button
+            type="button"
+            className="hidden w-full rounded-[8px] px-3 py-2 text-left text-[13px] text-black hover:bg-[#f2f2f2] lg:block"
+            onClick={() => onAction("compare")}
+          >
+            比較ビュー
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function RecordDetailPage() {
+  const currentRun = getRunById(defaultRunId);
+  const [descriptionExpanded, setDescriptionExpanded] = useState(false);
+  const [liked, setLiked] = useState(false);
+  const [shared, setShared] = useState(false);
+  const [commentDraft, setCommentDraft] = useState("");
+  const [comments, setComments] = useState(currentRun?.comments ?? []);
+  const [openMenuRunId, setOpenMenuRunId] = useState<string | null>(null);
+  const [compareQueuedRunId, setCompareQueuedRunId] = useState<string | null>(null);
+  const [syncPlaying, setSyncPlaying] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia("(min-width: 1024px)").matches : false,
+  );
+  const [similarActionState, setSimilarActionState] = useState<Record<string, { liked: boolean; shared: boolean }>>({});
+  const [headerVersion, setHeaderVersion] = useState(currentRun?.versionLabel ?? "Luna3");
+  const mainVideoIframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  const versionOptions = useMemo(() => Array.from(new Set(mockRuns.map((run) => run.versionLabel))), []);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 1024px)");
+    const updateDesktopState = () => setIsDesktop(mediaQuery.matches);
+
+    updateDesktopState();
+    mediaQuery.addEventListener("change", updateDesktopState);
+    return () => mediaQuery.removeEventListener("change", updateDesktopState);
+  }, []);
+
+  useEffect(() => {
+    if (isDesktop) {
+      return;
+    }
+
+    setOpenMenuRunId(null);
+    setCompareQueuedRunId(null);
+    setSyncPlaying(false);
+  }, [isDesktop]);
+
+  if (!currentRun) {
+    return null;
+  }
+
+  const similarRuns = getSimilarRuns(currentRun, mockRuns, 4);
+  const compareRun = compareQueuedRunId ? getRunById(compareQueuedRunId) ?? null : null;
+  const compareOpen = isDesktop && compareRun !== null;
+  const forceMobileLayout = compareOpen;
+  const visibleTags = descriptionExpanded ? currentRun.tags : [];
+  const shouldShowExpandedArea = descriptionExpanded && (currentRun.summary.length > 0 || currentRun.tags.length > 0);
+  const canExpandDescription = currentRun.tags.length > 0 || currentRun.summary.length > 0;
+  const partyLoadout = getPartyLoadout(currentRun);
+
+  useEffect(() => {
+    if (!compareOpen) {
+      return;
+    }
+
+    const originalOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
+  }, [compareOpen]);
+
+  const handleCommentSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const body = commentDraft.trim();
+
+    if (!body) {
+      return;
+    }
+
+    setComments((previousComments) => [
+      {
+        id: `local-${Date.now()}`,
+        userName: "You",
+        userHandle: "@local-runner",
+        postedLabel: "たった今",
+        body,
+      },
+      ...previousComments,
+    ]);
+    setCommentDraft("");
+  };
+
+  const handleSimilarAction = (runId: string, action: "like" | "share" | "compare") => {
+    setOpenMenuRunId(null);
+
+    if (action === "compare") {
+      if (!isDesktop) {
+        return;
+      }
+
+      setCompareQueuedRunId(runId);
+      setSyncPlaying(false);
+      return;
+    }
+
+    setSimilarActionState((previousState) => {
+      const currentState = previousState[runId] ?? { liked: false, shared: false };
+      const nextState = {
+        liked: action === "like" ? !currentState.liked : currentState.liked,
+        shared: action === "share" ? !currentState.shared : currentState.shared,
+      };
+
+      return {
+        ...previousState,
+        [runId]: nextState,
+      };
+    });
+  };
+
+  return (
+    <>
+      <main className={`bg-white text-[#333333] transition-[width] duration-300 ${compareOpen ? "fixed inset-y-0 left-0 z-40 overflow-y-auto lg:w-[50vw]" : "min-h-screen lg:w-full"}`}>
+        <nav className="sticky top-0 z-40 border-b border-[#ebebeb] bg-white shadow-[0_1px_0_rgba(0,0,0,0.02)]">
+          <div className={`header-font mx-auto flex max-w-[1600px] items-center justify-between px-4 py-2 ${forceMobileLayout ? "min-h-[52px]" : "md:px-6 md:py-3"}`}>
+            <div className={`flex items-center ${forceMobileLayout ? "gap-3" : "gap-4 md:gap-6"}`}>
+              <h1 className={`font-semibold tracking-tight text-black ${forceMobileLayout ? "text-[24px]" : "text-[26px] md:text-[38px]"}`}>精鋭狩りDB仮</h1>
+              <div className="relative">
+                <select
+                  className={`appearance-none rounded-full border border-black/30 bg-white py-1.5 pl-3 pr-10 font-medium text-black ${forceMobileLayout ? "text-[15px]" : "text-[16px] md:pl-4 md:pr-12 md:text-[20px]"}`}
+                  value={headerVersion}
+                  onChange={(event) => setHeaderVersion(event.target.value)}
+                >
+                  {versionOptions.map((version) => (
+                    <option key={version} value={version}>
+                      {version}
+                    </option>
+                  ))}
+                </select>
+                <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-black/70">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" />
+                  </svg>
+                </span>
+              </div>
+            </div>
+
+            <div className={`flex items-center ${forceMobileLayout ? "gap-2" : "gap-3 md:gap-4"}`}>
+              <button
+                type="button"
+                className={`flex h-9 w-9 items-center justify-center rounded-full bg-black text-white ${forceMobileLayout ? "" : "md:h-auto md:w-auto md:gap-2 md:px-5 md:py-2.5 md:text-[20px]"}`}
+              >
+                <span className="text-[20px] leading-none md:text-[22px]">＋</span>
+                <span className={forceMobileLayout ? "hidden" : "hidden md:inline"}>記録提出</span>
+              </button>
+              <CircleAvatar label="luna3" size={36} bordered />
+            </div>
+          </div>
+        </nav>
+
+        <div className={`mx-auto flex w-full max-w-[1600px] flex-col gap-[12px] px-4 py-4 ${forceMobileLayout ? "" : "md:px-6 md:py-5 lg:py-6"} ${compareOpen ? "lg:items-stretch" : "lg:flex-row lg:items-start lg:gap-[14px]"}`}>
+          <section className={`flex min-w-0 flex-1 flex-col gap-[18px] ${compareOpen ? "lg:flex-none" : "lg:flex-[1_1_auto]"}`}>
+            <VideoFrame title={currentRun.title} videoUrl={currentRun.videoUrl} iframeRef={mainVideoIframeRef} autoplay mute />
+
+            <div className="flex flex-col gap-[12px]">
+              <div className="flex flex-col gap-[12px]">
+                <div className={`font-bold leading-none text-black ${forceMobileLayout ? "text-[20px]" : "text-[20px] md:text-[24px]"}`}>{currentRun.title}</div>
+                <div className={`flex gap-[12px] ${compareOpen ? "flex-col items-start" : "items-center justify-between"}`}>
+                  <div className="flex min-w-0 items-center gap-[12px]">
+                    <CircleAvatar label={currentRun.userName} size={40} />
+                    <div className={`truncate leading-none text-black ${forceMobileLayout ? "text-[18px]" : "text-[18px] md:text-[20px]"}`}>{currentRun.userName}</div>
+                  </div>
+                  <div className={`flex gap-[12px] md:gap-[12px] ${compareOpen ? "w-full shrink min-w-0 flex-wrap" : "shrink-0 flex-nowrap"}`}>
+                    <PillButton active={liked} onClick={() => setLiked((previous) => !previous)} className="min-h-[36px] min-w-[92px]">
+                      いいねSVD
+                    </PillButton>
+                    <PillButton active={shared} onClick={() => setShared((previous) => !previous)} className="min-h-[36px] min-w-[92px]">
+                      共有SVD
+                    </PillButton>
+                  </div>
+                </div>
+              </div>
+
+              <div className="w-full rounded-[16px] bg-[#f2f2f2] p-[12px] shadow-[inset_0_1px_0_rgba(255,255,255,0.45)]">
+                <div className={`flex gap-[16px] ${compareOpen ? "flex-col items-start whitespace-normal" : "items-center justify-between whitespace-nowrap"}`}>
+                  <div className={`flex min-w-0 gap-x-[16px] text-[13px] text-black md:gap-x-[18px] md:text-[14px] ${compareOpen ? "flex-wrap items-center gap-y-[6px]" : "items-center"}`}>
+                    <span>ver : {currentRun.versionLabel}</span>
+                    <span>{currentRun.postedLabel}</span>
+                    <span>{currentRun.platform}のSVD</span>
+                    <span>{currentRun.platform}</span>
+                  </div>
+                  {canExpandDescription && !descriptionExpanded ? (
+                    <button
+                      type="button"
+                      onClick={() => setDescriptionExpanded((previous) => !previous)}
+                      className={`shrink-0 text-right text-black ${forceMobileLayout ? "text-[13px]" : "text-[13px] md:text-[14px]"}`}
+                    >
+                      ...もっと見る
+                    </button>
+                  ) : null}
+                </div>
+
+                {shouldShowExpandedArea ? (
+                  <div className="mt-[12px] space-y-[12px]">
+                    <p className={`whitespace-pre-line leading-[1.75] text-black ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`} style={descriptionExpanded ? undefined : collapsedCopyStyle}>
+                      {currentRun.summary}
+                    </p>
+                    <div className="flex flex-wrap gap-[10px] md:gap-[12px]">
+                      {visibleTags.map((tag) => (
+                        <span key={tag} className={`rounded-[42px] bg-white px-[10px] py-[5px] text-black ${forceMobileLayout ? "text-[12px]" : "text-[12px] md:px-[12px] md:py-[6px] md:text-[13px]"}`}>
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-[12px]">
+              <div className="flex flex-col gap-[12px]">
+                <SectionTitle>{comments.length}件のコメント</SectionTitle>
+                <form onSubmit={handleCommentSubmit} className="flex w-full items-center gap-[8px]">
+                  <CircleAvatar label="You" size={36} />
+                  <div className="flex flex-1 items-center justify-between border-b border-[#d9d9d9] p-[8px] transition focus-within:border-[#b9b9cc]">
+                    <input
+                      value={commentDraft}
+                      onChange={(event) => setCommentDraft(event.target.value)}
+                      placeholder="コメントする..."
+                      className={`w-full border-none bg-transparent text-black outline-none ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}
+                    />
+                    <PillButton className="ml-[8px] min-h-[30px] px-[12px] py-[5px] text-[12px] md:text-[13px]">送信SVD</PillButton>
+                  </div>
+                </form>
+              </div>
+
+              <div className="flex flex-col gap-[20px] md:gap-[24px]">
+                {comments.map((comment) => (
+                  <article key={comment.id} className="flex items-start gap-[12px]">
+                    <CircleAvatar label={comment.userName} size={40} />
+                    <div className="flex min-w-0 flex-1 flex-col gap-[8px] justify-center">
+                      <div className={`flex flex-wrap items-center gap-[8px] text-black ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>
+                        <span>{comment.userName}</span>
+                        <span className="text-[#9999b1]">{comment.postedLabel}</span>
+                      </div>
+                      <div className={`leading-[1.75] text-[#3d3d3d] ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>{comment.body}</div>
+                      <div className={`flex gap-[12px] md:gap-[12px] ${compareOpen ? "w-full shrink min-w-0 flex-wrap" : "shrink-0 flex-nowrap"}`}>
+                        <PillButton className="px-[8px] py-[4px] text-[11px] md:text-[12px]">いいねSVD</PillButton>
+                        <PillButton className="px-[8px] py-[4px] text-[11px] md:text-[12px]">返信</PillButton>
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <aside className={`flex w-full shrink-0 flex-col gap-[18px] ${compareOpen ? "lg:w-full xl:w-full" : "lg:w-[360px] xl:w-[372px]"}`}>
+            <section className="w-full rounded-[16px] border border-[#f1f3f5] bg-white p-[12px]">
+              <div className="flex flex-col gap-[20px]">
+                <SectionTitle>使用編成</SectionTitle>
+                <div className="flex flex-col gap-[18px] md:gap-[20px]">
+                  {partyLoadout.map((entry) => (
+                    <div key={`${entry.characterName}-${entry.slot}`} className="flex items-center gap-[12px]">
+                      <CircleAvatar label={entry.characterName} size={60} />
+                      <div className="flex min-w-0 flex-1 items-center justify-between gap-[12px]">
+                        <div className="min-w-0">
+                          <div className="truncate text-[17px] font-medium leading-none text-black md:text-[18px]">{entry.characterName}</div>
+                          <div className="mt-[4px] truncate text-[12px] text-[#9999b1] md:text-[13px]">{entry.weaponName}</div>
+                        </div>
+                        <div className="flex w-[30px] shrink-0 flex-col gap-[6px] pb-[2px] pt-[4px]">
+                          <TinyBadge label={`C${entry.cons}`} />
+                          <TinyBadge label={`R${entry.refine}`} />
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </section>
+
+            <section className="w-full rounded-[16px] border border-[#f1f3f5] bg-white p-[12px]">
+              <div className="flex flex-col gap-[20px]">
+                <SectionTitle>類似編成の記録</SectionTitle>
+                <div className="flex flex-col gap-[18px] md:gap-[20px]">
+                  {similarRuns.map((match) => {
+                    const runState = similarActionState[match.run.id] ?? { liked: false, shared: false };
+                    const isOpen = openMenuRunId === match.run.id;
+                    const isCompareQueued = compareQueuedRunId === match.run.id;
+
+                    return (
+                      <div key={match.run.id} className={isCompareQueued ? "rounded-[12px] bg-[#f7f7f7] px-[8px] py-[8px]" : "rounded-[10px] px-[4px] py-[4px] transition-colors hover:bg-[#fafafa]"}>
+                        <div className="flex flex-col items-end gap-[10px]">
+                          <div className="h-[40px] w-full px-[8px]">
+                            <div className="flex h-[40px] items-center justify-between gap-[4px]">
+                              {match.run.party.map((member) => {
+                                const characterName = characterDb[member.characterId]?.name ?? member.characterId;
+                                return <CircleAvatar key={`${match.run.id}-${member.characterId}`} label={characterName} size={32} dark />;
+                              })}
+                            </div>
+                          </div>
+                          <div className="flex w-full items-end gap-[4px]">
+                            <div className="min-w-0 flex-1">
+                              <div className="flex flex-col gap-[8px]">
+                                <div className="truncate text-[14px] font-medium leading-[1.35] text-black md:text-[15px]">{match.run.title}</div>
+                                <div className="flex flex-wrap items-center gap-[4px] text-[12px] text-[#9999b1] md:text-[13px]">
+                                  <span>{match.run.userName}</span>
+                                  <span>・</span>
+                                  <span>{match.run.postedLabel}</span>
+                                  <span>・</span>
+                                  <span>{match.run.platform}</span>
+                                </div>
+                              </div>
+                            </div>
+                            <SimilarActionMenu
+                              isOpen={isOpen}
+                              liked={runState.liked}
+                              shared={runState.shared}
+                              onToggle={() => setOpenMenuRunId((previous) => (previous === match.run.id ? null : match.run.id))}
+                              onAction={(action) => handleSimilarAction(match.run.id, action)}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </section>
+          </aside>
+        </div>
+      </main>
+
+      <CompareDrawer
+        baseIframeRef={mainVideoIframeRef}
+        comparedRun={compareRun}
+        isOpen={compareOpen}
+        syncPlaying={syncPlaying}
+        onClose={() => {
+          setCompareQueuedRunId(null);
+          setSyncPlaying(false);
+        }}
+        onToggleSync={() => setSyncPlaying((previous) => !previous)}
+      />
+    </>
+  );
+}
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/data/mockRuns.ts
+++ b/src/data/mockRuns.ts
@@ -1,0 +1,543 @@
+﻿export type Element = "pyro" | "hydro" | "cryo" | "electro" | "anemo" | "geo" | "dendro";
+export type CharacterType = "limited" | "standard" | "four_star";
+export type WeaponTier = "five_star" | "four_star";
+export type WeaponClass = "sword" | "claymore" | "polearm" | "bow" | "catalyst";
+export type Platform = "PC" | "Mobile" | "PS5";
+
+export type Character = {
+  id: string;
+  name: string;
+  shortLabel: string;
+  element: Element;
+  weaponClass: WeaponClass;
+  type: CharacterType;
+};
+
+export type Weapon = {
+  id: string;
+  name: string;
+  shortLabel: string;
+  tier: WeaponTier;
+  weaponClass: WeaponClass;
+};
+
+export type PartyMember = {
+  characterId: string;
+  cons: number;
+};
+
+export type WeaponLoadout = {
+  weaponId: string;
+  refine: number;
+};
+
+export type RunComment = {
+  id: string;
+  userName: string;
+  userHandle: string;
+  postedLabel: string;
+  body: string;
+};
+
+export type RunRecordRaw = {
+  id: string;
+  title: string;
+  userName: string;
+  userHandle: string;
+  postedLabel: string;
+  date: string;
+  season: string;
+  versionLabel: string;
+  ruleset: string;
+  platform: Platform;
+  region: string;
+  time: string;
+  videoUrl: string;
+  summary: string;
+  tags: string[];
+  likeCount: number;
+  shareCount: number;
+  mainAttackerId: string;
+  party: PartyMember[];
+  weapons: WeaponLoadout[];
+  comments: RunComment[];
+};
+
+export type Bracket = 1 | 2 | 3 | 4;
+
+export type RunRecord = RunRecordRaw & {
+  charCost: number;
+  weaponCost: number;
+  totalCost: number;
+  bracket: Bracket;
+};
+
+export const bracketLabels: Record<Bracket, string> = {
+  1: "Bracket 1",
+  2: "Bracket 2",
+  3: "Bracket 3",
+  4: "Bracket 4",
+};
+
+export const characterDb: Record<string, Character> = {
+  mav: {
+    id: "mav",
+    name: "Mavuika",
+    shortLabel: "Mv",
+    element: "pyro",
+    weaponClass: "claymore",
+    type: "limited",
+  },
+  furina: {
+    id: "furina",
+    name: "Furina",
+    shortLabel: "Fu",
+    element: "hydro",
+    weaponClass: "sword",
+    type: "limited",
+  },
+  bennett: {
+    id: "bennett",
+    name: "Bennett",
+    shortLabel: "Bn",
+    element: "pyro",
+    weaponClass: "sword",
+    type: "four_star",
+  },
+  xiangling: {
+    id: "xiangling",
+    name: "Xiangling",
+    shortLabel: "Xl",
+    element: "pyro",
+    weaponClass: "polearm",
+    type: "four_star",
+  },
+  citlali: {
+    id: "citlali",
+    name: "Citlali",
+    shortLabel: "Ct",
+    element: "cryo",
+    weaponClass: "catalyst",
+    type: "limited",
+  },
+  xilonen: {
+    id: "xilonen",
+    name: "Xilonen",
+    shortLabel: "Xi",
+    element: "geo",
+    weaponClass: "sword",
+    type: "limited",
+  },
+  amber: {
+    id: "amber",
+    name: "Amber",
+    shortLabel: "Am",
+    element: "pyro",
+    weaponClass: "bow",
+    type: "four_star",
+  },
+  xingqiu: {
+    id: "xingqiu",
+    name: "Xingqiu",
+    shortLabel: "Xq",
+    element: "hydro",
+    weaponClass: "sword",
+    type: "four_star",
+  },
+  collei: {
+    id: "collei",
+    name: "Collei",
+    shortLabel: "Co",
+    element: "dendro",
+    weaponClass: "bow",
+    type: "four_star",
+  },
+  keqing: {
+    id: "keqing",
+    name: "Keqing",
+    shortLabel: "Kq",
+    element: "electro",
+    weaponClass: "sword",
+    type: "standard",
+  },
+  zhongli: {
+    id: "zhongli",
+    name: "Zhongli",
+    shortLabel: "Zl",
+    element: "geo",
+    weaponClass: "polearm",
+    type: "limited",
+  },
+};
+
+export const weaponDb: Record<string, Weapon> = {
+  blazingSun: {
+    id: "blazingSun",
+    name: "A Thousand Blazing Suns",
+    shortLabel: "ABS",
+    tier: "five_star",
+    weaponClass: "claymore",
+  },
+  splendor: {
+    id: "splendor",
+    name: "Splendor of Tranquil Waters",
+    shortLabel: "SoT",
+    tier: "five_star",
+    weaponClass: "sword",
+  },
+  skywardBlade: {
+    id: "skywardBlade",
+    name: "Skyward Blade",
+    shortLabel: "SB",
+    tier: "five_star",
+    weaponClass: "sword",
+  },
+  theCatch: {
+    id: "theCatch",
+    name: "The Catch",
+    shortLabel: "TC",
+    tier: "four_star",
+    weaponClass: "polearm",
+  },
+  starcaller: {
+    id: "starcaller",
+    name: "Starcaller Watch",
+    shortLabel: "SW",
+    tier: "five_star",
+    weaponClass: "catalyst",
+  },
+  peakPatrol: {
+    id: "peakPatrol",
+    name: "Peak Patrol Song",
+    shortLabel: "PP",
+    tier: "five_star",
+    weaponClass: "sword",
+  },
+  stringless: {
+    id: "stringless",
+    name: "The Stringless",
+    shortLabel: "TS",
+    tier: "four_star",
+    weaponClass: "bow",
+  },
+  sacrificialSword: {
+    id: "sacrificialSword",
+    name: "Sacrificial Sword",
+    shortLabel: "SS",
+    tier: "four_star",
+    weaponClass: "sword",
+  },
+  haran: {
+    id: "haran",
+    name: "Haran Geppaku Futsu",
+    shortLabel: "HG",
+    tier: "five_star",
+    weaponClass: "sword",
+  },
+  homa: {
+    id: "homa",
+    name: "Staff of Homa",
+    shortLabel: "Ho",
+    tier: "five_star",
+    weaponClass: "polearm",
+  },
+};
+
+export const elementStyles: Record<Element, { ring: string; bg: string; text: string }> = {
+  pyro: { ring: "ring-[#f97352]", bg: "bg-[#fff1eb]", text: "text-[#8f2d14]" },
+  hydro: { ring: "ring-[#4ea1ff]", bg: "bg-[#eef7ff]", text: "text-[#0d4678]" },
+  cryo: { ring: "ring-[#7bd6ff]", bg: "bg-[#edfaff]", text: "text-[#0f5675]" },
+  electro: { ring: "ring-[#b877ff]", bg: "bg-[#f5efff]", text: "text-[#5a2b8f]" },
+  anemo: { ring: "ring-[#58d3ab]", bg: "bg-[#ecfbf5]", text: "text-[#145642]" },
+  geo: { ring: "ring-[#d7a74b]", bg: "bg-[#fff6e9]", text: "text-[#7b5411]" },
+  dendro: { ring: "ring-[#82c25c]", bg: "bg-[#f1faea]", text: "text-[#345b1e]" },
+};
+
+export function calcCharCost(party: PartyMember[]) {
+  return party.reduce((sum, member) => {
+    const character = characterDb[member.characterId];
+    if (!character) {
+      return sum;
+    }
+
+    if (character.type === "limited") {
+      return sum + member.cons + 1;
+    }
+
+    if (character.type === "standard") {
+      return sum + 1;
+    }
+
+    return sum;
+  }, 0);
+}
+
+export function calcWeaponCost(weapons: WeaponLoadout[]) {
+  return weapons.reduce((sum, weaponLoadout) => {
+    const weapon = weaponDb[weaponLoadout.weaponId];
+    if (!weapon || weapon.tier !== "five_star") {
+      return sum;
+    }
+
+    return sum + weaponLoadout.refine;
+  }, 0);
+}
+
+export function calcBracket(charCost: number, weaponCost: number): Bracket {
+  if (charCost <= 3 && weaponCost <= 1) {
+    return 1;
+  }
+
+  if (charCost <= 6 && weaponCost <= 2) {
+    return 2;
+  }
+
+  if (charCost <= 12 && weaponCost <= 3) {
+    return 3;
+  }
+
+  return 4;
+}
+
+const rawRuns: RunRecordRaw[] = [
+  {
+    id: "run-npui-high",
+    title: "【Npui】27:49 (high)",
+    userName: "らんだむ",
+    userHandle: "@luna3",
+    postedLabel: "3日前",
+    date: "2026-03-11",
+    season: "5.3",
+    versionLabel: "Luna3",
+    ruleset: "高難度",
+    platform: "PC",
+    region: "Asia",
+    time: "27:49",
+    videoUrl: "https://www.youtube.com/watch?v=cUkSP9YgeRA",
+    summary:
+      "Natlan 側の密集を先に崩してから Npui 側へ戻る、短期決戦寄りの高難度ルートです。\n\n炎付着を切らさないことと、Furina の burst を最後まで温存しすぎないことが今回の安定ポイントでした。細かいルート取りはまだ詰め切れていないので、更新余地はあります。",
+    tags: ["高難度", "Natlan", "Mavuika", "Furina", "高速処理", "炎共鳴", "短期決戦", "PCのSVD"],
+    likeCount: 68,
+    shareCount: 9,
+    mainAttackerId: "mav",
+    party: [
+      { characterId: "mav", cons: 2 },
+      { characterId: "bennett", cons: 6 },
+      { characterId: "furina", cons: 1 },
+      { characterId: "xiangling", cons: 6 },
+    ],
+    weapons: [
+      { weaponId: "blazingSun", refine: 2 },
+      { weaponId: "skywardBlade", refine: 1 },
+      { weaponId: "splendor", refine: 1 },
+      { weaponId: "theCatch", refine: 5 },
+    ],
+    comments: [
+      {
+        id: "c1",
+        userName: "R",
+        userHandle: "@route_lab",
+        postedLabel: "2日前",
+        body: "炎主人公入りよりも、この並びの方が雑魚処理のばらつきが少なく見えました。",
+      },
+      {
+        id: "c2",
+        userName: "Bird",
+        userHandle: "@amber_main",
+        postedLabel: "2日前",
+        body: "後半の Furina burst タイミングがかなり参考になります。ルート更新あればまた見たいです。",
+      },
+    ],
+  },
+  {
+    id: "run-npui-balance",
+    title: "【Npui】28:14 (stable)",
+    userName: "Luna",
+    userHandle: "@luna_route",
+    postedLabel: "5日前",
+    date: "2026-03-09",
+    season: "5.3",
+    versionLabel: "Luna3",
+    ruleset: "高難度",
+    platform: "PC",
+    region: "Asia",
+    time: "28:14",
+    videoUrl: "https://www.youtube.com/watch?v=8yGn2O9yVi4",
+    summary:
+      "Citlali を入れて事故率を下げた安定寄りの編成。終盤の移動を少し長めに取っている代わりに、被弾リカバリーがしやすいです。",
+    tags: ["高難度", "安定寄り", "Mavuika", "Citlali", "PC+PCのSVD"],
+    likeCount: 41,
+    shareCount: 5,
+    mainAttackerId: "mav",
+    party: [
+      { characterId: "mav", cons: 2 },
+      { characterId: "bennett", cons: 6 },
+      { characterId: "citlali", cons: 0 },
+      { characterId: "furina", cons: 1 },
+    ],
+    weapons: [
+      { weaponId: "blazingSun", refine: 2 },
+      { weaponId: "skywardBlade", refine: 1 },
+      { weaponId: "starcaller", refine: 1 },
+      { weaponId: "splendor", refine: 1 },
+    ],
+    comments: [],
+  },
+  {
+    id: "run-budget-bow",
+    title: "Amber route 32:10",
+    userName: "Bird",
+    userHandle: "@amber_main",
+    postedLabel: "4日前",
+    date: "2026-03-10",
+    season: "5.3",
+    versionLabel: "Luna3",
+    ruleset: "高難度",
+    platform: "Mobile",
+    region: "Asia",
+    time: "32:10",
+    videoUrl: "https://www.youtube.com/watch?v=4ZguwblpL6Q",
+    summary:
+      "Amber 主軸の低コスト寄りルート。ベースは違いますが、炎キャラ軸での雑魚散らし方が近いです。",
+    tags: ["高難度", "Budget", "Amber", "Mobile"],
+    likeCount: 24,
+    shareCount: 3,
+    mainAttackerId: "amber",
+    party: [
+      { characterId: "amber", cons: 0 },
+      { characterId: "collei", cons: 6 },
+      { characterId: "bennett", cons: 6 },
+      { characterId: "xingqiu", cons: 6 },
+    ],
+    weapons: [
+      { weaponId: "stringless", refine: 5 },
+      { weaponId: "stringless", refine: 5 },
+      { weaponId: "skywardBlade", refine: 1 },
+      { weaponId: "sacrificialSword", refine: 5 },
+    ],
+    comments: [],
+  },
+  {
+    id: "run-npui-burst",
+    title: "Mavuika burst 27:58",
+    userName: "RouteLab",
+    userHandle: "@route_lab",
+    postedLabel: "6日前",
+    date: "2026-03-08",
+    season: "5.3",
+    versionLabel: "Luna3",
+    ruleset: "高難度",
+    platform: "PS5",
+    region: "Asia",
+    time: "27:58",
+    videoUrl: "https://www.youtube.com/watch?v=UDh_JVpcvns",
+    summary:
+      "Xilonen 採用で前半の burst 密度を上げた編成。操作難度は上がりますが、Mavuika の回転はかなり近いです。",
+    tags: ["高難度", "Mavuika", "Xilonen", "PS5"],
+    likeCount: 36,
+    shareCount: 4,
+    mainAttackerId: "mav",
+    party: [
+      { characterId: "mav", cons: 2 },
+      { characterId: "xilonen", cons: 0 },
+      { characterId: "bennett", cons: 6 },
+      { characterId: "furina", cons: 1 },
+    ],
+    weapons: [
+      { weaponId: "blazingSun", refine: 2 },
+      { weaponId: "peakPatrol", refine: 1 },
+      { weaponId: "skywardBlade", refine: 1 },
+      { weaponId: "splendor", refine: 1 },
+    ],
+    comments: [],
+  },
+  {
+    id: "run-keqing-tech",
+    title: "Keqing tech 30:42",
+    userName: "Random",
+    userHandle: "@random_tech",
+    postedLabel: "1週間前",
+    date: "2026-03-05",
+    season: "5.3",
+    versionLabel: "Luna3",
+    ruleset: "高難度",
+    platform: "PC",
+    region: "Asia",
+    time: "30:42",
+    videoUrl: "https://www.youtube.com/watch?v=2pMYLhjdMVw",
+    summary:
+      "メインアタッカーは違いますが、Bennett と Xiangling を中心にした湧き処理の組み立てが近いオフメタ案です。",
+    tags: ["高難度", "OffMeta", "Keqing", "PC"],
+    likeCount: 19,
+    shareCount: 2,
+    mainAttackerId: "keqing",
+    party: [
+      { characterId: "keqing", cons: 0 },
+      { characterId: "zhongli", cons: 0 },
+      { characterId: "bennett", cons: 6 },
+      { characterId: "xiangling", cons: 6 },
+    ],
+    weapons: [
+      { weaponId: "haran", refine: 1 },
+      { weaponId: "homa", refine: 1 },
+      { weaponId: "skywardBlade", refine: 1 },
+      { weaponId: "theCatch", refine: 5 },
+    ],
+    comments: [],
+  },
+  {
+    id: "run-festival-swap",
+    title: "Festival rules 42:00",
+    userName: "R",
+    userHandle: "@festival_only",
+    postedLabel: "8日前",
+    date: "2026-03-03",
+    season: "5.3",
+    versionLabel: "Luna3",
+    ruleset: "祭典",
+    platform: "PC",
+    region: "Asia",
+    time: "42:00",
+    videoUrl: "https://www.youtube.com/watch?v=kWRNqHLLlq0",
+    summary:
+      "祭典ルール側の参考記録。ルールセットは違いますが、炎コアの使い方だけは近いです。",
+    tags: ["祭典", "参考用", "Mavuika"],
+    likeCount: 12,
+    shareCount: 1,
+    mainAttackerId: "mav",
+    party: [
+      { characterId: "mav", cons: 0 },
+      { characterId: "bennett", cons: 6 },
+      { characterId: "xiangling", cons: 6 },
+      { characterId: "xingqiu", cons: 6 },
+    ],
+    weapons: [
+      { weaponId: "blazingSun", refine: 1 },
+      { weaponId: "skywardBlade", refine: 1 },
+      { weaponId: "theCatch", refine: 5 },
+      { weaponId: "sacrificialSword", refine: 5 },
+    ],
+    comments: [],
+  },
+];
+
+function normalizeRun(run: RunRecordRaw): RunRecord {
+  const charCost = calcCharCost(run.party);
+  const weaponCost = calcWeaponCost(run.weapons);
+  const bracket = calcBracket(charCost, weaponCost);
+
+  return {
+    ...run,
+    charCost,
+    weaponCost,
+    totalCost: charCost + weaponCost,
+    bracket,
+  };
+}
+
+export const mockRuns = rawRuns.map(normalizeRun);
+export const defaultRunId = "run-npui-high";
+
+export function getRunById(runId: string) {
+  return mockRuns.find((run) => run.id === runId);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,10 +1,10 @@
-﻿@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&family=Space+Grotesk:wght@500;600;700&display=swap");
+﻿@import url("https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700&family=Space+Grotesk:wght@500;600;700&display=swap");
 @import "tailwindcss";
 
 :root {
   color: #000000;
   background-color: #ffffff;
-  font-family: "Inter", "Noto Sans JP", "Segoe UI", sans-serif;
+  font-family: "Noto Sans JP", "Segoe UI", sans-serif;
   line-height: 1.5;
   font-weight: 400;
   font-synthesis: none;
@@ -47,3 +47,4 @@ textarea::placeholder {
 code {
   font-family: "Consolas", "SFMono-Regular", monospace;
 }
+

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,10 @@
+﻿@import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Noto+Sans+JP:wght@400;500;700&family=Space+Grotesk:wght@500;600;700&display=swap");
 @import "tailwindcss";
 
 :root {
-  color: #f4f4f5;
-  background-color: #09090b;
-  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  color: #000000;
+  background-color: #ffffff;
+  font-family: "Inter", "Noto Sans JP", "Segoe UI", sans-serif;
   line-height: 1.5;
   font-weight: 400;
   font-synthesis: none;
@@ -24,6 +25,23 @@ body,
 
 body {
   margin: 0;
+  background: #ffffff;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: #9999b1;
+}
+
+.header-font {
+  font-family: "Space Grotesk", "Noto Sans JP", sans-serif;
 }
 
 code {

--- a/src/lib/getSimilarRuns.ts
+++ b/src/lib/getSimilarRuns.ts
@@ -1,0 +1,93 @@
+﻿import { type RunRecord } from "../data/mockRuns";
+
+export type SimilarRunMatch = {
+  run: RunRecord;
+  score: number;
+  reasons: string[];
+  sharedCharacters: string[];
+  sharedWeapons: string[];
+};
+
+function toSeconds(time: string) {
+  const parts = time.split(":").map((part) => Number(part));
+
+  if (parts.some((part) => Number.isNaN(part))) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  if (parts.length === 3) {
+    return parts[0] * 3600 + parts[1] * 60 + parts[2];
+  }
+
+  if (parts.length === 2) {
+    return parts[0] * 60 + parts[1];
+  }
+
+  return parts[0] ?? Number.POSITIVE_INFINITY;
+}
+
+export function getSimilarRuns(baseRun: RunRecord, allRuns: RunRecord[], limit = 4): SimilarRunMatch[] {
+  return allRuns
+    .filter((run) => run.id !== baseRun.id)
+    .map((run) => {
+      let score = 0;
+      const reasons: string[] = [];
+      const baseCharacters = new Set(baseRun.party.map((member) => member.characterId));
+      const runCharacters = new Set(run.party.map((member) => member.characterId));
+      const baseWeapons = new Set(baseRun.weapons.map((weapon) => weapon.weaponId));
+      const runWeapons = new Set(run.weapons.map((weapon) => weapon.weaponId));
+      const sharedCharacters = [...baseCharacters].filter((characterId) => runCharacters.has(characterId));
+      const sharedWeapons = [...baseWeapons].filter((weaponId) => runWeapons.has(weaponId));
+
+      if (run.ruleset === baseRun.ruleset) {
+        score += 30;
+        reasons.push("同じルールセット");
+      }
+
+      if (run.season === baseRun.season) {
+        score += 18;
+        reasons.push("同じシーズン");
+      }
+
+      if (run.mainAttackerId === baseRun.mainAttackerId) {
+        score += 28;
+        reasons.push("同じメインアタッカー");
+      }
+
+      if (sharedCharacters.length > 0) {
+        score += sharedCharacters.length * 14;
+        reasons.push(`キャラ重複 ${sharedCharacters.length}`);
+      }
+
+      if (sharedWeapons.length > 0) {
+        score += sharedWeapons.length * 4;
+        reasons.push(`武器重複 ${sharedWeapons.length}`);
+      }
+
+      if (run.platform === baseRun.platform) {
+        score += 3;
+      }
+
+      return {
+        run,
+        score,
+        reasons,
+        sharedCharacters,
+        sharedWeapons,
+      };
+    })
+    .filter((match) => match.score > 0)
+    .sort((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score;
+      }
+
+      const timeDelta = toSeconds(left.run.time) - toSeconds(right.run.time);
+      if (timeDelta !== 0) {
+        return timeDelta;
+      }
+
+      return new Date(right.run.date).getTime() - new Date(left.run.date).getTime();
+    })
+    .slice(0, limit);
+}


### PR DESCRIPTION
## 概要
- `src/` に記録詳細画面を統合し、モックデータを使って一連の表示と操作を行えるようにしました
- 類似編成の記録、アクションメニュー、デスクトップ向け比較ビューを実装しました
- デザイン調整、キャラアイコン表示、YouTube 埋め込み再生まで含めて、現行モックに沿う形で整えました

## 変更内容
- `RecordDetailPage` を実装し、記録詳細画面をアプリのメイン表示として統合
- `CharacterIcon` を追加し、プロトタイプ準拠のキャラ画像取得処理を実装
- キャラ・武器・ラン記録のモックデータと、コスト / bracket 算出用の補助ロジックを追加
- `src/lib/getSimilarRuns.ts` に、差し替え可能な類似記録ヒューリスティックを追加
- 類似記録アクションから開ける desktop only の比較ビューを実装
- 左右独立スクロールと YouTube の同期再生 / 同期停止を実装

## 確認
- `npm run build`

## 次のタスク候補
- 投稿フロー 3 ステップの統合
- UID キャラクターピッカーモーダル
- ローカル draft 保存 / 復元