### PR TITLE
Issue #3: 全画面のSVDプレースホルダーを実UIアイコンへ置換

### DIFF
--- a/src/components/RecordDetailPage.tsx
+++ b/src/components/RecordDetailPage.tsx
@@ -19,6 +19,7 @@ import {
 import { getSimilarRuns } from "../lib/getSimilarRuns";
 import { getYouTubeEmbedUrl } from "../lib/youtube";
 import { CharacterIcon } from "./CharacterIcon";
+import { LikeIcon, PauseIcon, PlayIcon, PlatformIcon, ShareIcon } from "./UiIcons";
 
 const collapsedCopyStyle: CSSProperties = {
   display: "-webkit-box",
@@ -122,6 +123,52 @@ function SectionTitle({ children }: { children: ReactNode }) {
   return <div className="text-[16px] font-bold leading-none text-black md:text-[18px]">{children}</div>;
 }
 
+function parsePlatformTag(tag: string): RunRecord["platform"][] | null {
+  const parts = tag.replace(/\s/g, "").split("+");
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  if (parts.every((part) => part === "PC" || part === "PS5" || part === "Mobile")) {
+    return parts as RunRecord["platform"][];
+  }
+
+  return null;
+}
+
+function PlatformLabel({
+  platform,
+  iconClassName = "h-4 w-4",
+}: {
+  platform: RunRecord["platform"];
+  iconClassName?: string;
+}) {
+  return (
+    <span className="inline-flex items-center gap-[6px]">
+      <PlatformIcon platform={platform} className={iconClassName} />
+      <span>{platform}</span>
+    </span>
+  );
+}
+
+function TagChip({ tag }: { tag: string }) {
+  const platformParts = parsePlatformTag(tag);
+
+  return (
+    <span className="inline-flex items-center gap-[6px] rounded-[42px] bg-white px-[10px] py-[5px] text-[12px] text-black md:px-[12px] md:py-[6px] md:text-[13px]">
+      {platformParts ? (
+        <span className="inline-flex items-center gap-[4px]">
+          {platformParts.map((platform, index) => (
+            <PlatformIcon key={`${tag}-${platform}-${index}`} platform={platform} className="h-[13px] w-[13px] md:h-[14px] md:w-[14px]" />
+          ))}
+        </span>
+      ) : null}
+      <span>{tag}</span>
+    </span>
+  );
+}
+
 function VideoFrame({
   title,
   videoUrl,
@@ -168,8 +215,9 @@ function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.R
               <CircleAvatar label={run.userName} size={40} />
               <div className="truncate text-[16px] font-bold leading-none text-black md:text-[18px]">{run.userName}</div>
             </div>
-            <div className="shrink-0 rounded-[42px] bg-[#f2f2f2] px-[10px] py-[5px] text-[12px] text-black md:text-[13px]">
-              {run.platform}
+            <div className="inline-flex shrink-0 items-center gap-[6px] rounded-[42px] bg-[#f2f2f2] px-[10px] py-[5px] text-[12px] text-black md:text-[13px]">
+              <PlatformIcon platform={run.platform} className="h-[13px] w-[13px]" />
+              <span>{run.platform}</span>
             </div>
           </div>
         </div>
@@ -178,16 +226,13 @@ function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.R
           <div className="flex items-center gap-x-[16px] overflow-x-auto whitespace-nowrap text-[13px] text-black md:gap-x-[18px] md:text-[14px]">
             <span>ver : {run.versionLabel}</span>
             <span>{run.postedLabel}</span>
-            <span>{run.platform}のSVD</span>
-            <span>{run.platform}</span>
+            <PlatformLabel platform={run.platform} />
           </div>
           <div className="mt-[12px] space-y-[12px]">
             <p className="whitespace-pre-line text-[14px] leading-[1.75] text-black md:text-[15px]">{run.summary}</p>
             <div className="flex flex-wrap gap-[10px] md:gap-[12px]">
               {run.tags.map((tag) => (
-                <span key={`${run.id}-${tag}`} className="rounded-[42px] bg-white px-[10px] py-[5px] text-[12px] text-black md:px-[12px] md:py-[6px] md:text-[13px]">
-                  {tag}
-                </span>
+                <TagChip key={`${run.id}-${tag}`} tag={tag} />
               ))}
             </div>
           </div>
@@ -282,9 +327,10 @@ function CompareDrawer({
             <button
               type="button"
               onClick={onToggleSync}
-              className="inline-flex h-9 items-center justify-center rounded-[42px] bg-[#f2f2f2] px-4 text-[13px] font-medium text-black transition hover:bg-[#e8e8e8]"
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-[42px] bg-[#f2f2f2] px-4 text-[13px] font-medium text-black transition hover:bg-[#e8e8e8]"
             >
-              {syncPlaying ? "同期停止" : "同期再生"}
+              {syncPlaying ? <PauseIcon className="h-4 w-4" /> : <PlayIcon className="h-4 w-4" />}
+              <span>{syncPlaying ? "同期停止" : "同時再生"}</span>
             </button>
             <button
               type="button"
@@ -339,17 +385,19 @@ function SimilarActionMenu({
         <div className="absolute right-0 top-full z-20 mt-2 w-[168px] rounded-[12px] border border-[#ebebeb] bg-white p-2 shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
           <button
             type="button"
-            className="block w-full rounded-[8px] px-3 py-2 text-left text-[13px] text-black hover:bg-[#f2f2f2]"
+            className="flex w-full items-center gap-2 rounded-[8px] px-3 py-2 text-left text-[13px] text-black hover:bg-[#f2f2f2]"
             onClick={() => onAction("like")}
           >
-            {liked ? "いいね解除" : "いいねSVD"}
+            <LikeIcon className="h-4 w-4" />
+            <span>{liked ? "いいね解除" : "いいね"}</span>
           </button>
           <button
             type="button"
-            className="block w-full rounded-[8px] px-3 py-2 text-left text-[13px] text-black hover:bg-[#f2f2f2]"
+            className="flex w-full items-center gap-2 rounded-[8px] px-3 py-2 text-left text-[13px] text-black hover:bg-[#f2f2f2]"
             onClick={() => onAction("share")}
           >
-            {shared ? "共有解除" : "共有SVD"}
+            <ShareIcon className="h-4 w-4" />
+            <span>{shared ? "共有解除" : "共有"}</span>
           </button>
           <button
             type="button"
@@ -568,10 +616,12 @@ export function RecordDetailPage({
                   </div>
                   <div className={`flex gap-[12px] md:gap-[12px] ${compareOpen ? "w-full shrink min-w-0 flex-wrap" : "shrink-0 flex-nowrap"}`}>
                     <PillButton active={liked} onClick={() => setLiked((previous) => !previous)} className="min-h-[36px] min-w-[92px]">
-                      いいねSVD
+                      <LikeIcon className="h-4 w-4" />
+                      <span>いいね</span>
                     </PillButton>
                     <PillButton active={shared} onClick={() => setShared((previous) => !previous)} className="min-h-[36px] min-w-[92px]">
-                      共有SVD
+                      <ShareIcon className="h-4 w-4" />
+                      <span>共有</span>
                     </PillButton>
                   </div>
                 </div>
@@ -582,8 +632,7 @@ export function RecordDetailPage({
                   <div className={`flex min-w-0 gap-x-[16px] text-[13px] text-black md:gap-x-[18px] md:text-[14px] ${compareOpen ? "flex-wrap items-center gap-y-[6px]" : "items-center"}`}>
                     <span>ver : {currentRun.versionLabel}</span>
                     <span>{currentRun.postedLabel}</span>
-                    <span>{currentRun.platform}のSVD</span>
-                    <span>{currentRun.platform}</span>
+                    <PlatformLabel platform={currentRun.platform} />
                   </div>
                   {canExpandDescription && !descriptionExpanded ? (
                     <button
@@ -603,9 +652,7 @@ export function RecordDetailPage({
                     </p>
                     <div className="flex flex-wrap gap-[10px] md:gap-[12px]">
                       {visibleTags.map((tag) => (
-                        <span key={tag} className={`rounded-[42px] bg-white px-[10px] py-[5px] text-black ${forceMobileLayout ? "text-[12px]" : "text-[12px] md:px-[12px] md:py-[6px] md:text-[13px]"}`}>
-                          {tag}
-                        </span>
+                        <TagChip key={tag} tag={tag} />
                       ))}
                     </div>
                   </div>
@@ -623,9 +670,9 @@ export function RecordDetailPage({
                       value={commentDraft}
                       onChange={(event) => setCommentDraft(event.target.value)}
                       placeholder="コメントする..."
-                      className={`w-full border-none bg-transparent text-black outline-none ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}
+                      className={`min-w-0 flex-1 border-none bg-transparent text-black outline-none ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}
                     />
-                    <PillButton className="ml-[8px] min-h-[30px] px-[12px] py-[5px] text-[12px] md:text-[13px]">送信SVD</PillButton>
+                    <PillButton className="ml-[8px] min-h-[30px] shrink-0 whitespace-nowrap px-[12px] py-[5px] text-[12px] md:text-[13px]">送信</PillButton>
                   </div>
                 </form>
               </div>
@@ -641,7 +688,10 @@ export function RecordDetailPage({
                       </div>
                       <div className={`leading-[1.75] text-[#3d3d3d] ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>{comment.body}</div>
                       <div className={`flex gap-[12px] md:gap-[12px] ${compareOpen ? "w-full shrink min-w-0 flex-wrap" : "shrink-0 flex-nowrap"}`}>
-                        <PillButton className="px-[8px] py-[4px] text-[11px] md:text-[12px]">いいねSVD</PillButton>
+                        <PillButton className="px-[8px] py-[4px] text-[11px] md:text-[12px]">
+                          <LikeIcon className="h-3 w-3" />
+                          <span>いいね</span>
+                        </PillButton>
                         <PillButton className="px-[8px] py-[4px] text-[11px] md:text-[12px]">返信</PillButton>
                       </div>
                     </div>
@@ -741,14 +791,6 @@ export function RecordDetailPage({
     </>
   );
 }
-
-
-
-
-
-
-
-
 
 
 

--- a/src/components/RunSubmitPage.tsx
+++ b/src/components/RunSubmitPage.tsx
@@ -13,6 +13,7 @@ import {
 import { fetchEnkaProfile, isValidEnkaUid, type EnkaProfile, type EnkaProfileCharacter } from "../lib/enkaNetwork";
 import { isYouTubeUrl } from "../lib/youtube";
 import { CharacterIcon } from "./CharacterIcon";
+import { PlatformIcon } from "./UiIcons";
 
 const SUBMIT_DRAFT_KEY = "elite-run-db.submitDraft.v1";
 const AUTO_SAVE_DELAY_MS = 500;
@@ -447,7 +448,7 @@ function SectionTitle({
   );
 }
 
-function SearchSvdIcon() {
+function SearchActionIcon() {
   return (
     <span className="inline-flex h-7 w-7 items-center justify-center text-current">
       <svg
@@ -464,6 +465,15 @@ function SearchSvdIcon() {
         <path d="M14.25 14.25L18.5 18.5" />
       </svg>
     </span>
+  );
+}
+
+function PlatformChoiceContent({ platform }: { platform: Platform }) {
+  return (
+    <>
+      <PlatformIcon platform={platform} className="h-5 w-5 md:h-6 md:w-6" />
+      <span>{platform}</span>
+    </>
   );
 }
 
@@ -1118,7 +1128,7 @@ function MockChoiceButton({
     <button
       type="button"
       onClick={onClick}
-      className={`rounded-[42px] px-5 py-4 text-[18px] transition md:text-[24px] ${
+      className={`inline-flex items-center justify-center gap-3 rounded-[42px] px-5 py-4 text-[18px] transition md:text-[24px] ${
         active ? "bg-[#333333] text-white" : "bg-[#f2f2f2] text-[#9999b1]"
       } ${className}`}
     >
@@ -1675,7 +1685,7 @@ export function RunSubmitPage({ onBack }: { onBack: () => void }) {
                           onClick={() => updateBasicInfo("primaryPlatform", option)}
                           className="w-full"
                         >
-                          {option}
+                          <PlatformChoiceContent platform={option} />
                         </MockChoiceButton>
                       ))}
                     </div>
@@ -1692,7 +1702,7 @@ export function RunSubmitPage({ onBack }: { onBack: () => void }) {
                             onClick={() => updateBasicInfo("secondaryPlatform", option)}
                             className="w-full"
                           >
-                            {option}
+                            <PlatformChoiceContent platform={option} />
                           </MockChoiceButton>
                         ))}
                       </div>
@@ -1732,7 +1742,7 @@ export function RunSubmitPage({ onBack }: { onBack: () => void }) {
                           title={"UID\u3092\u691c\u7d22"}
                           className="group inline-flex h-[44px] shrink-0 items-center justify-center gap-[10px] rounded-[8px] bg-[#ececf2] px-4 text-[#5f6373] shadow-[inset_0_0_0_1px_rgba(123,123,141,0.14)] transition duration-150 hover:-translate-y-[1px] hover:bg-[#e4e5ec] hover:text-[#4d5160] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#333333]/10"
                         >
-                          <SearchSvdIcon />
+                          <SearchActionIcon />
                           <span className="text-[16px] font-medium leading-none md:text-[17px]">{"\u53d6\u5f97"}</span>
                         </button>
                       </div>

--- a/src/components/UiIcons.tsx
+++ b/src/components/UiIcons.tsx
@@ -1,0 +1,99 @@
+import type { Platform } from "../data/mockRuns";
+
+type IconProps = {
+  className?: string;
+};
+
+export function LikeIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M7 11v9H4v-9h3zm3.6-6.5L7 11v9h9.1c.8 0 1.5-.5 1.7-1.2l1.7-6.1c.3-1.1-.5-2.2-1.7-2.2H13V6c0-1.1-.9-2-2-2h-.4z" />
+    </svg>
+  );
+}
+
+export function ShareIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="18" cy="5" r="2.5" />
+      <circle cx="6" cy="12" r="2.5" />
+      <circle cx="18" cy="19" r="2.5" />
+      <path d="M8.2 10.9L15.7 6.4" />
+      <path d="M8.2 13.1l7.5 4.5" />
+    </svg>
+  );
+}
+
+export function SendIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M21 3L10 14" />
+      <path d="M21 3l-7 18-4-7-7-4 18-7z" />
+    </svg>
+  );
+}
+
+export function PlayIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M8 6.5v11l9-5.5-9-5.5z" />
+    </svg>
+  );
+}
+
+export function PauseIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <rect x="7" y="6" width="3.5" height="12" rx="1" />
+      <rect x="13.5" y="6" width="3.5" height="12" rx="1" />
+    </svg>
+  );
+}
+
+export function PlatformPcIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="2.5" y="3.5" width="19" height="13" rx="2" />
+      <path d="M8 20.5h8" />
+      <path d="M12 16.5v4" />
+    </svg>
+  );
+}
+
+export function PlatformMobileIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="6" y="2.5" width="12" height="19" rx="2.5" />
+      <path d="M11 5.5h2" />
+      <path d="M11.5 18.5h1" />
+    </svg>
+  );
+}
+
+export function PlatformPs5Icon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M3 13c0-1.8 1.6-3 3.4-3h11.2c1.8 0 3.4 1.2 3.4 3v2.1c0 1.3-1.1 2.4-2.4 2.4-1.1 0-1.9-.7-2.3-1.5l-1-1.9H8.7l-1 1.9c-.4.8-1.2 1.5-2.3 1.5C4.1 17.5 3 16.4 3 15.1V13z" />
+      <path d="M9.5 11.5h5" />
+      <path d="M12 9.5v4" />
+    </svg>
+  );
+}
+
+export function PlatformIcon({
+  platform,
+  className,
+}: {
+  platform: Platform;
+  className?: string;
+}) {
+  if (platform === "PS5") {
+    return <PlatformPs5Icon className={className} />;
+  }
+
+  if (platform === "Mobile") {
+    return <PlatformMobileIcon className={className} />;
+  }
+
+  return <PlatformPcIcon className={className} />;
+}

--- a/src/data/mockRuns.ts
+++ b/src/data/mockRuns.ts
@@ -408,7 +408,7 @@ const rawRuns: RunRecordRaw[] = [
     videoUrl: "https://www.youtube.com/watch?v=cUkSP9YgeRA",
     summary:
       "Natlan 側の密集を先に崩してから Npui 側へ戻る、短期決戦寄りの高難度ルートです。\n\n炎付着を切らさないことと、Furina の burst を最後まで温存しすぎないことが今回の安定ポイントでした。細かいルート取りはまだ詰め切れていないので、更新余地はあります。",
-    tags: ["高難度", "Natlan", "Mavuika", "Furina", "高速処理", "炎共鳴", "短期決戦", "PCのSVD"],
+    tags: ["高難度", "Natlan", "Mavuika", "Furina", "高速処理", "炎共鳴", "短期決戦", "PC"],
     likeCount: 68,
     shareCount: 9,
     mainAttackerId: "mav",
@@ -457,7 +457,7 @@ const rawRuns: RunRecordRaw[] = [
     videoUrl: "https://www.youtube.com/watch?v=8yGn2O9yVi4",
     summary:
       "Citlali を入れて事故率を下げた安定寄りの編成。終盤の移動を少し長めに取っている代わりに、被弾リカバリーがしやすいです。",
-    tags: ["高難度", "安定寄り", "Mavuika", "Citlali", "PC+PCのSVD"],
+    tags: ["高難度", "安定寄り", "Mavuika", "Citlali", "PC+PC"],
     likeCount: 41,
     shareCount: 5,
     mainAttackerId: "mav",


### PR DESCRIPTION
﻿## 変更内容
- 記録詳細 / 比較ビューで `SVD` が置かれていた箇所を、いいね・共有・送信・同時再生・プラットフォームの実アイコンに置換
- 提出 Step 1 のプラットフォーム選択をアイコン付きの選択 UI に更新
- 共通アイコンを `src/components/UiIcons.tsx` に集約し、画面間で再利用
- モックデータのプラットフォーム系タグを `PC` / `PC+PC` に正規化し、描画側でアイコン付きチップに変換

## 実装理由
- Issue #3 の対象は単純な文言修正ではなく、モック上で `SVD` が示していた視覚要素を実 UI に置き換えることだと解釈したため
- 画面ごとに別実装へ散らすと見た目の差異が出やすいため、共通 SVG を切り出して Detail / Compare / Submit で揃えた
- `PC+PC` のような複数プラットフォーム表現はデータを簡潔に保ちつつ、表示時に複数アイコンへ展開する方が差し替えやすい

## 補足
- コメント送信ボタンは折り返しを防ぐため、内容幅固定のテキストボタンに調整
- 検索やメインアタッカー選択など、既に実 UI 化されていた箇所の既存表現は維持

## 確認
- `npm run build`
