### PR TITLE
Issue #6: グローバルナビとサイドメニュー導線を実装

### DIFF
--- a/docs/mocks/sidebar.mock.tsx
+++ b/docs/mocks/sidebar.mock.tsx
@@ -1,0 +1,184 @@
+import React, { useState } from 'react';
+import { 
+  Trophy, 
+  MessageCircle, 
+  HelpCircle, 
+  Lightbulb, 
+  Calendar, 
+  ClipboardList, 
+  Bell, 
+  User, 
+  MoreVertical,
+  Menu,
+  ChevronDown,
+  Plus
+} from 'lucide-react';
+
+const Sidebar = ({ isOpen }) => {
+  const menuSections = [
+    {
+      id: 'main',
+      items: [
+        { id: 'leaderboard', label: 'リーダーボード', icon: Trophy },
+        { id: 'chat', label: '雑談', icon: MessageCircle },
+        { id: 'question', label: '質問', icon: HelpCircle },
+        { id: 'exchange', label: '情報交換', icon: Lightbulb },
+        { id: 'event', label: 'イベント情報', icon: Calendar },
+      ]
+    },
+    {
+      id: 'sub',
+      items: [
+        { id: 'apply', label: '記録申請', icon: ClipboardList },
+        { id: 'notification', label: '通知', icon: Bell },
+        { id: 'account', label: 'アカウント', icon: User },
+      ]
+    }
+  ];
+
+  return (
+    <div className={`
+      fixed md:static inset-y-0 left-0 z-50
+      bg-black text-[#d9d9d9] h-full flex flex-col overflow-y-auto 
+      border-r border-[#333] shrink-0
+      transition-transform duration-300 ease-in-out
+      ${isOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}
+      w-[280px] md:w-[80px] lg:w-[320px] 
+    `}>
+      
+      {/* プロフィールセクション */}
+      <div className="w-full px-4 md:px-2 lg:px-8 py-8 lg:pt-16 lg:pb-8 border-b border-[#333] flex justify-start md:justify-center lg:justify-start">
+        <div className="flex items-center justify-between w-full max-w-[240px] group cursor-pointer p-2 lg:p-3 rounded-full hover:bg-neutral-800 transition-colors">
+          <div className="flex items-center gap-4">
+            <div className="relative shrink-0 size-[36px] rounded-full bg-[#d9d9d9] flex items-center justify-center overflow-hidden">
+              <User className="size-5 text-gray-500" />
+            </div>
+            {/* モバイル(md未満)とPC(lg以上)の時だけテキストを表示 */}
+            <p className="block md:hidden lg:block font-bold text-[16px] whitespace-nowrap group-hover:text-white transition-colors">
+              アカウント名
+            </p>
+          </div>
+          <MoreVertical className="block md:hidden lg:block size-5 text-gray-500 group-hover:text-gray-300 transition-colors" />
+        </div>
+      </div>
+
+      {/* メインメニューセクション */}
+      <div className="w-full px-4 md:px-2 lg:px-8 py-8 border-b border-[#333] flex flex-col items-start md:items-center lg:items-start gap-4 lg:gap-6">
+        {menuSections[0].items.map((item) => {
+          const Icon = item.icon;
+          return (
+            <button 
+              key={item.id}
+              className="flex items-center gap-4 w-full md:w-auto lg:w-full text-left group transition-all p-3 lg:px-4 lg:py-3 rounded-full hover:bg-neutral-800"
+            >
+              <Icon className="size-6 text-gray-400 group-hover:text-white shrink-0" />
+              <p className="block md:hidden lg:block font-normal text-[20px] whitespace-nowrap group-hover:text-white transition-colors">
+                {item.label}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* サブメニューセクション */}
+      <div className="w-full px-4 md:px-2 lg:px-8 py-8 flex flex-col items-start md:items-center lg:items-start gap-4 lg:gap-6">
+        {menuSections[1].items.map((item) => {
+          const Icon = item.icon;
+          return (
+            <button 
+              key={item.id}
+              className="flex items-center gap-4 w-full md:w-auto lg:w-full text-left group transition-all p-3 lg:px-4 lg:py-3 rounded-full hover:bg-neutral-800"
+            >
+              <Icon className="size-6 text-gray-400 group-hover:text-white shrink-0" />
+              <p className="block md:hidden lg:block font-normal text-[20px] whitespace-nowrap group-hover:text-white transition-colors">
+                {item.label}
+              </p>
+            </button>
+          );
+        })}
+      </div>
+      
+    </div>
+  );
+};
+
+const Header = ({ onMenuClick }) => {
+  return (
+    <header className="bg-black border-b border-[#333] px-4 py-4 flex items-center justify-between shrink-0 h-[80px]">
+      {/* ヘッダー左側 */}
+      <div className="flex items-center gap-4 sm:gap-6">
+        {/* スマホ(md未満)の時だけハンバーガーメニューを表示 */}
+        <button 
+          className="md:hidden text-[#d9d9d9] hover:text-white transition-colors"
+          onClick={onMenuClick}
+        >
+          <Menu className="size-7" />
+        </button>
+        <h1 className="text-[#d9d9d9] text-[18px] sm:text-[20px] md:text-[24px] font-normal whitespace-nowrap">
+          精鋭狩りDB仮
+        </h1>
+        <button className="flex items-center gap-1 text-[#d9d9d9] hover:text-white transition-colors group">
+          <span className="text-[18px] sm:text-[20px] md:text-[24px] font-normal">luna3</span>
+          <ChevronDown className="size-5 mt-1 group-hover:translate-y-0.5 transition-transform" />
+        </button>
+      </div>
+
+      {/* ヘッダー右側 */}
+      <div className="flex items-center gap-4 sm:gap-6">
+        <button className="bg-[#333] hover:bg-neutral-700 text-[#d9d9d9] px-3 sm:px-4 py-2 rounded-full flex items-center gap-2 transition-colors">
+          <Plus className="size-5" />
+          <span className="text-[16px] sm:text-[18px] md:text-[20px] font-normal hidden sm:block whitespace-nowrap">
+            記録提出
+          </span>
+        </button>
+        <button className="text-[#d9d9d9] hover:text-white transition-colors relative">
+          <Bell className="size-6 sm:size-7" />
+          {/* 通知ポッチ */}
+          <span className="absolute top-0 right-0 size-2.5 bg-red-500 rounded-full border-2 border-black hidden"></span>
+        </button>
+        <button className="relative shrink-0 size-[32px] sm:size-[36px] rounded-full bg-[#d9d9d9] flex items-center justify-center overflow-hidden hover:opacity-80 transition-opacity">
+          <User className="size-5 text-gray-600" />
+        </button>
+      </div>
+    </header>
+  );
+};
+
+export default function App() {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  return (
+    <div className="flex h-screen bg-[#121212] font-['Noto_Sans_JP',sans-serif] overflow-hidden relative">
+      
+      {/* モバイル用背景オーバーレイ（透明度20%の黒） */}
+      {isMobileMenuOpen && (
+        <div 
+          className="fixed inset-0 bg-[rgba(0,0,0,0.2)] z-40 md:hidden transition-opacity"
+          onClick={() => setIsMobileMenuOpen(false)}
+        />
+      )}
+
+      {/* サイドバー */}
+      <Sidebar isOpen={isMobileMenuOpen} />
+
+      {/* メインエリア（ヘッダー ＋ コンテンツ） */}
+      <div className="flex-1 flex flex-col h-full overflow-hidden w-full">
+        
+        {/* ヘッダー */}
+        <Header onMenuClick={() => setIsMobileMenuOpen(true)} />
+
+        {/* メインコンテンツエリア */}
+        <main className="flex-1 overflow-y-auto p-4 sm:p-8 flex flex-col items-center justify-center text-center">
+          <div className="max-w-md space-y-4">
+            <Lightbulb className="size-16 text-yellow-400 mx-auto opacity-80" />
+            <h2 className="text-xl sm:text-2xl font-bold text-white">メインコンテンツエリア</h2>
+            <p className="text-sm sm:text-base text-gray-400 leading-relaxed">
+              プレビュー画面の幅をドラッグして狭くしてみてください。<br/>
+              スマホサイズになると左上のハンバーガーメニューが現れます。そこを押すと、サイドバーがX（Twitter）のようにスライドして表示されます！
+            </p>
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/RootApp.tsx
+++ b/src/RootApp.tsx
@@ -1,11 +1,27 @@
-import { useEffect, useRef, useState } from "react";
+﻿import { useEffect, useRef, useState } from "react";
 
+import { AppShell } from "./components/AppShell";
+import { PlaceholderPage } from "./components/PlaceholderPage";
 import { RecordDetailPage } from "./components/RecordDetailPage";
 import { RunHomePage } from "./components/RunHomePage";
 import { RunSubmitPage } from "./components/RunSubmitPage";
-import { defaultRunId, getRunById } from "./data/mockRuns";
+import { defaultRunId, getRunById, mockRuns } from "./data/mockRuns";
 
-type AppRoute = { name: "home" } | { name: "detail"; runId: string } | { name: "submit" };
+type AppRoute =
+  | { name: "home" }
+  | { name: "detail"; runId: string }
+  | { name: "submit" }
+  | { name: "chat" }
+  | { name: "question" }
+  | { name: "exchange" }
+  | { name: "event" }
+  | { name: "notifications" }
+  | { name: "account" };
+
+type ShellDestination = Exclude<AppRoute["name"], "detail">;
+
+const DEFAULT_VERSION_OPTIONS = ["Luna3", "Luna2", "Luna1", "5.8", "5.7", "5.6", "5.5", "5.4", "5.3", "5.2", "5.1", "5.0"];
+const APP_VERSION_OPTIONS = Array.from(new Set([...DEFAULT_VERSION_OPTIONS, ...mockRuns.map((run) => run.versionLabel)]));
 
 function getRouteFromHash(): AppRoute {
   if (typeof window === "undefined") {
@@ -27,6 +43,30 @@ function getRouteFromHash(): AppRoute {
     return { name: "detail", runId: getRunById(runId) ? runId : defaultRunId };
   }
 
+  if (normalizedHash === "chat") {
+    return { name: "chat" };
+  }
+
+  if (normalizedHash === "question") {
+    return { name: "question" };
+  }
+
+  if (normalizedHash === "exchange") {
+    return { name: "exchange" };
+  }
+
+  if (normalizedHash === "event") {
+    return { name: "event" };
+  }
+
+  if (normalizedHash === "notifications") {
+    return { name: "notifications" };
+  }
+
+  if (normalizedHash === "account") {
+    return { name: "account" };
+  }
+
   return { name: "home" };
 }
 
@@ -39,11 +79,127 @@ function getHashFromRoute(route: AppRoute) {
     return `#detail/${encodeURIComponent(route.runId)}`;
   }
 
+  if (route.name === "chat") {
+    return "#chat";
+  }
+
+  if (route.name === "question") {
+    return "#question";
+  }
+
+  if (route.name === "exchange") {
+    return "#exchange";
+  }
+
+  if (route.name === "event") {
+    return "#event";
+  }
+
+  if (route.name === "notifications") {
+    return "#notifications";
+  }
+
+  if (route.name === "account") {
+    return "#account";
+  }
+
   return "#home";
+}
+
+function RoutePlaceholder({ routeName }: { routeName: Exclude<AppRoute["name"], "home" | "detail" | "submit"> }) {
+  if (routeName === "chat") {
+    return (
+      <PlaceholderPage
+        eyebrow="Chat"
+        title="雑談"
+        description="精鋭狩りの軽い相談、雑談、日々の試走メモを溜めるための入口です。後続 issue でスレッド一覧や投稿 UI を差し替えやすいよう、まずは route と受け皿だけを繋いでいます。"
+      >
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4 text-[14px] text-[#5e6173]">最近の話題や募集を見つけやすい一覧領域</div>
+          <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4 text-[14px] text-[#5e6173]">簡易投稿ボックスや pinned thread の置き場</div>
+        </div>
+      </PlaceholderPage>
+    );
+  }
+
+  if (routeName === "question") {
+    return (
+      <PlaceholderPage
+        eyebrow="Questions"
+        title="質問"
+        description="編成、ルート、装備、申請方法など、記録閲覧と地続きの質問を独立ページとして置きます。情報交換に埋もれないよう専用 route で扱います。"
+      >
+        <div className="space-y-3 text-[14px] leading-[1.8] text-[#5e6173]">
+          <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4">「この編成でどこを短縮できるか」などの Q&A 一覧</div>
+          <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4">初心者向け導線と、答えが見つかりやすい固定カテゴリ</div>
+        </div>
+      </PlaceholderPage>
+    );
+  }
+
+  if (routeName === "exchange") {
+    return (
+      <PlaceholderPage
+        eyebrow="Exchange"
+        title="情報交換"
+        description="ルート知見、キャラ運用、季節更新の差分などを静的でも蓄積できるハブです。コミュニティの付加価値を無理なくサイト内に残すための土台にします。"
+      >
+        <div className="grid gap-3 md:grid-cols-3">
+          <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4 text-[14px] text-[#5e6173]">ルート共有</div>
+          <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4 text-[14px] text-[#5e6173]">編成メモ</div>
+          <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4 text-[14px] text-[#5e6173]">バージョン差分</div>
+        </div>
+      </PlaceholderPage>
+    );
+  }
+
+  if (routeName === "event") {
+    return (
+      <PlaceholderPage
+        eyebrow="Events"
+        title="イベント情報"
+        description="大会告知やシーズン切替、提出締切などの告知をまとめるページです。公開導線のひとつとして global nav から常に辿れる状態を先に作ります。"
+      >
+        <div className="space-y-3 text-[14px] leading-[1.8] text-[#5e6173]">
+          <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4">近日開催のイベントカード</div>
+          <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4">提出ルールや更新履歴の告知枠</div>
+        </div>
+      </PlaceholderPage>
+    );
+  }
+
+  if (routeName === "notifications") {
+    return (
+      <PlaceholderPage
+        eyebrow="Notifications"
+        title="通知"
+        description="通知は header からアクセスする補助導線として置きます。閲覧系 route と混ぜず、今は unread 表現と受け皿だけを持たせます。"
+      >
+        <div className="space-y-3 text-[14px] leading-[1.8] text-[#5e6173]">
+          <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4">コメントや申請更新の通知一覧が入る領域</div>
+          <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4">通知設定や既読処理は後続で追加予定</div>
+        </div>
+      </PlaceholderPage>
+    );
+  }
+
+  return (
+    <PlaceholderPage
+      eyebrow="Account"
+      title="アカウント"
+      description="Google account first の設定導線を置くための placeholder です。ログイン、プロフィール、今後の通知設定などをここに集約します。"
+    >
+      <div className="space-y-3 text-[14px] leading-[1.8] text-[#5e6173]">
+        <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4">プロフィール表示と接続中アカウントの確認</div>
+        <div className="rounded-[16px] border border-[#ececf4] bg-[#f8f8fb] px-4 py-4">将来の設定メニューを追加しやすい構造</div>
+      </div>
+    </PlaceholderPage>
+  );
 }
 
 export default function RootApp() {
   const [route, setRoute] = useState<AppRoute>(() => getRouteFromHash());
+  const [selectedVersion, setSelectedVersion] = useState(() => APP_VERSION_OPTIONS[0] ?? "Luna3");
   const [lastBrowseRoute, setLastBrowseRoute] = useState<AppRoute>(() => (route.name === "submit" ? { name: "home" } : route));
   const routeRef = useRef(route);
   const previousRouteRef = useRef<AppRoute | null>(null);
@@ -71,6 +227,15 @@ export default function RootApp() {
   useEffect(() => {
     if (route.name !== "submit") {
       setLastBrowseRoute(route);
+    }
+  }, [route]);
+
+  useEffect(() => {
+    if (route.name === "detail") {
+      const currentRun = getRunById(route.runId);
+      if (currentRun?.versionLabel) {
+        setSelectedVersion(currentRun.versionLabel);
+      }
     }
   }, [route]);
 
@@ -112,14 +277,68 @@ export default function RootApp() {
     }
   };
 
+  const navigateFromShell = (target: ShellDestination) => {
+    if (target === "home") {
+      navigate({ name: "home" });
+      return;
+    }
+
+    if (target === "submit") {
+      navigate({ name: "submit" });
+      return;
+    }
+
+    if (target === "chat") {
+      navigate({ name: "chat" });
+      return;
+    }
+
+    if (target === "question") {
+      navigate({ name: "question" });
+      return;
+    }
+
+    if (target === "exchange") {
+      navigate({ name: "exchange" });
+      return;
+    }
+
+    if (target === "event") {
+      navigate({ name: "event" });
+      return;
+    }
+
+    if (target === "notifications") {
+      navigate({ name: "notifications" });
+      return;
+    }
+
+    navigate({ name: "account" });
+  };
+
   return (
-    <>
+    <AppShell
+      routeName={route.name}
+      version={selectedVersion}
+      versionOptions={APP_VERSION_OPTIONS}
+      hasUnreadNotifications={route.name !== "notifications"}
+      onNavigate={navigateFromShell}
+      onRequestSubmit={() => navigate({ name: "submit" })}
+      onVersionChange={setSelectedVersion}
+    >
       <div style={{ display: route.name === "home" ? "block" : "none" }} aria-hidden={route.name !== "home"}>
-        <RunHomePage onRequestSubmit={() => navigate({ name: "submit" })} onSelectRun={(runId) => navigate({ name: "detail", runId })} />
+        <RunHomePage
+          embedded
+          selectedSeason={selectedVersion}
+          onSelectedSeasonChange={setSelectedVersion}
+          onRequestSubmit={() => navigate({ name: "submit" })}
+          onSelectRun={(runId) => navigate({ name: "detail", runId })}
+        />
       </div>
 
       {route.name === "submit" ? (
         <RunSubmitPage
+          embedded
           onBack={() => {
             navigate(lastBrowseRoute.name === "submit" ? { name: "home" } : lastBrowseRoute);
           }}
@@ -128,12 +347,15 @@ export default function RootApp() {
 
       {route.name === "detail" ? (
         <RecordDetailPage
+          embedded
           key={route.runId}
           runId={route.runId}
           onBack={() => navigate({ name: "home" })}
           onRequestSubmit={() => navigate({ name: "submit" })}
         />
       ) : null}
-    </>
+
+      {route.name !== "home" && route.name !== "submit" && route.name !== "detail" ? <RoutePlaceholder routeName={route.name} /> : null}
+    </AppShell>
   );
 }

--- a/src/RootApp.tsx
+++ b/src/RootApp.tsx
@@ -316,6 +316,17 @@ export default function RootApp() {
     navigate({ name: "account" });
   };
 
+  const navigateHomeFromTitle = () => {
+    homeScrollRef.current = 0;
+
+    if (routeRef.current.name === "home") {
+      window.scrollTo({ top: 0, behavior: "auto" });
+      return;
+    }
+
+    navigate({ name: "home" });
+  };
+
   return (
     <AppShell
       routeName={route.name}
@@ -323,6 +334,7 @@ export default function RootApp() {
       versionOptions={APP_VERSION_OPTIONS}
       hasUnreadNotifications={route.name !== "notifications"}
       onNavigate={navigateFromShell}
+      onTitleClick={navigateHomeFromTitle}
       onRequestSubmit={() => navigate({ name: "submit" })}
       onVersionChange={setSelectedVersion}
     >
@@ -359,3 +371,7 @@ export default function RootApp() {
     </AppShell>
   );
 }
+
+
+
+

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -13,10 +13,15 @@ type ShellRouteName =
 
 type ShellDestination = Exclude<ShellRouteName, "detail">;
 
+type IconProps = {
+  className?: string;
+  active?: boolean;
+};
+
 type NavItem = {
   route: "home" | "chat" | "question" | "exchange" | "event";
   label: string;
-  icon: (props: { className?: string }) => ReactNode;
+  icon: (props: IconProps) => ReactNode;
 };
 
 const navSections: NavItem[][] = [
@@ -68,7 +73,17 @@ function ShellIcon({
   );
 }
 
-function TrophyIcon({ className }: { className?: string }) {
+function TrophyIcon({ className, active = false }: IconProps) {
+  if (active) {
+    return (
+      <svg viewBox="0 0 24 24" className={classNames("shrink-0", className)} fill="currentColor" aria-hidden="true">
+        <path d="M7 4a1 1 0 0 0-1 1v2a6 6 0 0 0 5 5.92V15H9.8a1 1 0 0 0-.97.76l-.84 3.24A1 1 0 0 0 8.96 20h6.08a1 1 0 0 0 .97-1.25l-.84-3.24A1 1 0 0 0 14.2 15H13v-2.08A6 6 0 0 0 18 7V5a1 1 0 0 0-1-1H7Z" />
+        <path d="M5 6H4.5A1.5 1.5 0 0 0 3 7.5V8a4 4 0 0 0 4 4h.06A7.96 7.96 0 0 1 5 8V6Z" />
+        <path d="M19 6h.5A1.5 1.5 0 0 1 21 7.5V8a4 4 0 0 1-4 4h-.06A7.96 7.96 0 0 0 19 8V6Z" />
+      </svg>
+    );
+  }
+
   return (
     <ShellIcon className={className}>
       <path d="M8 4h8v3a4 4 0 0 1-8 0V4Z" />
@@ -81,7 +96,15 @@ function TrophyIcon({ className }: { className?: string }) {
   );
 }
 
-function MessageIcon({ className }: { className?: string }) {
+function MessageIcon({ className, active = false }: IconProps) {
+  if (active) {
+    return (
+      <svg viewBox="0 0 24 24" className={classNames("shrink-0", className)} fill="currentColor" aria-hidden="true">
+        <path d="M6.5 4A2.5 2.5 0 0 0 4 6.5v6A2.5 2.5 0 0 0 6.5 15H8v4l4.4-4h5.1A2.5 2.5 0 0 0 20 12.5v-6A2.5 2.5 0 0 0 17.5 4h-11Z" />
+      </svg>
+    );
+  }
+
   return (
     <ShellIcon className={className}>
       <path d="M4 6.5A2.5 2.5 0 0 1 6.5 4h11A2.5 2.5 0 0 1 20 6.5v6A2.5 2.5 0 0 1 17.5 15H10l-4.5 4v-4H6.5A2.5 2.5 0 0 1 4 12.5v-6Z" />
@@ -89,7 +112,23 @@ function MessageIcon({ className }: { className?: string }) {
   );
 }
 
-function QuestionIcon({ className }: { className?: string }) {
+function QuestionIcon({ className, active = false }: IconProps) {
+  if (active) {
+    return (
+      <svg viewBox="0 0 24 24" className={classNames("shrink-0", className)} fill="none" aria-hidden="true">
+        <circle cx="12" cy="12" r="9" fill="currentColor" />
+        <path
+          d="M9.6 9.3a2.4 2.4 0 1 1 4.2 1.5c-.7.7-1.5 1.1-1.8 2.2"
+          stroke="#0f141c"
+          strokeWidth="1.9"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path d="M12 16.8h.01" stroke="#0f141c" strokeWidth="2.2" strokeLinecap="round" />
+      </svg>
+    );
+  }
+
   return (
     <ShellIcon className={className}>
       <circle cx="12" cy="12" r="9" />
@@ -99,7 +138,17 @@ function QuestionIcon({ className }: { className?: string }) {
   );
 }
 
-function LightbulbIcon({ className }: { className?: string }) {
+function LightbulbIcon({ className, active = false }: IconProps) {
+  if (active) {
+    return (
+      <svg viewBox="0 0 24 24" className={classNames("shrink-0", className)} fill="currentColor" aria-hidden="true">
+        <path d="M12 3.5a5.5 5.5 0 0 0-3.85 9.43c.77.73 1.2 1.53 1.37 2.07h5c.17-.54.6-1.34 1.37-2.07A5.5 5.5 0 0 0 12 3.5Z" />
+        <path d="M9 17a1 1 0 0 0 0 2h6a1 1 0 1 0 0-2H9Z" />
+        <path d="M10 20a1 1 0 0 0 0 2h4a1 1 0 1 0 0-2h-4Z" />
+      </svg>
+    );
+  }
+
   return (
     <ShellIcon className={className}>
       <path d="M9 17.5h6" />
@@ -109,7 +158,16 @@ function LightbulbIcon({ className }: { className?: string }) {
   );
 }
 
-function CalendarIcon({ className }: { className?: string }) {
+function CalendarIcon({ className, active = false }: IconProps) {
+  if (active) {
+    return (
+      <svg viewBox="0 0 24 24" className={classNames("shrink-0", className)} fill="currentColor" aria-hidden="true">
+        <path d="M8 3a1 1 0 0 1 1 1v1h6V4a1 1 0 1 1 2 0v1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h1V4a1 1 0 0 1 1-1Z" />
+        <path d="M6 10.25h12v1.5H6Z" fill="#0f141c" opacity="0.35" />
+      </svg>
+    );
+  }
+
   return (
     <ShellIcon className={className}>
       <rect x="4" y="5" width="16" height="15" rx="2" />
@@ -180,7 +238,7 @@ function PlusIcon({ className }: { className?: string }) {
   );
 }
 
-function SidebarSection({
+function DrawerSection({
   items,
   routeName,
   onNavigate,
@@ -190,26 +248,23 @@ function SidebarSection({
   onNavigate: (route: ShellDestination) => void;
 }) {
   return (
-    <div className="flex flex-col items-start gap-4 px-4 py-8 md:items-center md:px-2 lg:items-start lg:gap-6 lg:px-8">
+    <div className="flex flex-col gap-4 px-4 py-8 sm:px-6">
       {items.map((item) => {
         const Icon = item.icon;
         const active = isNavActive(routeName, item.route);
 
         return (
-            <button
-              key={item.route}
-              type="button"
-              onClick={() => onNavigate(item.route)}
-              className={classNames(
-                "group flex w-full items-center gap-4 rounded-full p-3 text-left transition-all md:w-auto lg:w-full lg:px-4 lg:py-3",
-                active ? "bg-neutral-800" : "hover:bg-neutral-800",
-              )}
-            >
-            <Icon className={classNames("size-6 shrink-0", active ? "text-white" : "text-gray-400")} />
+          <button
+            key={item.route}
+            type="button"
+            onClick={() => onNavigate(item.route)}
+            className="group flex w-full items-center gap-4 rounded-full px-4 py-3 text-left transition-all hover:bg-[#171d28]"
+          >
+            <Icon active={active} className={classNames("size-6 shrink-0", active ? "text-[#d9d9d9]" : "text-[#8b95a7]")} />
             <span
               className={classNames(
-                "block whitespace-nowrap text-[20px] font-normal transition-colors md:hidden lg:block",
-                active ? "text-white" : "text-[#d9d9d9] group-hover:text-white",
+                "whitespace-nowrap text-[20px] transition-colors",
+                active ? "font-bold text-[#d9d9d9]" : "font-normal text-[#d9d9d9] group-hover:text-[#d9d9d9]",
               )}
             >
               {item.label}
@@ -221,7 +276,7 @@ function SidebarSection({
   );
 }
 
-function SidebarBody({
+function DrawerBody({
   routeName,
   onNavigate,
 }: {
@@ -230,42 +285,34 @@ function SidebarBody({
 }) {
   return (
     <>
-      <div className="flex justify-start border-b border-[#333] px-4 py-8 md:justify-center md:px-2 lg:justify-start lg:px-8 lg:pt-16 lg:pb-8">
-        <div className="flex w-full max-w-[240px] items-center justify-between rounded-full p-2 transition-colors hover:bg-neutral-800 lg:p-3">
-          <div className="flex items-center gap-4">
+      <div className="flex justify-start border-b border-[#2a3140] px-4 py-8 sm:px-6">
+        <div className="flex w-full max-w-[240px] flex-col gap-3 rounded-[24px] p-3 transition-colors hover:bg-[#171d28]">
+          <div className="flex items-center justify-between gap-4">
             <div className="relative flex size-[36px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#d9d9d9]">
               <UserIcon className="size-5 text-gray-500" />
             </div>
-            <p className="block whitespace-nowrap text-[16px] font-bold text-[#d9d9d9] md:hidden lg:block">アカウント名</p>
+            <button
+              type="button"
+              className="rounded-full p-1 text-[#8b95a7] transition-colors hover:bg-[#222938] hover:text-[#d9d9d9]"
+              aria-label="アカウントメニュー"
+            >
+              <MoreIcon className="size-5" />
+            </button>
           </div>
-          <MoreIcon className="block size-5 text-gray-500 md:hidden lg:block" />
+          <p className="truncate text-[16px] font-bold text-[#d9d9d9]">アカウント名</p>
         </div>
       </div>
 
-      <div className="border-b border-[#333]">
-        <SidebarSection items={navSections[0]} routeName={routeName} onNavigate={onNavigate} />
+      <div className="border-b border-[#2a3140]">
+        <DrawerSection items={navSections[0]} routeName={routeName} onNavigate={onNavigate} />
       </div>
 
-      <SidebarSection items={navSections[1]} routeName={routeName} onNavigate={onNavigate} />
+      <DrawerSection items={navSections[1]} routeName={routeName} onNavigate={onNavigate} />
     </>
   );
 }
 
-function StaticSidebar({
-  routeName,
-  onNavigate,
-}: {
-  routeName: ShellRouteName;
-  onNavigate: (route: ShellDestination) => void;
-}) {
-  return (
-    <aside className="hidden shrink-0 border-r border-[#333] bg-black text-[#d9d9d9] md:sticky md:top-0 md:flex md:h-screen md:w-[80px] md:flex-col md:overflow-y-auto lg:w-[320px]">
-      <SidebarBody routeName={routeName} onNavigate={onNavigate} />
-    </aside>
-  );
-}
-
-function MobileSidebar({
+function GlobalDrawer({
   isOpen,
   routeName,
   onClose,
@@ -284,11 +331,12 @@ function MobileSidebar({
   return (
     <aside
       className={classNames(
-        "fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-y-auto border-r border-[#333] bg-black text-[#d9d9d9] transition-transform duration-300 ease-in-out md:hidden",
+        "fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-y-auto border-r border-[#2a3140] bg-[#0f141c] text-[#d9d9d9] transition-transform duration-300 ease-in-out sm:w-[320px]",
         isOpen ? "translate-x-0" : "-translate-x-full",
       )}
+      aria-hidden={!isOpen}
     >
-      <SidebarBody routeName={routeName} onNavigate={handleNavigate} />
+      <DrawerBody routeName={routeName} onNavigate={handleNavigate} />
     </aside>
   );
 }
@@ -313,31 +361,31 @@ function GlobalHeader({
   onVersionChange: (version: string) => void;
 }) {
   const utilityButtonClass =
-    "relative rounded-full p-2 text-[#d9d9d9] transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#999]";
+    "relative rounded-full p-2 text-[#d9d9d9] transition-colors hover:bg-[#171d28] hover:text-[#d9d9d9] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#657086]";
 
   return (
-    <header className="sticky top-0 z-30 h-[80px] shrink-0 border-b border-[#333] bg-black">
+    <header className="sticky top-0 z-30 h-[80px] shrink-0 border-b border-[#2a3140] bg-[#0f141c]">
       <div className="header-font flex h-full items-center justify-between gap-4 px-4 py-4 md:px-6">
         <div className="flex min-w-0 items-center gap-4 sm:gap-6">
-          <button type="button" className="text-[#d9d9d9] transition-colors hover:text-white md:hidden" onClick={onMenuClick} aria-label="メニューを開く">
+          <button type="button" className="text-[#d9d9d9] transition-colors hover:text-[#d9d9d9]" onClick={onMenuClick} aria-label="メニューを開く">
             <MenuIcon className="size-7" />
           </button>
 
-          <h1 className="shrink-0 whitespace-nowrap text-[18px] font-normal text-[#d9d9d9] sm:text-[20px] md:text-[24px]">精鋭狩りDB</h1>
+          <h1 className="shrink-0 whitespace-nowrap text-[20px] font-semibold tracking-tight text-[#d9d9d9] md:text-[32px]">精鋭狩りDB</h1>
 
           <div className="relative min-w-0">
             <select
               value={version}
               onChange={(event) => onVersionChange(event.target.value)}
-              className="min-w-[104px] appearance-none rounded-full border border-[#4a4a4a] bg-[#1a1a1a] py-2 pl-4 pr-10 text-[16px] font-normal text-[#d9d9d9] outline-none transition-colors hover:border-[#5c5c5c] focus:border-[#7a7a7a] sm:text-[18px] md:text-[20px]"
+              className="min-w-[104px] appearance-none rounded-full border border-[#2f3949] bg-[#171d28] py-2 pl-4 pr-10 text-[12px] font-normal text-[#d9d9d9] outline-none transition-colors hover:border-[#445066] focus:border-[#657086] sm:text-[14px] md:text-[16px]"
             >
               {versionOptions.map((option) => (
-                <option key={option} value={option} className="bg-[#1a1a1a] text-[#d9d9d9]">
+                <option key={option} value={option} className="bg-[#171d28] text-[#d9d9d9]">
                   {option}
                 </option>
               ))}
             </select>
-            <ChevronDownIcon className="pointer-events-none absolute top-1/2 right-3 size-5 -translate-y-1/2 text-[#a8a8a8]" />
+            <ChevronDownIcon className="pointer-events-none absolute top-1/2 right-3 size-5 -translate-y-1/2 text-[#8b95a7]" />
           </div>
         </div>
 
@@ -347,21 +395,21 @@ function GlobalHeader({
             onClick={onRequestSubmit}
             className={classNames(
               "flex items-center gap-2 rounded-full px-3 py-2 transition-colors sm:px-4",
-              routeName === "submit" ? "bg-[#454545] text-white" : "bg-[#333] text-[#d9d9d9] hover:bg-neutral-700",
+              routeName === "submit" ? "bg-white text-[#111111]" : "bg-[#2a3140] text-[#d9d9d9] hover:bg-[#364055]",
             )}
           >
             <PlusIcon className="size-5" />
-            <span className="hidden whitespace-nowrap text-[16px] font-normal sm:block md:text-[20px]">記録申請</span>
+            <span className="hidden whitespace-nowrap text-[12px] font-normal sm:block md:text-[16px]">記録申請</span>
           </button>
 
           <button
             type="button"
             onClick={() => onNavigate("notifications")}
             aria-label="通知"
-            className={classNames(utilityButtonClass, routeName === "notifications" && "bg-[#1d1d1d] text-white")}
+            className={classNames(utilityButtonClass, routeName === "notifications" && "bg-[#2a3140] text-[#d9d9d9] hover:bg-[#2a3140]")}
           >
             <BellIcon className="size-6 sm:size-7" />
-            {hasUnreadNotifications ? <span className="absolute top-1 right-1 block size-2.5 rounded-full border-2 border-black bg-red-500" /> : null}
+            {hasUnreadNotifications ? <span className="absolute top-1 right-1 block size-2.5 rounded-full border-2 border-[#0f141c] bg-red-500" /> : null}
           </button>
 
           <button
@@ -370,7 +418,7 @@ function GlobalHeader({
             aria-label="アカウント"
             className={classNames(
               "flex size-[32px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#d9d9d9] transition-opacity hover:opacity-80 sm:size-[36px]",
-              routeName === "account" && "ring-2 ring-[#7a7a7a]",
+              routeName === "account" && "ring-2 ring-[#657086]",
             )}
           >
             <UserIcon className="size-5 text-gray-600" />
@@ -400,43 +448,50 @@ export function AppShell({
   onVersionChange: (version: string) => void;
   children: ReactNode;
 }) {
-  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   useEffect(() => {
-    if (!isMobileMenuOpen) {
+    if (!isDrawerOpen) {
       return;
     }
 
     const previousOverflow = document.body.style.overflow;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsDrawerOpen(false);
+      }
+    };
+
     document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", handleKeyDown);
 
     return () => {
       document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", handleKeyDown);
     };
-  }, [isMobileMenuOpen]);
+  }, [isDrawerOpen]);
 
   return (
-    <div className="relative min-h-screen bg-[#121212] font-['Noto_Sans_JP',sans-serif] text-[#d9d9d9]">
-      {isMobileMenuOpen ? (
-        <div className="fixed inset-0 z-40 bg-[rgba(0,0,0,0.2)] transition-opacity md:hidden" onClick={() => setIsMobileMenuOpen(false)} />
+    <div className="relative min-h-screen bg-[#f8f9fb] font-['Noto_Sans_JP',sans-serif] text-[#333333]">
+      {isDrawerOpen ? (
+        <div className="fixed inset-0 z-40 bg-[rgba(0,0,0,0.5)] transition-opacity" onClick={() => setIsDrawerOpen(false)} />
       ) : null}
 
-      <div className="flex min-h-screen">
-        <MobileSidebar
-          isOpen={isMobileMenuOpen}
-          routeName={routeName}
-          onClose={() => setIsMobileMenuOpen(false)}
-          onNavigate={onNavigate}
-        />
-        <StaticSidebar routeName={routeName} onNavigate={onNavigate} />
+      <GlobalDrawer
+        isOpen={isDrawerOpen}
+        routeName={routeName}
+        onClose={() => setIsDrawerOpen(false)}
+        onNavigate={onNavigate}
+      />
 
-        <div className="flex min-w-0 flex-1 flex-col bg-[#121212]">
+      <div className="flex min-h-screen">
+        <div className="flex min-w-0 flex-1 flex-col bg-[#f8f9fb]">
           <GlobalHeader
             routeName={routeName}
             version={version}
             versionOptions={versionOptions}
             hasUnreadNotifications={hasUnreadNotifications}
-            onMenuClick={() => setIsMobileMenuOpen(true)}
+            onMenuClick={() => setIsDrawerOpen(true)}
             onNavigate={onNavigate}
             onRequestSubmit={onRequestSubmit}
             onVersionChange={onVersionChange}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect, useState } from "react";
+﻿import { type ReactNode, useEffect, useState } from "react";
 
 type ShellRouteName =
   | "home"
@@ -18,29 +18,54 @@ type IconProps = {
   active?: boolean;
 };
 
-type NavItem = {
+type InternalNavItem = {
+  key: string;
+  kind: "route";
   route: "home" | "chat" | "question" | "exchange" | "event";
   label: string;
   icon: (props: IconProps) => ReactNode;
 };
 
-const navSections: NavItem[][] = [
-  [
-    { route: "home", label: "リーダーボード", icon: TrophyIcon },
-    { route: "chat", label: "雑談", icon: MessageIcon },
-    { route: "question", label: "質問", icon: QuestionIcon },
-  ],
-  [
-    { route: "exchange", label: "情報交換", icon: LightbulbIcon },
-    { route: "event", label: "イベント情報", icon: CalendarIcon },
-  ],
+type ExternalNavItem = {
+  key: string;
+  kind: "external";
+  href: string;
+  label: string;
+  icon: (props: IconProps) => ReactNode;
+};
+
+type NavItem = InternalNavItem | ExternalNavItem;
+
+const primaryNavItems: NavItem[] = [
+  { key: "home", kind: "route", route: "home", label: "\u30ea\u30fc\u30c0\u30fc\u30dc\u30fc\u30c9", icon: TrophyIcon },
+  { key: "event", kind: "route", route: "event", label: "\u30a4\u30d9\u30f3\u30c8\u60c5\u5831", icon: CalendarIcon },
+  { key: "exchange", kind: "route", route: "exchange", label: "\u60c5\u5831\u4ea4\u63db", icon: LightbulbIcon },
+  { key: "chat", kind: "route", route: "chat", label: "\u96d1\u8ac7", icon: MessageIcon },
+  { key: "question", kind: "route", route: "question", label: "\u8cea\u554f", icon: QuestionIcon },
+];
+
+const externalToolItems: NavItem[] = [
+  {
+    key: "tsurumi-planner",
+    kind: "external",
+    href: "https://anotokinotori.github.io/Tsurumi-Map-Optimizer/",
+    label: "\u9db4\u898b\u8abf\u6574\u30d7\u30e9\u30f3\u30ca\u30fc",
+    icon: ExternalLinkIcon,
+  },
+  {
+    key: "autosplit",
+    kind: "external",
+    href: "https://github.com/semaruebi/400ee_win_autosplit/releases",
+    label: "AutoSplit",
+    icon: ExternalLinkIcon,
+  },
 ];
 
 function classNames(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
 }
 
-function isNavActive(routeName: ShellRouteName, itemRoute: NavItem["route"]) {
+function isNavActive(routeName: ShellRouteName, itemRoute: InternalNavItem["route"]) {
   if (itemRoute === "home") {
     return routeName === "home" || routeName === "detail";
   }
@@ -181,6 +206,16 @@ function CalendarIcon({ className, active = false }: IconProps) {
   );
 }
 
+function ExternalLinkIcon({ className }: IconProps) {
+  return (
+    <ShellIcon className={className}>
+      <path d="M15 3h6v6" />
+      <path d="M10 14 21 3" />
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+    </ShellIcon>
+  );
+}
+
 function MenuIcon({ className }: { className?: string }) {
   return (
     <ShellIcon className={className}>
@@ -242,33 +277,44 @@ function DrawerSection({
   items,
   routeName,
   onNavigate,
+  onExternalSelect,
 }: {
   items: NavItem[];
   routeName: ShellRouteName;
   onNavigate: (route: ShellDestination) => void;
+  onExternalSelect: () => void;
 }) {
   return (
     <div className="flex flex-col gap-4 px-4 py-8 sm:px-6">
       {items.map((item) => {
         const Icon = item.icon;
-        const active = isNavActive(routeName, item.route);
+        const active = item.kind === "route" ? isNavActive(routeName, item.route) : false;
+        const itemClassName = "group flex w-full items-center gap-4 rounded-full px-4 py-3 text-left transition-all hover:bg-[#171d28]";
+        const labelClassName = classNames(
+          "whitespace-nowrap text-[20px] transition-colors",
+          active ? "font-bold text-[#d9d9d9]" : "font-normal text-[#d9d9d9] group-hover:text-[#d9d9d9]",
+        );
+
+        if (item.kind === "external") {
+          return (
+            <a
+              key={item.key}
+              href={item.href}
+              target="_blank"
+              rel="noreferrer"
+              onClick={onExternalSelect}
+              className={itemClassName}
+            >
+              <Icon className="size-6 shrink-0 text-[#8b95a7]" />
+              <span className={labelClassName}>{item.label}</span>
+            </a>
+          );
+        }
 
         return (
-          <button
-            key={item.route}
-            type="button"
-            onClick={() => onNavigate(item.route)}
-            className="group flex w-full items-center gap-4 rounded-full px-4 py-3 text-left transition-all hover:bg-[#171d28]"
-          >
+          <button key={item.key} type="button" onClick={() => onNavigate(item.route)} className={itemClassName}>
             <Icon active={active} className={classNames("size-6 shrink-0", active ? "text-[#d9d9d9]" : "text-[#8b95a7]")} />
-            <span
-              className={classNames(
-                "whitespace-nowrap text-[20px] transition-colors",
-                active ? "font-bold text-[#d9d9d9]" : "font-normal text-[#d9d9d9] group-hover:text-[#d9d9d9]",
-              )}
-            >
-              {item.label}
-            </span>
+            <span className={labelClassName}>{item.label}</span>
           </button>
         );
       })}
@@ -279,35 +325,40 @@ function DrawerSection({
 function DrawerBody({
   routeName,
   onNavigate,
+  onClose,
 }: {
   routeName: ShellRouteName;
   onNavigate: (route: ShellDestination) => void;
+  onClose: () => void;
 }) {
   return (
     <>
       <div className="flex justify-start border-b border-[#2a3140] px-4 py-8 sm:px-6">
-        <div className="flex w-full max-w-[240px] flex-col gap-3 rounded-[24px] p-3 transition-colors hover:bg-[#171d28]">
+        <button
+          type="button"
+          onClick={() => onNavigate("account")}
+          className="flex w-full max-w-[240px] flex-col gap-3 rounded-[24px] p-3 text-left transition-colors hover:bg-[#171d28]"
+        >
           <div className="flex items-center justify-between gap-4">
             <div className="relative flex size-[36px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#d9d9d9]">
               <UserIcon className="size-5 text-gray-500" />
             </div>
-            <button
-              type="button"
-              className="rounded-full p-1 text-[#8b95a7] transition-colors hover:bg-[#222938] hover:text-[#d9d9d9]"
-              aria-label="アカウントメニュー"
-            >
+            <span className="rounded-full p-1 text-[#8b95a7]" aria-hidden="true">
               <MoreIcon className="size-5" />
-            </button>
+            </span>
           </div>
-          <p className="truncate text-[16px] font-bold text-[#d9d9d9]">アカウント名</p>
-        </div>
+          <div className="flex flex-col gap-1">
+            <p className="truncate text-[16px] font-bold text-[#d9d9d9]">{"アカウント名"}</p>
+            <p className="truncate text-[12px] font-normal text-[#8b95a7]">{"いいねをもらった数：０"}</p>
+          </div>
+        </button>
       </div>
 
       <div className="border-b border-[#2a3140]">
-        <DrawerSection items={navSections[0]} routeName={routeName} onNavigate={onNavigate} />
+        <DrawerSection items={primaryNavItems} routeName={routeName} onNavigate={onNavigate} onExternalSelect={onClose} />
       </div>
 
-      <DrawerSection items={navSections[1]} routeName={routeName} onNavigate={onNavigate} />
+      <DrawerSection items={externalToolItems} routeName={routeName} onNavigate={onNavigate} onExternalSelect={onClose} />
     </>
   );
 }
@@ -336,7 +387,7 @@ function GlobalDrawer({
       )}
       aria-hidden={!isOpen}
     >
-      <DrawerBody routeName={routeName} onNavigate={handleNavigate} />
+      <DrawerBody routeName={routeName} onNavigate={handleNavigate} onClose={onClose} />
     </aside>
   );
 }
@@ -347,6 +398,7 @@ function GlobalHeader({
   versionOptions,
   hasUnreadNotifications,
   onMenuClick,
+  onTitleClick,
   onNavigate,
   onRequestSubmit,
   onVersionChange,
@@ -356,6 +408,7 @@ function GlobalHeader({
   versionOptions: string[];
   hasUnreadNotifications: boolean;
   onMenuClick: () => void;
+  onTitleClick: () => void;
   onNavigate: (route: ShellDestination) => void;
   onRequestSubmit: () => void;
   onVersionChange: (version: string) => void;
@@ -367,11 +420,19 @@ function GlobalHeader({
     <header className="sticky top-0 z-30 h-[80px] shrink-0 border-b border-[#2a3140] bg-[#0f141c]">
       <div className="header-font flex h-full items-center justify-between gap-4 px-4 py-4 md:px-6">
         <div className="flex min-w-0 items-center gap-4 sm:gap-6">
-          <button type="button" className="text-[#d9d9d9] transition-colors hover:text-[#d9d9d9]" onClick={onMenuClick} aria-label="メニューを開く">
+          <button type="button" className="text-[#d9d9d9] transition-colors hover:text-[#d9d9d9]" onClick={onMenuClick} aria-label="\u30e1\u30cb\u30e5\u30fc\u3092\u958b\u304f">
             <MenuIcon className="size-7" />
           </button>
 
-          <h1 className="shrink-0 whitespace-nowrap text-[20px] font-semibold tracking-tight text-[#d9d9d9] md:text-[32px]">精鋭狩りDB</h1>
+          <h1 className="shrink-0">
+            <button
+              type="button"
+              onClick={onTitleClick}
+              className="whitespace-nowrap text-[20px] font-semibold tracking-tight text-[#d9d9d9] transition-opacity hover:opacity-85 md:text-[32px]"
+            >
+              {"\u7cbe\u92ed\u72e9\u308aDB"}
+            </button>
+          </h1>
 
           <div className="relative min-w-0">
             <select
@@ -399,13 +460,13 @@ function GlobalHeader({
             )}
           >
             <PlusIcon className="size-5" />
-            <span className="hidden whitespace-nowrap text-[12px] font-normal sm:block md:text-[16px]">記録申請</span>
+            <span className="hidden whitespace-nowrap text-[12px] font-normal sm:block md:text-[16px]">{"\u8a18\u9332\u7533\u8acb"}</span>
           </button>
 
           <button
             type="button"
             onClick={() => onNavigate("notifications")}
-            aria-label="通知"
+            aria-label="\u901a\u77e5"
             className={classNames(utilityButtonClass, routeName === "notifications" && "bg-[#2a3140] text-[#d9d9d9] hover:bg-[#2a3140]")}
           >
             <BellIcon className="size-6 sm:size-7" />
@@ -415,7 +476,7 @@ function GlobalHeader({
           <button
             type="button"
             onClick={() => onNavigate("account")}
-            aria-label="アカウント"
+            aria-label="\u30a2\u30ab\u30a6\u30f3\u30c8"
             className={classNames(
               "flex size-[32px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#d9d9d9] transition-opacity hover:opacity-80 sm:size-[36px]",
               routeName === "account" && "ring-2 ring-[#657086]",
@@ -435,6 +496,7 @@ export function AppShell({
   versionOptions,
   hasUnreadNotifications,
   onNavigate,
+  onTitleClick,
   onRequestSubmit,
   onVersionChange,
   children,
@@ -444,6 +506,7 @@ export function AppShell({
   versionOptions: string[];
   hasUnreadNotifications: boolean;
   onNavigate: (route: ShellDestination) => void;
+  onTitleClick: () => void;
   onRequestSubmit: () => void;
   onVersionChange: (version: string) => void;
   children: ReactNode;
@@ -471,6 +534,11 @@ export function AppShell({
     };
   }, [isDrawerOpen]);
 
+  const handleTitleClick = () => {
+    setIsDrawerOpen(false);
+    onTitleClick();
+  };
+
   return (
     <div className="relative min-h-screen bg-[#f8f9fb] font-['Noto_Sans_JP',sans-serif] text-[#333333]">
       {isDrawerOpen ? (
@@ -492,6 +560,7 @@ export function AppShell({
             versionOptions={versionOptions}
             hasUnreadNotifications={hasUnreadNotifications}
             onMenuClick={() => setIsDrawerOpen(true)}
+            onTitleClick={handleTitleClick}
             onNavigate={onNavigate}
             onRequestSubmit={onRequestSubmit}
             onVersionChange={onVersionChange}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,450 @@
+import { type ReactNode, useEffect, useState } from "react";
+
+type ShellRouteName =
+  | "home"
+  | "detail"
+  | "submit"
+  | "chat"
+  | "question"
+  | "exchange"
+  | "event"
+  | "notifications"
+  | "account";
+
+type ShellDestination = Exclude<ShellRouteName, "detail">;
+
+type NavItem = {
+  route: "home" | "chat" | "question" | "exchange" | "event";
+  label: string;
+  icon: (props: { className?: string }) => ReactNode;
+};
+
+const navSections: NavItem[][] = [
+  [
+    { route: "home", label: "リーダーボード", icon: TrophyIcon },
+    { route: "chat", label: "雑談", icon: MessageIcon },
+    { route: "question", label: "質問", icon: QuestionIcon },
+  ],
+  [
+    { route: "exchange", label: "情報交換", icon: LightbulbIcon },
+    { route: "event", label: "イベント情報", icon: CalendarIcon },
+  ],
+];
+
+function classNames(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}
+
+function isNavActive(routeName: ShellRouteName, itemRoute: NavItem["route"]) {
+  if (itemRoute === "home") {
+    return routeName === "home" || routeName === "detail";
+  }
+
+  return routeName === itemRoute;
+}
+
+function ShellIcon({
+  children,
+  className,
+  viewBox = "0 0 24 24",
+}: {
+  children: ReactNode;
+  className?: string;
+  viewBox?: string;
+}) {
+  return (
+    <svg
+      viewBox={viewBox}
+      className={classNames("shrink-0", className)}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.9"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  );
+}
+
+function TrophyIcon({ className }: { className?: string }) {
+  return (
+    <ShellIcon className={className}>
+      <path d="M8 4h8v3a4 4 0 0 1-8 0V4Z" />
+      <path d="M6 5H4a1 1 0 0 0-1 1v1a4 4 0 0 0 4 4" />
+      <path d="M18 5h2a1 1 0 0 1 1 1v1a4 4 0 0 1-4 4" />
+      <path d="M12 11v4" />
+      <path d="M9 20h6" />
+      <path d="M10 15h4l1 5H9l1-5Z" />
+    </ShellIcon>
+  );
+}
+
+function MessageIcon({ className }: { className?: string }) {
+  return (
+    <ShellIcon className={className}>
+      <path d="M4 6.5A2.5 2.5 0 0 1 6.5 4h11A2.5 2.5 0 0 1 20 6.5v6A2.5 2.5 0 0 1 17.5 15H10l-4.5 4v-4H6.5A2.5 2.5 0 0 1 4 12.5v-6Z" />
+    </ShellIcon>
+  );
+}
+
+function QuestionIcon({ className }: { className?: string }) {
+  return (
+    <ShellIcon className={className}>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M9.6 9.3a2.4 2.4 0 1 1 4.2 1.5c-.7.7-1.5 1.1-1.8 2.2" />
+      <path d="M12 16.8h.01" />
+    </ShellIcon>
+  );
+}
+
+function LightbulbIcon({ className }: { className?: string }) {
+  return (
+    <ShellIcon className={className}>
+      <path d="M9 17.5h6" />
+      <path d="M10 21h4" />
+      <path d="M8.5 14.5c-1.2-1-2-2.6-2-4.4a5.5 5.5 0 1 1 11 0c0 1.8-.8 3.4-2 4.4-.8.7-1.3 1.6-1.5 2.4h-4c-.2-.8-.7-1.7-1.5-2.4Z" />
+    </ShellIcon>
+  );
+}
+
+function CalendarIcon({ className }: { className?: string }) {
+  return (
+    <ShellIcon className={className}>
+      <rect x="4" y="5" width="16" height="15" rx="2" />
+      <path d="M8 3v4" />
+      <path d="M16 3v4" />
+      <path d="M4 10h16" />
+      <path d="M8.5 14h.01" />
+      <path d="M12 14h.01" />
+      <path d="M15.5 14h.01" />
+    </ShellIcon>
+  );
+}
+
+function MenuIcon({ className }: { className?: string }) {
+  return (
+    <ShellIcon className={className}>
+      <path d="M4 7h16" />
+      <path d="M4 12h16" />
+      <path d="M4 17h16" />
+    </ShellIcon>
+  );
+}
+
+function BellIcon({ className }: { className?: string }) {
+  return (
+    <ShellIcon className={className}>
+      <path d="M15 18H9" />
+      <path d="M6 18h12" />
+      <path d="M7 18v-5a5 5 0 1 1 10 0v5" />
+      <path d="M10 21a2 2 0 0 0 4 0" />
+    </ShellIcon>
+  );
+}
+
+function UserIcon({ className }: { className?: string }) {
+  return (
+    <ShellIcon className={className}>
+      <circle cx="12" cy="8" r="3.25" />
+      <path d="M5 19a7 7 0 0 1 14 0" />
+    </ShellIcon>
+  );
+}
+
+function MoreIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 24 24" className={classNames("shrink-0", className)} fill="currentColor" aria-hidden="true">
+      <circle cx="12" cy="5" r="1.7" />
+      <circle cx="12" cy="12" r="1.7" />
+      <circle cx="12" cy="19" r="1.7" />
+    </svg>
+  );
+}
+
+function ChevronDownIcon({ className }: { className?: string }) {
+  return (
+    <ShellIcon className={className}>
+      <path d="m6 9 6 6 6-6" />
+    </ShellIcon>
+  );
+}
+
+function PlusIcon({ className }: { className?: string }) {
+  return (
+    <ShellIcon className={className}>
+      <path d="M12 5v14" />
+      <path d="M5 12h14" />
+    </ShellIcon>
+  );
+}
+
+function SidebarSection({
+  items,
+  routeName,
+  onNavigate,
+}: {
+  items: NavItem[];
+  routeName: ShellRouteName;
+  onNavigate: (route: ShellDestination) => void;
+}) {
+  return (
+    <div className="flex flex-col items-start gap-4 px-4 py-8 md:items-center md:px-2 lg:items-start lg:gap-6 lg:px-8">
+      {items.map((item) => {
+        const Icon = item.icon;
+        const active = isNavActive(routeName, item.route);
+
+        return (
+            <button
+              key={item.route}
+              type="button"
+              onClick={() => onNavigate(item.route)}
+              className={classNames(
+                "group flex w-full items-center gap-4 rounded-full p-3 text-left transition-all md:w-auto lg:w-full lg:px-4 lg:py-3",
+                active ? "bg-neutral-800" : "hover:bg-neutral-800",
+              )}
+            >
+            <Icon className={classNames("size-6 shrink-0", active ? "text-white" : "text-gray-400")} />
+            <span
+              className={classNames(
+                "block whitespace-nowrap text-[20px] font-normal transition-colors md:hidden lg:block",
+                active ? "text-white" : "text-[#d9d9d9] group-hover:text-white",
+              )}
+            >
+              {item.label}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SidebarBody({
+  routeName,
+  onNavigate,
+}: {
+  routeName: ShellRouteName;
+  onNavigate: (route: ShellDestination) => void;
+}) {
+  return (
+    <>
+      <div className="flex justify-start border-b border-[#333] px-4 py-8 md:justify-center md:px-2 lg:justify-start lg:px-8 lg:pt-16 lg:pb-8">
+        <div className="flex w-full max-w-[240px] items-center justify-between rounded-full p-2 transition-colors hover:bg-neutral-800 lg:p-3">
+          <div className="flex items-center gap-4">
+            <div className="relative flex size-[36px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#d9d9d9]">
+              <UserIcon className="size-5 text-gray-500" />
+            </div>
+            <p className="block whitespace-nowrap text-[16px] font-bold text-[#d9d9d9] md:hidden lg:block">アカウント名</p>
+          </div>
+          <MoreIcon className="block size-5 text-gray-500 md:hidden lg:block" />
+        </div>
+      </div>
+
+      <div className="border-b border-[#333]">
+        <SidebarSection items={navSections[0]} routeName={routeName} onNavigate={onNavigate} />
+      </div>
+
+      <SidebarSection items={navSections[1]} routeName={routeName} onNavigate={onNavigate} />
+    </>
+  );
+}
+
+function StaticSidebar({
+  routeName,
+  onNavigate,
+}: {
+  routeName: ShellRouteName;
+  onNavigate: (route: ShellDestination) => void;
+}) {
+  return (
+    <aside className="hidden shrink-0 border-r border-[#333] bg-black text-[#d9d9d9] md:sticky md:top-0 md:flex md:h-screen md:w-[80px] md:flex-col md:overflow-y-auto lg:w-[320px]">
+      <SidebarBody routeName={routeName} onNavigate={onNavigate} />
+    </aside>
+  );
+}
+
+function MobileSidebar({
+  isOpen,
+  routeName,
+  onClose,
+  onNavigate,
+}: {
+  isOpen: boolean;
+  routeName: ShellRouteName;
+  onClose: () => void;
+  onNavigate: (route: ShellDestination) => void;
+}) {
+  const handleNavigate = (route: ShellDestination) => {
+    onNavigate(route);
+    onClose();
+  };
+
+  return (
+    <aside
+      className={classNames(
+        "fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-y-auto border-r border-[#333] bg-black text-[#d9d9d9] transition-transform duration-300 ease-in-out md:hidden",
+        isOpen ? "translate-x-0" : "-translate-x-full",
+      )}
+    >
+      <SidebarBody routeName={routeName} onNavigate={handleNavigate} />
+    </aside>
+  );
+}
+
+function GlobalHeader({
+  routeName,
+  version,
+  versionOptions,
+  hasUnreadNotifications,
+  onMenuClick,
+  onNavigate,
+  onRequestSubmit,
+  onVersionChange,
+}: {
+  routeName: ShellRouteName;
+  version: string;
+  versionOptions: string[];
+  hasUnreadNotifications: boolean;
+  onMenuClick: () => void;
+  onNavigate: (route: ShellDestination) => void;
+  onRequestSubmit: () => void;
+  onVersionChange: (version: string) => void;
+}) {
+  const utilityButtonClass =
+    "relative rounded-full p-2 text-[#d9d9d9] transition-colors hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-[#999]";
+
+  return (
+    <header className="sticky top-0 z-30 h-[80px] shrink-0 border-b border-[#333] bg-black">
+      <div className="header-font flex h-full items-center justify-between gap-4 px-4 py-4 md:px-6">
+        <div className="flex min-w-0 items-center gap-4 sm:gap-6">
+          <button type="button" className="text-[#d9d9d9] transition-colors hover:text-white md:hidden" onClick={onMenuClick} aria-label="メニューを開く">
+            <MenuIcon className="size-7" />
+          </button>
+
+          <h1 className="shrink-0 whitespace-nowrap text-[18px] font-normal text-[#d9d9d9] sm:text-[20px] md:text-[24px]">精鋭狩りDB</h1>
+
+          <div className="relative min-w-0">
+            <select
+              value={version}
+              onChange={(event) => onVersionChange(event.target.value)}
+              className="min-w-[104px] appearance-none rounded-full border border-[#4a4a4a] bg-[#1a1a1a] py-2 pl-4 pr-10 text-[16px] font-normal text-[#d9d9d9] outline-none transition-colors hover:border-[#5c5c5c] focus:border-[#7a7a7a] sm:text-[18px] md:text-[20px]"
+            >
+              {versionOptions.map((option) => (
+                <option key={option} value={option} className="bg-[#1a1a1a] text-[#d9d9d9]">
+                  {option}
+                </option>
+              ))}
+            </select>
+            <ChevronDownIcon className="pointer-events-none absolute top-1/2 right-3 size-5 -translate-y-1/2 text-[#a8a8a8]" />
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-4 sm:gap-6">
+          <button
+            type="button"
+            onClick={onRequestSubmit}
+            className={classNames(
+              "flex items-center gap-2 rounded-full px-3 py-2 transition-colors sm:px-4",
+              routeName === "submit" ? "bg-[#454545] text-white" : "bg-[#333] text-[#d9d9d9] hover:bg-neutral-700",
+            )}
+          >
+            <PlusIcon className="size-5" />
+            <span className="hidden whitespace-nowrap text-[16px] font-normal sm:block md:text-[20px]">記録申請</span>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => onNavigate("notifications")}
+            aria-label="通知"
+            className={classNames(utilityButtonClass, routeName === "notifications" && "bg-[#1d1d1d] text-white")}
+          >
+            <BellIcon className="size-6 sm:size-7" />
+            {hasUnreadNotifications ? <span className="absolute top-1 right-1 block size-2.5 rounded-full border-2 border-black bg-red-500" /> : null}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => onNavigate("account")}
+            aria-label="アカウント"
+            className={classNames(
+              "flex size-[32px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#d9d9d9] transition-opacity hover:opacity-80 sm:size-[36px]",
+              routeName === "account" && "ring-2 ring-[#7a7a7a]",
+            )}
+          >
+            <UserIcon className="size-5 text-gray-600" />
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+export function AppShell({
+  routeName,
+  version,
+  versionOptions,
+  hasUnreadNotifications,
+  onNavigate,
+  onRequestSubmit,
+  onVersionChange,
+  children,
+}: {
+  routeName: ShellRouteName;
+  version: string;
+  versionOptions: string[];
+  hasUnreadNotifications: boolean;
+  onNavigate: (route: ShellDestination) => void;
+  onRequestSubmit: () => void;
+  onVersionChange: (version: string) => void;
+  children: ReactNode;
+}) {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isMobileMenuOpen) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isMobileMenuOpen]);
+
+  return (
+    <div className="relative min-h-screen bg-[#121212] font-['Noto_Sans_JP',sans-serif] text-[#d9d9d9]">
+      {isMobileMenuOpen ? (
+        <div className="fixed inset-0 z-40 bg-[rgba(0,0,0,0.2)] transition-opacity md:hidden" onClick={() => setIsMobileMenuOpen(false)} />
+      ) : null}
+
+      <div className="flex min-h-screen">
+        <MobileSidebar
+          isOpen={isMobileMenuOpen}
+          routeName={routeName}
+          onClose={() => setIsMobileMenuOpen(false)}
+          onNavigate={onNavigate}
+        />
+        <StaticSidebar routeName={routeName} onNavigate={onNavigate} />
+
+        <div className="flex min-w-0 flex-1 flex-col bg-[#121212]">
+          <GlobalHeader
+            routeName={routeName}
+            version={version}
+            versionOptions={versionOptions}
+            hasUnreadNotifications={hasUnreadNotifications}
+            onMenuClick={() => setIsMobileMenuOpen(true)}
+            onNavigate={onNavigate}
+            onRequestSubmit={onRequestSubmit}
+            onVersionChange={onVersionChange}
+          />
+
+          <main className="min-w-0 flex-1 bg-[#f0f2f5] text-[#333333]">{children}</main>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/PlaceholderPage.tsx
+++ b/src/components/PlaceholderPage.tsx
@@ -1,0 +1,44 @@
+import { type ReactNode } from "react";
+
+export function PlaceholderPage({
+  title,
+  description,
+  eyebrow,
+  children,
+}: {
+  title: string;
+  description: string;
+  eyebrow: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="min-h-full bg-[#f0f2f5] text-[#333333]">
+      <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-6 px-4 py-6 md:px-6 md:py-8">
+        <section className="rounded-[20px] border border-black/8 bg-white px-6 py-7 shadow-[0_12px_30px_rgba(0,0,0,0.06)]">
+          <div className="text-[12px] font-bold tracking-[0.18em] text-[#9999b1] uppercase">{eyebrow}</div>
+          <h2 className="mt-3 text-[28px] font-semibold tracking-tight text-black md:text-[40px]">{title}</h2>
+          <p className="mt-3 max-w-[760px] text-[15px] leading-[1.8] text-[#5e6173] md:text-[16px]">{description}</p>
+        </section>
+
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1.4fr)_minmax(280px,0.8fr)]">
+          <section className="rounded-[20px] border border-black/8 bg-white p-6 shadow-[0_12px_30px_rgba(0,0,0,0.06)]">
+            <div className="text-[18px] font-semibold text-black">準備中のUI</div>
+            <div className="mt-3 text-[14px] leading-[1.9] text-[#666a7c]">
+              このページは共通ナビ導線の接続を優先して先に配置しています。実データ接続や投稿永続化は後続 issue で差し替えやすい形に留めています。
+            </div>
+            {children ? <div className="mt-6">{children}</div> : null}
+          </section>
+
+          <aside className="rounded-[20px] border border-black/8 bg-[#fbfbfc] p-6 shadow-[0_12px_30px_rgba(0,0,0,0.05)]">
+            <div className="text-[14px] font-semibold text-black">この段階で置くもの</div>
+            <div className="mt-4 space-y-3 text-[14px] leading-[1.8] text-[#666a7c]">
+              <div className="rounded-[14px] border border-[#ececf4] bg-white px-4 py-3">共通導線から到達できること</div>
+              <div className="rounded-[14px] border border-[#ececf4] bg-white px-4 py-3">ページの役割が見えること</div>
+              <div className="rounded-[14px] border border-[#ececf4] bg-white px-4 py-3">将来の静的データ差し替えに耐えること</div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RecordDetailPage.tsx
+++ b/src/components/RecordDetailPage.tsx
@@ -16,10 +16,10 @@ import {
   mockRuns,
   weaponDb,
 } from "../data/mockRuns";
-import { getSimilarRuns } from "../lib/getSimilarRuns";
+import { getSimilarRuns, type SimilarRunMatch } from "../lib/getSimilarRuns";
 import { getYouTubeEmbedUrl } from "../lib/youtube";
 import { CharacterIcon } from "./CharacterIcon";
-import { LikeIcon, PauseIcon, PlayIcon, PlatformIcon, ShareIcon } from "./UiIcons";
+import { CompareViewIcon, LikeIcon, PauseIcon, PlayIcon, PlatformIcon, ShareIcon } from "./UiIcons";
 
 const collapsedCopyStyle: CSSProperties = {
   display: "-webkit-box",
@@ -43,6 +43,16 @@ function getInitials(label: string) {
   return label.slice(0, 2).toUpperCase();
 }
 
+type PartyLoadoutEntry = {
+  slot: number;
+  characterId: string;
+  characterName: string;
+  cons: number;
+  weaponName: string;
+  refine: number;
+  isMainAttacker: boolean;
+};
+
 function getPartyLoadout(run: RunRecord) {
   return run.party.map((member, index) => {
     const character = characterDb[member.characterId];
@@ -56,6 +66,7 @@ function getPartyLoadout(run: RunRecord) {
       cons: member.cons,
       weaponName: weapon?.name ?? weaponLoadout.weaponId,
       refine: weaponLoadout.refine,
+      isMainAttacker: member.characterId === run.mainAttackerId,
     };
   });
 }
@@ -111,16 +122,61 @@ function PillButton({
   );
 }
 
-function TinyBadge({ label }: { label: string }) {
+function TinyBadge({ label, highlighted = false }: { label: string; highlighted?: boolean }) {
   return (
-    <div className="w-full rounded-[4px] bg-[rgba(248,196,163,0.25)] px-[4px] py-[3px] text-center text-[11px] leading-none text-[#f09e78] md:text-[12px]">
+    <span
+      className={`inline-flex min-w-[38px] items-center justify-center rounded-full px-[9px] py-[5px] text-[11px] font-semibold leading-none md:text-[12px] ${
+        highlighted
+          ? "border border-[#efc9b0] bg-[#fbf1ea] text-[#c27642]"
+          : "border border-[#dde2ea] bg-[#f2f4f7] text-[#5f6678]"
+      }`}
+    >
       {label}
-    </div>
+    </span>
   );
 }
 
 function SectionTitle({ children }: { children: ReactNode }) {
   return <div className="text-[16px] font-bold leading-none text-black md:text-[18px]">{children}</div>;
+}
+
+function SidebarPanel({ children }: { children: ReactNode }) {
+  return <section className="w-full rounded-[16px] border border-[#ebebeb] bg-white p-[16px] shadow-[0_4px_12px_rgba(0,0,0,0.05)]">{children}</section>;
+}
+
+function SidebarSectionHeader({ title, meta }: { title: ReactNode; meta?: ReactNode }) {
+  return (
+    <div className="flex items-start justify-between gap-[12px]">
+      <SectionTitle>{title}</SectionTitle>
+      {meta ? <div className="shrink-0 text-[12px] font-medium text-[#8d93a3] md:text-[13px]">{meta}</div> : null}
+    </div>
+  );
+}
+
+function LoadoutEntryCard({ entry }: { entry: PartyLoadoutEntry }) {
+  return (
+    <div className="rounded-[16px] border border-[#eceff3] bg-[#fbfbfc] p-[12px] md:p-[14px]">
+      <div className="flex items-start gap-[12px] md:gap-[14px]">
+        <CharacterIcon characterId={entry.characterId} alt={entry.characterName} fallbackLabel={entry.characterName} size={56} />
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[16px] font-semibold leading-[1.2] text-black md:text-[17px]">{entry.characterName}</div>
+          <div className="mt-[5px] truncate text-[13px] leading-[1.45] text-[#8f94a3] md:text-[14px]">{entry.weaponName}</div>
+          <div className="mt-[10px] flex flex-wrap gap-[8px]">
+            <TinyBadge label={`C${entry.cons}`} highlighted={entry.cons === 6} />
+            <TinyBadge label={`R${entry.refine}`} highlighted={entry.refine === 5} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SimilarityReasonChip({ label }: { label: string }) {
+  return (
+    <span className="inline-flex items-center rounded-full bg-[#f2f4f7] px-[10px] py-[5px] text-[11px] font-medium leading-none text-[#5f6678] md:text-[12px]">
+      {label}
+    </span>
+  );
 }
 
 function parsePlatformTag(tag: string): RunRecord["platform"][] | null {
@@ -239,28 +295,16 @@ function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.R
         </div>
       </div>
 
-      <section className="w-full rounded-[12px] border border-[#ebebeb] bg-white p-[12px] shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
-        <div className="flex flex-col gap-[20px]">
-          <SectionTitle>使用編成</SectionTitle>
-          <div className="flex flex-col gap-[18px] md:gap-[20px]">
+      <SidebarPanel>
+        <div className="flex flex-col gap-[16px]">
+          <SidebarSectionHeader title="使用編成" meta={`${partyLoadout.length}メンバー`} />
+          <div className="flex flex-col gap-[12px]">
             {partyLoadout.map((entry) => (
-              <div key={`${run.id}-${entry.characterName}-${entry.slot}`} className="flex items-center gap-[12px]">
-                <CharacterIcon characterId={entry.characterId} alt={entry.characterName} fallbackLabel={entry.characterName} size={60} />
-                <div className="flex min-w-0 flex-1 items-center justify-between gap-[12px]">
-                  <div className="min-w-0">
-                    <div className="truncate text-[17px] font-medium leading-none text-black md:text-[18px]">{entry.characterName}</div>
-                    <div className="mt-[4px] truncate text-[12px] text-[#9999b1] md:text-[13px]">{entry.weaponName}</div>
-                  </div>
-                  <div className="flex w-[30px] shrink-0 flex-col gap-[6px] pb-[2px] pt-[4px]">
-                    <TinyBadge label={`C${entry.cons}`} />
-                    <TinyBadge label={`R${entry.refine}`} />
-                  </div>
-                </div>
-              </div>
+              <LoadoutEntryCard key={`${run.id}-${entry.characterName}-${entry.slot}`} entry={entry} />
             ))}
           </div>
         </div>
-      </section>
+      </SidebarPanel>
     </div>
   );
 }
@@ -375,7 +419,7 @@ function SimilarActionMenu({
         type="button"
         onClick={onToggle}
         aria-label="類似記録の操作"
-        className="grid h-8 w-8 place-items-center rounded-full bg-[#f2f2f2] text-black transition hover:bg-[#e7e7e7]"
+        className="grid h-9 w-9 place-items-center rounded-full border border-[#dde2ea] bg-white text-[#5f6678] transition hover:bg-[#f5f6f8]"
       >
         <svg viewBox="0 0 24 24" className="h-4 w-4" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="5" r="1.8" />
@@ -384,10 +428,10 @@ function SimilarActionMenu({
         </svg>
       </button>
       {isOpen ? (
-        <div className="absolute right-0 top-full z-20 mt-2 w-[168px] rounded-[12px] border border-[#ebebeb] bg-white p-2 shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
+        <div className="absolute right-0 top-full z-20 mt-2 w-[180px] rounded-[16px] border border-[#ebebeb] bg-white p-2 shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
           <button
             type="button"
-            className="flex w-full items-center gap-2 rounded-[8px] px-3 py-2 text-left text-[13px] text-black hover:bg-[#f2f2f2]"
+            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-black hover:bg-[#f2f2f2]"
             onClick={() => onAction("like")}
           >
             <LikeIcon className="h-4 w-4" />
@@ -395,7 +439,7 @@ function SimilarActionMenu({
           </button>
           <button
             type="button"
-            className="flex w-full items-center gap-2 rounded-[8px] px-3 py-2 text-left text-[13px] text-black hover:bg-[#f2f2f2]"
+            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-black hover:bg-[#f2f2f2]"
             onClick={() => onAction("share")}
           >
             <ShareIcon className="h-4 w-4" />
@@ -403,14 +447,76 @@ function SimilarActionMenu({
           </button>
           <button
             type="button"
-            className="hidden w-full rounded-[8px] px-3 py-2 text-left text-[13px] text-black hover:bg-[#f2f2f2] lg:block"
+            className="hidden h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-black hover:bg-[#f2f2f2] lg:flex"
             onClick={() => onAction("compare")}
           >
+            <CompareViewIcon className="h-4 w-4" />
             比較ビュー
           </button>
         </div>
       ) : null}
     </div>
+  );
+}
+
+function SimilarRunCard({
+  match,
+  liked,
+  shared,
+  isMenuOpen,
+  isCompareQueued,
+  onToggleMenu,
+  onAction,
+}: {
+  match: SimilarRunMatch;
+  liked: boolean;
+  shared: boolean;
+  isMenuOpen: boolean;
+  isCompareQueued: boolean;
+  onToggleMenu: () => void;
+  onAction: (action: "like" | "share" | "compare") => void;
+}) {
+  const visibleReasons = match.reasons.slice(0, 2);
+
+  return (
+    <article
+      className={`rounded-[16px] border p-[14px] transition-colors ${
+        isCompareQueued ? "border-[#d5dbe5] bg-[#f7f8fa]" : "border-[#eceff3] bg-[#fcfcfd] hover:bg-white"
+      }`}
+    >
+      <div className="flex items-start gap-[10px]">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-[12px]">
+            <div className="min-w-0 flex-1">
+              <div className="truncate text-[15px] font-semibold leading-[1.4] text-black md:text-[16px]">{match.run.title}</div>
+              <div className="mt-[6px] flex flex-wrap items-center gap-x-[8px] gap-y-[4px] text-[12px] text-[#8f94a3] md:text-[13px]">
+                <span className="font-medium text-[#5f6678]">{match.run.userName}</span>
+                <span>{match.run.postedLabel}</span>
+                <PlatformLabel platform={match.run.platform} iconClassName="h-[13px] w-[13px]" />
+              </div>
+            </div>
+            <div className="flex shrink-0 items-start">
+              <SimilarActionMenu isOpen={isMenuOpen} liked={liked} shared={shared} onToggle={onToggleMenu} onAction={onAction} />
+            </div>
+          </div>
+
+          <div className="mt-[12px] rounded-[16px] border border-[#eceff3] bg-[#f5f6f8] px-[10px] py-[9px]">
+            <div className="flex items-center justify-between gap-[8px]">
+              {match.run.party.map((member) => {
+                const characterName = characterDb[member.characterId]?.name ?? member.characterId;
+                return <CharacterIcon key={`${match.run.id}-${member.characterId}`} characterId={member.characterId} alt={characterName} fallbackLabel={characterName} size={36} />;
+              })}
+            </div>
+          </div>
+
+          <div className="mt-[12px] flex flex-wrap gap-[8px]">
+            {(visibleReasons.length > 0 ? visibleReasons : ["近い条件"]).map((reason) => (
+              <SimilarityReasonChip key={`${match.run.id}-${reason}`} label={reason} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </article>
   );
 }
 
@@ -565,7 +671,7 @@ export function RecordDetailPage({
       <main className={`bg-white text-[#333333] transition-[width] duration-300 ${mainSurfaceClass}`}>
         {embedded ? (
           <div className="border-b border-[#ebebeb] bg-white">
-            <div className={`header-font mx-auto flex max-w-[1600px] items-center gap-3 px-4 py-3 ${forceMobileLayout ? "" : "md:px-6"}`}>
+            <div className={`header-font mx-auto flex min-h-[52px] max-w-[1600px] items-center gap-3 px-4 py-2 ${forceMobileLayout ? "" : "md:px-6"}`}>
               {onBack ? (
                 <button
                   type="button"
@@ -578,10 +684,7 @@ export function RecordDetailPage({
                   </svg>
                 </button>
               ) : null}
-              <div className="min-w-0">
-                <div className={`font-semibold tracking-tight text-black ${forceMobileLayout ? "text-[20px]" : "text-[22px] md:text-[28px]"}`}>記録詳細</div>
-                <div className="truncate text-[12px] text-[#9999b1] md:text-[13px]">{currentRun.title}</div>
-              </div>
+              <div className="min-w-0 text-[16px] font-semibold tracking-tight text-black md:text-[18px]">記録詳細</div>
             </div>
           </div>
         ) : null}
@@ -735,77 +838,48 @@ export function RecordDetailPage({
           </section>
 
           <aside className={`flex w-full shrink-0 flex-col gap-[18px] ${compareOpen ? "lg:w-full xl:w-full" : "lg:w-[360px] xl:w-[372px]"}`}>
-            <section className="w-full rounded-[12px] border border-[#ebebeb] bg-white p-[12px] shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
-              <div className="flex flex-col gap-[20px]">
-                <SectionTitle>使用編成</SectionTitle>
-                <div className="flex flex-col gap-[18px] md:gap-[20px]">
+            <SidebarPanel>
+              <div className="flex flex-col gap-[16px]">
+                <SidebarSectionHeader title="使用編成" meta={`${partyLoadout.length}メンバー`} />
+                <div className="flex flex-col gap-[12px]">
                   {partyLoadout.map((entry) => (
-                    <div key={`${entry.characterName}-${entry.slot}`} className="flex items-center gap-[12px]">
-                      <CharacterIcon characterId={entry.characterId} alt={entry.characterName} fallbackLabel={entry.characterName} size={60} />
-                      <div className="flex min-w-0 flex-1 items-center justify-between gap-[12px]">
-                        <div className="min-w-0">
-                          <div className="truncate text-[17px] font-medium leading-none text-black md:text-[18px]">{entry.characterName}</div>
-                          <div className="mt-[4px] truncate text-[12px] text-[#9999b1] md:text-[13px]">{entry.weaponName}</div>
-                        </div>
-                        <div className="flex w-[30px] shrink-0 flex-col gap-[6px] pb-[2px] pt-[4px]">
-                          <TinyBadge label={`C${entry.cons}`} />
-                          <TinyBadge label={`R${entry.refine}`} />
-                        </div>
-                      </div>
-                    </div>
+                    <LoadoutEntryCard key={`${entry.characterName}-${entry.slot}`} entry={entry} />
                   ))}
                 </div>
               </div>
-            </section>
+            </SidebarPanel>
 
-            <section className="w-full rounded-[12px] border border-[#ebebeb] bg-white p-[12px] shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
-              <div className="flex flex-col gap-[20px]">
-                <SectionTitle>類似編成の記録</SectionTitle>
-                <div className="flex flex-col gap-[18px] md:gap-[20px]">
-                  {similarRuns.map((match) => {
-                    const runState = similarActionState[match.run.id] ?? { liked: false, shared: false };
-                    const isOpen = openMenuRunId === match.run.id;
-                    const isCompareQueued = compareQueuedRunId === match.run.id;
+            <SidebarPanel>
+              <div className="flex flex-col gap-[16px]">
+                <SidebarSectionHeader title="類似編成の記録" meta={`${similarRuns.length}件`} />
+                {similarRuns.length > 0 ? (
+                  <div className="flex flex-col gap-[12px]">
+                    {similarRuns.map((match) => {
+                      const runState = similarActionState[match.run.id] ?? { liked: false, shared: false };
+                      const isOpen = openMenuRunId === match.run.id;
+                      const isCompareQueued = compareQueuedRunId === match.run.id;
 
-                    return (
-                      <div key={match.run.id} className={isCompareQueued ? "rounded-[12px] bg-[#f7f7f7] px-[8px] py-[8px]" : "rounded-[12px] px-[4px] py-[4px] transition-colors hover:bg-[#fafafa]"}>
-                        <div className="flex flex-col items-end gap-[10px]">
-                          <div className="h-[40px] w-full px-[8px]">
-                            <div className="flex h-[40px] items-center justify-between gap-[4px]">
-                              {match.run.party.map((member) => {
-                                const characterName = characterDb[member.characterId]?.name ?? member.characterId;
-                                return <CharacterIcon key={`${match.run.id}-${member.characterId}`} characterId={member.characterId} alt={characterName} fallbackLabel={characterName} size={32} />;
-                              })}
-                            </div>
-                          </div>
-                          <div className="flex w-full items-end gap-[4px]">
-                            <div className="min-w-0 flex-1">
-                              <div className="flex flex-col gap-[8px]">
-                                <div className="truncate text-[14px] font-medium leading-[1.35] text-black md:text-[15px]">{match.run.title}</div>
-                                <div className="flex flex-wrap items-center gap-[4px] text-[12px] text-[#9999b1] md:text-[13px]">
-                                  <span>{match.run.userName}</span>
-                                  <span>・</span>
-                                  <span>{match.run.postedLabel}</span>
-                                  <span>・</span>
-                                  <span>{match.run.platform}</span>
-                                </div>
-                              </div>
-                            </div>
-                            <SimilarActionMenu
-                              isOpen={isOpen}
-                              liked={runState.liked}
-                              shared={runState.shared}
-                              onToggle={() => setOpenMenuRunId((previous) => (previous === match.run.id ? null : match.run.id))}
-                              onAction={(action) => handleSimilarAction(match.run.id, action)}
-                            />
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
+                      return (
+                        <SimilarRunCard
+                          key={match.run.id}
+                          match={match}
+                          liked={runState.liked}
+                          shared={runState.shared}
+                          isMenuOpen={isOpen}
+                          isCompareQueued={isCompareQueued}
+                          onToggleMenu={() => setOpenMenuRunId((previous) => (previous === match.run.id ? null : match.run.id))}
+                          onAction={(action) => handleSimilarAction(match.run.id, action)}
+                        />
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <div className="rounded-[16px] border border-dashed border-[#d9dee7] bg-[#fbfbfc] px-[14px] py-[16px] text-[13px] leading-[1.7] text-[#8f94a3]">
+                    近い条件の記録はまだありません。
+                  </div>
+                )}
               </div>
-            </section>
+            </SidebarPanel>
           </aside>
         </div>
       </main>
@@ -825,7 +899,3 @@ export function RecordDetailPage({
     </>
   );
 }
-
-
-
-

--- a/src/components/RecordDetailPage.tsx
+++ b/src/components/RecordDetailPage.tsx
@@ -270,6 +270,7 @@ function CompareDrawer({
   comparedRun,
   isOpen,
   syncPlaying,
+  embedded = false,
   onClose,
   onToggleSync,
 }: {
@@ -277,6 +278,7 @@ function CompareDrawer({
   comparedRun: RunRecord | null;
   isOpen: boolean;
   syncPlaying: boolean;
+  embedded?: boolean;
   onClose: () => void;
   onToggleSync: () => void;
 }) {
@@ -317,7 +319,7 @@ function CompareDrawer({
   }
 
   return (
-    <div className="fixed inset-y-0 right-0 z-50 hidden lg:block" aria-modal="false" role="complementary">
+    <div className={embedded ? "fixed top-[80px] right-0 bottom-0 z-20 hidden lg:block" : "fixed inset-y-0 right-0 z-50 hidden lg:block"} aria-modal="false" role="complementary">
       <div className="flex h-full w-[50vw] flex-col border-l border-[#ebebeb] bg-white shadow-[-12px_0_24px_rgba(0,0,0,0.08)]">
         <div className="flex min-h-[52px] items-center justify-between border-b border-[#ebebeb] px-4 py-2">
           <div className="min-w-0">
@@ -416,10 +418,12 @@ export function RecordDetailPage({
   runId,
   onBack,
   onRequestSubmit,
+  embedded = false,
 }: {
   runId?: string;
   onBack?: () => void;
   onRequestSubmit?: () => void;
+  embedded?: boolean;
 }) {
   const currentRun = getRunById(runId ?? defaultRunId) ?? getRunById(defaultRunId) ?? null;
   const [descriptionExpanded, setDescriptionExpanded] = useState(false);
@@ -487,9 +491,16 @@ export function RecordDetailPage({
   const shouldShowExpandedArea = descriptionExpanded && (currentRun.summary.length > 0 || currentRun.tags.length > 0);
   const canExpandDescription = currentRun.tags.length > 0 || currentRun.summary.length > 0;
   const partyLoadout = getPartyLoadout(currentRun);
+  const mainSurfaceClass = embedded
+    ? compareOpen
+      ? "min-h-full lg:mr-[50vw]"
+      : "min-h-full"
+    : compareOpen
+      ? "fixed inset-y-0 left-0 z-40 overflow-y-auto lg:w-[50vw]"
+      : "min-h-screen lg:w-full";
 
   useEffect(() => {
-    if (!compareOpen) {
+    if (!compareOpen || embedded) {
       return;
     }
 
@@ -499,7 +510,7 @@ export function RecordDetailPage({
     return () => {
       document.body.style.overflow = originalOverflow;
     };
-  }, [compareOpen]);
+  }, [compareOpen, embedded]);
 
   const handleCommentSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -551,8 +562,30 @@ export function RecordDetailPage({
 
   return (
     <>
-      <main className={`bg-white text-[#333333] transition-[width] duration-300 ${compareOpen ? "fixed inset-y-0 left-0 z-40 overflow-y-auto lg:w-[50vw]" : "min-h-screen lg:w-full"}`}>
-        <nav className="sticky top-0 z-40 border-b border-[#ebebeb] bg-white shadow-[0_1px_0_rgba(0,0,0,0.02)]">
+      <main className={`bg-white text-[#333333] transition-[width] duration-300 ${mainSurfaceClass}`}>
+        {embedded ? (
+          <div className="border-b border-[#ebebeb] bg-white">
+            <div className={`header-font mx-auto flex max-w-[1600px] items-center gap-3 px-4 py-3 ${forceMobileLayout ? "" : "md:px-6"}`}>
+              {onBack ? (
+                <button
+                  type="button"
+                  onClick={onBack}
+                  aria-label="一覧へ戻る"
+                  className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[#f2f2f2] text-black transition hover:bg-[#e8e8e8]"
+                >
+                  <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M15 5L8 12L15 19" />
+                  </svg>
+                </button>
+              ) : null}
+              <div className="min-w-0">
+                <div className={`font-semibold tracking-tight text-black ${forceMobileLayout ? "text-[20px]" : "text-[22px] md:text-[28px]"}`}>記録詳細</div>
+                <div className="truncate text-[12px] text-[#9999b1] md:text-[13px]">{currentRun.title}</div>
+              </div>
+            </div>
+          </div>
+        ) : null}
+        <nav className={embedded ? "hidden" : "sticky top-0 z-40 border-b border-[#ebebeb] bg-white shadow-[0_1px_0_rgba(0,0,0,0.02)]"}>
           <div className={`header-font mx-auto flex max-w-[1600px] items-center justify-between px-4 py-2 ${forceMobileLayout ? "min-h-[52px]" : "md:px-6 md:py-3"}`}>
             <div className={`flex items-center ${forceMobileLayout ? "gap-3" : "gap-4 md:gap-6"}`}>
               {onBack ? (
@@ -782,6 +815,7 @@ export function RecordDetailPage({
         comparedRun={compareRun}
         isOpen={compareOpen}
         syncPlaying={syncPlaying}
+        embedded={embedded}
         onClose={() => {
           setCompareQueuedRunId(null);
           setSyncPlaying(false);
@@ -791,12 +825,6 @@ export function RecordDetailPage({
     </>
   );
 }
-
-
-
-
-
-
 
 
 

--- a/src/components/RunHomePage.tsx
+++ b/src/components/RunHomePage.tsx
@@ -42,6 +42,12 @@ const OFFMETA_PICKUP_LABEL = "\u958b\u62d3\u8005 \u4f7f\u7528\u73875%\u672a\u6e8
 const NO_RESULTS_LABEL = "\u8a18\u9332\u304c\u898b\u3064\u304b\u308a\u307e\u305b\u3093";
 const NO_RESULTS_COPY = "\u6761\u4ef6\u3092\u5909\u66f4\u3059\u308b\u304b\u3001\u65b0\u3057\u3044\u8a18\u9332\u306e\u8ffd\u52a0\u3092\u304a\u5f85\u3061\u304f\u3060\u3055\u3044\u3002";
 const OTHER_RULESET_TABS = ["Npui別", "武器別", "マルチPUI", "マルチUI", "マルチUA"];
+const HOME_SECTION_PANEL_CLASS = "bg-white rounded-[20px] border border-black/10 shadow-sm";
+const HOME_SECTION_TITLE_CLASS = "text-[17px] md:text-[18px] font-bold tracking-[0.01em] text-black";
+const HOME_ICON_BUTTON_CLASS =
+  "flex h-8 w-8 items-center justify-center rounded-full border border-[#dcdfe6] bg-white text-black transition-colors hover:bg-black/5";
+const HOME_PRIMARY_BUTTON_CLASS =
+  "inline-flex h-10 items-center justify-center rounded-full border border-[#d8dde6] bg-[#f5f6f8] px-4 text-[13px] font-semibold tracking-[0.01em] text-black transition-colors hover:border-[#c8ced8] hover:bg-[#eceff3]";
 
 const AMBR_NAME_MAP: Record<string, string> = {
   amber: "Ambor",
@@ -430,9 +436,10 @@ function LikeIcon({ size = 16, className = "" }: { size?: number; className?: st
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
       <path
-        d="M7 11v9H4v-9h3zm3.6-6.5L7 11v9h9.1c.8 0 1.5-.5 1.7-1.2l1.7-6.1c.3-1.1-.5-2.2-1.7-2.2H13V6c0-1.1-.9-2-2-2h-.4z"
+        d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"
         stroke="currentColor"
-        strokeWidth="1.5"
+        strokeWidth="2"
+        strokeLinecap="round"
         strokeLinejoin="round"
       />
     </svg>
@@ -443,9 +450,10 @@ function CommentIcon({ size = 16, className = "" }: { size?: number; className?:
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
       <path
-        d="M7 18l-3 3V6a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H7z"
+        d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"
         stroke="currentColor"
-        strokeWidth="1.5"
+        strokeWidth="2"
+        strokeLinecap="round"
         strokeLinejoin="round"
       />
     </svg>
@@ -482,8 +490,11 @@ function PlatformMobileIcon({ className = "" }: { className?: string }) {
 function PlatformPs5Icon({ className = "" }: { className?: string }) {
   return (
     <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M2 13c0-2 2-3 4-3h12c2 0 4 1 4 3v3c0 1.5-1.5 3-3 3-1.5 0-2.5-1-3-2l-1.5-2h-5l-1.5 2c-.5 1-1.5 2-3 2-1.5 0-3-1.5-3-3v-3z" />
-      <rect x="8" y="11" width="8" height="3" rx="0.5" />
+      <line x1="6" x2="10" y1="12" y2="12" />
+      <line x1="8" x2="8" y1="10" y2="14" />
+      <line x1="15" x2="15.01" y1="13" y2="13" />
+      <line x1="18" x2="18.01" y1="11" y2="11" />
+      <rect width="20" height="12" x="2" y="6" rx="2" />
     </svg>
   );
 }
@@ -593,15 +604,15 @@ function TopPlayerCard({
 }) {
   if (!run) {
     return (
-      <div className="flex flex-col h-full bg-white rounded-xl border border-[#ebebeb] shadow-sm overflow-hidden hover:shadow-md transition-all">
-        <div className={`relative h-28 w-full bg-gradient-to-r ${theme.gradient}`}>
-          <div className="absolute top-3 left-4 z-10">
-            <div className="text-white font-bold text-xl drop-shadow-md">{label}</div>
+      <div className="flex h-full flex-col overflow-hidden rounded-[16px] border border-[#e8eaef] bg-white shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md">
+        <div className={`relative h-24 w-full bg-gradient-to-r ${theme.gradient}`}>
+          <div className="absolute top-4 left-4 z-10 space-y-1">
+            <div className="text-[17px] font-bold leading-tight tracking-[0.01em] text-white drop-shadow-md md:text-[18px]">{label}</div>
           </div>
         </div>
-        <div className="p-3 bg-white flex flex-col justify-between flex-1 relative z-10">
+        <div className="relative z-10 flex flex-1 flex-col justify-between gap-4 bg-white p-4">
           <div className="text-sm text-[#606266]">{LOADING_LABEL}</div>
-          <button type="button" onClick={onView} className="mt-4 text-sm text-black border border-[#dcdfe6] rounded-full px-3 py-1 bg-black/5">
+          <button type="button" onClick={onView} className={`${HOME_PRIMARY_BUTTON_CLASS} w-full`}>
             {VIEW_RANKING_LABEL}
           </button>
         </div>
@@ -610,42 +621,43 @@ function TopPlayerCard({
   }
 
   return (
-    <div className="flex flex-col h-full bg-white rounded-xl border border-[#ebebeb] shadow-sm overflow-hidden hover:shadow-md transition-all cursor-pointer" onClick={() => onSelect(run.id)}>
-      <div className={`relative h-28 w-full bg-gradient-to-r ${theme.gradient}`}>
-        <div className="absolute top-3 left-4 z-10">
-          <div className="text-white font-bold text-xl drop-shadow-md">{label}</div>
-          <div className="text-white/85 text-sm mt-1">{run.userName}</div>
+    <div
+      className="flex h-full cursor-pointer flex-col overflow-hidden rounded-[16px] border border-[#e8eaef] bg-white shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
+      onClick={() => onSelect(run.id)}
+    >
+      <div className={`relative h-24 w-full bg-gradient-to-r ${theme.gradient}`}>
+        <div className="absolute top-4 left-4 z-10 space-y-1">
+          <div className="text-[17px] font-bold leading-tight tracking-[0.01em] text-white drop-shadow-md md:text-[18px]">{label}</div>
+          <div className="text-[13px] font-medium text-white/80">{run.userName}</div>
         </div>
         <CharacterImage
           characterId={run.mainAttackerId}
           alt={run.mainAttacker}
-          className="absolute -bottom-6 -right-6 w-48 h-auto object-cover z-0 opacity-90 drop-shadow-lg pointer-events-none"
+          className="pointer-events-none absolute -right-5 -bottom-5 z-0 h-auto w-44 object-cover opacity-85 drop-shadow-lg"
         />
       </div>
-      <div className="p-4 bg-white flex flex-col justify-between flex-1 relative z-10">
-        <div>
-          <div className="flex items-center justify-end gap-2 mt-2 text-[16px] text-black">
-            <button type="button" className="border border-[#dcdfe6] rounded-full px-2 py-0.5 bg-white/80" onClick={(event) => event.stopPropagation()}>
-              <LikeIcon size={14} className="text-black" />
-            </button>
-            <button type="button" className="border border-[#dcdfe6] rounded-full px-2 py-0.5 bg-white/80" onClick={(event) => event.stopPropagation()}>
-              <CommentIcon size={14} className="text-black" />
-            </button>
-          </div>
+      <div className="relative z-10 flex flex-1 flex-col gap-4 bg-white p-4">
+        <div className="flex items-center justify-end gap-2 text-black">
+          <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
+            <LikeIcon size={14} className="text-black" />
+          </button>
+          <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
+            <CommentIcon size={14} className="text-black" />
+          </button>
         </div>
-        <div className="bg-[#f7f7f7] border border-black/10 rounded-lg p-2 mt-3">
-          <div className="flex items-center justify-between">
+        <div className="rounded-[12px] border border-[#eceff3] bg-[#f7f8fa] p-3">
+          <div className="flex items-center justify-between gap-2">
             {run.party.map((member, index) => (
               <CharacterImage
                 key={`${run.id}-${member.characterId}-${index}`}
                 characterId={member.characterId}
                 alt={characterDb[member.characterId]?.name ?? member.characterId}
                 variant="circle"
-                className="w-9 h-9 rounded-full object-cover"
+                className="h-9 w-9 rounded-full object-cover"
               />
             ))}
           </div>
-          <div className="text-[20px] font-semibold text-black text-center mt-2">{run.time}</div>
+          <div className="mt-3 text-center text-[24px] font-semibold leading-none text-black">{run.time}</div>
         </div>
         <button
           type="button"
@@ -653,7 +665,7 @@ function TopPlayerCard({
             event.stopPropagation();
             onView();
           }}
-          className="mt-4 text-sm text-black border border-[#dcdfe6] rounded-full px-3 py-1 bg-black/5"
+          className={`${HOME_PRIMARY_BUTTON_CLASS} w-full`}
         >
           {VIEW_RANKING_LABEL}
         </button>
@@ -674,40 +686,42 @@ function LeaderboardRow({
   const PlatformIcon = PLATFORM_ICONS[run.platform] ?? PLATFORM_ICONS.PC;
 
   return (
-    <div className="border-t border-[#ebebeb] py-3 cursor-pointer" onClick={() => onSelect(run.id)}>
-      <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
-        <div className="flex items-center gap-3 md:gap-4 min-w-0">
-          <div className="w-6 md:w-6 flex items-center justify-center text-black/80">
-            <RankMoveIcon move={run.rankMove} className="w-5 h-5 md:w-5 md:h-5" />
+    <div className="cursor-pointer border-t border-[#ebebeb] py-4" onClick={() => onSelect(run.id)}>
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex min-w-0 items-center gap-3 md:gap-5">
+          <div className="flex w-6 items-center justify-center text-black/70">
+            <RankMoveIcon move={run.rankMove} className="h-5 w-5" />
           </div>
-          <div className="text-[22px] md:text-[24px] w-9 md:w-10 text-center font-semibold">{index + 1}</div>
+          <div className="w-9 text-center text-[20px] font-semibold md:w-10 md:text-[22px]">{index + 1}</div>
           <CharacterImage
             characterId={run.mainAttackerId}
             alt={characterDb[run.mainAttackerId]?.name ?? run.mainAttackerId}
             variant="circle"
-            className="w-10 h-10 md:w-10 md:h-10 rounded-full object-cover"
+            className="h-11 w-11 rounded-full object-cover"
           />
           <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2 min-w-0">
-              <div className="text-[19px] md:text-[22px] font-semibold truncate">{run.userName}</div>
-              <div className="hidden md:inline-flex text-[12px] px-2 py-0.5 rounded bg-black/5 border border-black/10">{getBracketLabel(run.bracket)}</div>
+            <div className="flex min-w-0 items-center gap-2">
+              <div className="truncate text-[17px] font-semibold md:text-[19px]">{run.userName}</div>
+              <div className="hidden rounded-full border border-black/10 bg-black/[0.04] px-2.5 py-1 text-[11px] font-medium md:inline-flex">
+                {getBracketLabel(run.bracket)}
+              </div>
             </div>
           </div>
-          <div className="ml-auto text-[22px] font-semibold md:hidden">{run.time}</div>
-          <div className="hidden md:flex w-10 h-10 rounded-full bg-black/5 border border-black/10 items-center justify-center">
-            <PlatformIcon className="w-5 h-5 text-black" />
+          <div className="ml-auto text-[20px] font-semibold md:hidden">{run.time}</div>
+          <div className="hidden h-9 w-9 items-center justify-center rounded-full border border-black/10 bg-black/[0.04] md:flex">
+            <PlatformIcon className="h-[18px] w-[18px] text-black" />
           </div>
         </div>
-        <div className="hidden md:flex items-center gap-4">
-          <button type="button" className="border border-[#dcdfe6] rounded-full px-2 py-0.5 bg-white/80" onClick={(event) => event.stopPropagation()}>
+        <div className="hidden items-center gap-3 md:flex">
+          <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
             <LikeIcon size={14} className="text-black" />
           </button>
-          <button type="button" className="border border-[#dcdfe6] rounded-full px-2 py-0.5 bg-white/80" onClick={(event) => event.stopPropagation()}>
+          <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
             <CommentIcon size={14} className="text-black" />
           </button>
-          <div className="text-[24px] font-semibold w-20 text-right">{run.time}</div>
+          <div className="w-20 text-right text-[22px] font-semibold">{run.time}</div>
           <a
-            className="border border-[#dcdfe6] rounded-full w-8 h-8 flex items-center justify-center"
+            className={HOME_ICON_BUTTON_CLASS}
             href={run.videoUrl}
             target="_blank"
             rel="noreferrer"
@@ -719,22 +733,22 @@ function LeaderboardRow({
           </a>
         </div>
       </div>
-      <div className="flex items-center justify-between gap-3 md:hidden mt-1.5">
+      <div className="mt-2 flex items-center justify-between gap-3 md:hidden">
         <div className="flex items-center gap-2">
-          <div className="text-[11px] px-1.5 py-0.5 rounded bg-black/5 border border-black/10">{getBracketLabel(run.bracket)}</div>
-          <div className="w-7 h-7 rounded-full bg-black/5 border border-black/10 flex items-center justify-center">
-            <PlatformIcon className="w-3.5 h-3.5 text-black" />
+          <div className="rounded-full border border-black/10 bg-black/[0.04] px-2 py-0.5 text-[11px] font-medium">{getBracketLabel(run.bracket)}</div>
+          <div className="flex h-8 w-8 items-center justify-center rounded-full border border-black/10 bg-black/[0.04]">
+            <PlatformIcon className="h-3.5 w-3.5 text-black" />
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <button type="button" className="border border-[#dcdfe6] rounded-full px-1.5 py-0.5 bg-white/80" onClick={(event) => event.stopPropagation()}>
+          <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
             <LikeIcon size={13} className="text-black" />
           </button>
-          <button type="button" className="border border-[#dcdfe6] rounded-full px-1.5 py-0.5 bg-white/80" onClick={(event) => event.stopPropagation()}>
+          <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
             <CommentIcon size={13} className="text-black" />
           </button>
           <a
-            className="border border-[#dcdfe6] rounded-full w-7 h-7 flex items-center justify-center"
+            className={HOME_ICON_BUTTON_CLASS}
             href={run.videoUrl}
             target="_blank"
             rel="noreferrer"
@@ -1155,10 +1169,10 @@ export function RunHomePage({
           <>
             <div className="relative z-10 -mt-40 md:-mt-72 mb-12">
               <div className="relative">
-                <div ref={topRowRef} className="flex gap-6 overflow-x-auto no-scrollbar" onScroll={updateTopScrollButtons}>
-                  <div className="bg-white rounded-xl border border-black/10 p-4 md:p-6 shadow-sm min-w-[780px] flex-shrink-0">
-                    <div className="text-[18px] font-semibold text-black mb-3">{TOP_PLAYERS_LABEL}</div>
-                    <div className="grid grid-cols-4 gap-4 min-w-[900px]">
+                <div ref={topRowRef} className="flex gap-5 overflow-x-auto no-scrollbar" onScroll={updateTopScrollButtons}>
+                  <div className={`${HOME_SECTION_PANEL_CLASS} min-w-[820px] flex-shrink-0 p-5`}>
+                    <div className={`${HOME_SECTION_TITLE_CLASS} mb-4`}>{TOP_PLAYERS_LABEL}</div>
+                    <div className="grid min-w-[860px] grid-cols-4 gap-5">
                       {[
                         { label: "Unlimited 1st", bracket: 4 as Bracket, theme: { gradient: "from-[#274060] to-[#1b2f45]" } },
                         { label: "High 1st", bracket: 3 as Bracket, theme: { gradient: "from-[#2c3e3d] to-[#1e2c2b]" } },
@@ -1181,16 +1195,16 @@ export function RunHomePage({
                     </div>
                   </div>
 
-                  <div className="bg-white rounded-xl border border-black/10 p-4 md:p-6 shadow-sm min-w-[240px] flex-shrink-0">
-                    <div className="text-[18px] font-semibold text-black mb-3">{FEATURED_PLAYERS_LABEL}</div>
-                    <div className="space-y-4">
+                  <div className={`${HOME_SECTION_PANEL_CLASS} min-w-[300px] flex-shrink-0 p-5`}>
+                    <div className={`${HOME_SECTION_TITLE_CLASS} mb-4`}>{FEATURED_PLAYERS_LABEL}</div>
+                    <div className="space-y-3">
                       {[
                         { title: FIRST_POST_LABEL, run: getBestRun(heroRuns.filter((run) => run.tags.includes("New"))) },
                         { title: OFFMETA_PICKUP_LABEL, run: getBestRun(heroRuns.filter((run) => run.tags.includes("OffMeta"))) },
                       ].map((item) => (
                         <div
                           key={item.title}
-                          className="border border-black/10 rounded-lg p-3 relative overflow-hidden shadow-md transition-transform hover:-translate-y-0.5 hover:shadow-lg cursor-pointer"
+                          className="relative cursor-pointer overflow-hidden rounded-[16px] border border-black/10 bg-[#fcfcfd] p-4 shadow-sm transition-transform hover:-translate-y-0.5 hover:shadow-md"
                           onClick={() => {
                             if (item.run) {
                               openRunDetail(item.run.id);
@@ -1198,27 +1212,27 @@ export function RunHomePage({
                           }}
                         >
                           <div className="absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-black/5 to-transparent pointer-events-none" />
-                          <div className="text-black font-medium">{item.title}</div>
+                          <div className="pr-8 text-[15px] font-semibold leading-snug text-black">{item.title}</div>
                           {item.run ? (
-                            <div className="mt-2">
-                              <div className="text-[14px] text-black">{item.run.userName}</div>
-                              <div className="mt-2 space-y-2">
-                                <div className="flex justify-end items-center gap-2 text-[16px] text-black">
-                                  <button type="button" className="border border-[#dcdfe6] rounded-full px-2 py-0.5 bg-white/80" onClick={(event) => event.stopPropagation()}>
+                            <div className="mt-3 space-y-3">
+                              <div className="text-[14px] font-semibold text-black">{item.run.userName}</div>
+                              <div className="space-y-3">
+                                <div className="flex items-center justify-end gap-2 text-black">
+                                  <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
                                     <LikeIcon size={14} className="text-black" />
                                   </button>
-                                  <button type="button" className="border border-[#dcdfe6] rounded-full px-2 py-0.5 bg-white/80" onClick={(event) => event.stopPropagation()}>
+                                  <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
                                     <CommentIcon size={14} className="text-black" />
                                   </button>
                                 </div>
-                                <div className="flex items-center gap-2">
+                                <div className="flex items-center gap-2.5">
                                   {item.run.party.map((member, index) => (
                                     <CharacterImage
                                       key={`${item.run?.id}-${member.characterId}-${index}`}
                                       characterId={member.characterId}
                                       alt={characterDb[member.characterId]?.name ?? member.characterId}
                                       variant="circle"
-                                      className="w-8 h-8 rounded-full object-cover"
+                                      className="h-9 w-9 rounded-full object-cover"
                                     />
                                   ))}
                                 </div>
@@ -1267,9 +1281,9 @@ export function RunHomePage({
               </div>
             </div>
 
-            <div ref={leaderboardRef} className="bg-white rounded-xl border border-black/10 p-4 md:p-6 shadow-sm mb-10">
-              <div className="text-[20px] font-semibold text-black mb-4">{LEADERBOARD_LABEL}</div>
-              <div className="flex items-center justify-center mb-4">
+            <div ref={leaderboardRef} className={`${HOME_SECTION_PANEL_CLASS} mb-10 p-5 md:p-6`}>
+              <div className="mb-5 text-[18px] font-bold tracking-[0.01em] text-black md:text-[20px]">{LEADERBOARD_LABEL}</div>
+              <div className="mb-5 flex items-center justify-center">
                 <div className="flex items-center border border-[#dcdfe6] rounded-full overflow-hidden w-full max-w-[520px] md:min-w-[520px]">
                   {[
                     { key: "rta", label: "RTAランキング", shortLabel: "RTA" },
@@ -1280,7 +1294,9 @@ export function RunHomePage({
                       key={item.key}
                       type="button"
                       onClick={() => setLeaderboardView(item.key as "rta" | "char" | "fes")}
-                      className={`px-4 py-1.5 text-sm font-medium flex-1 ${leaderboardView === item.key ? "bg-black text-white" : "bg-white text-black"}`}
+                      className={`flex-1 px-4 py-2.5 text-[13px] font-semibold transition-colors md:text-[14px] ${
+                        leaderboardView === item.key ? "bg-black text-white" : "bg-white text-black"
+                      }`}
                       title={item.label}
                       aria-label={item.label}
                     >
@@ -1290,12 +1306,16 @@ export function RunHomePage({
                   ))}
                 </div>
               </div>
-              <div className="flex items-center mb-3">
-                <button type="button" className="border border-[#dcdfe6] rounded-full w-9 h-9 flex items-center justify-center" onClick={() => setIsFilterOpen(true)}>
+              <div className="mb-4 flex items-center">
+                <button
+                  type="button"
+                  className="flex h-10 w-10 items-center justify-center rounded-full border border-[#dcdfe6] transition-colors hover:bg-black/5"
+                  onClick={() => setIsFilterOpen(true)}
+                >
                   <FilterFunnelIcon className="w-5 h-5 text-black" />
                 </button>
               </div>
-              <div className="flex items-center justify-between text-sm font-medium mb-4">
+              <div className="mb-5 flex items-center justify-between text-[13px] font-semibold md:text-[14px]">
                 {[
                   { label: ALL_LABEL, shortLabel: ALL_LABEL, value: null },
                   { label: "Unlimited", shortLabel: "Unl.", value: 4 as Bracket },
@@ -1307,7 +1327,7 @@ export function RunHomePage({
                     key={item.label}
                     type="button"
                     onClick={() => setFilterBracket(item.value)}
-                    className={`pb-2 border-b-2 flex-1 text-center ${
+                    className={`flex-1 border-b-2 pb-3 text-center ${
                       filterBracket === item.value || (item.value === null && filterBracket === null)
                         ? "border-black text-black"
                         : "border-transparent text-[#909399] hover:text-black"

--- a/src/components/RunHomePage.tsx
+++ b/src/components/RunHomePage.tsx
@@ -953,14 +953,20 @@ function HomeShell({ children }: { children: ReactNode }) {
 export function RunHomePage({
   onRequestSubmit,
   onSelectRun,
+  embedded = false,
+  selectedSeason,
+  onSelectedSeasonChange,
 }: {
   onRequestSubmit: () => void;
   onSelectRun: (runId: string) => void;
+  embedded?: boolean;
+  selectedSeason?: string;
+  onSelectedSeasonChange?: (season: string) => void;
 }) {
   const leaderboardRef = useRef<HTMLDivElement | null>(null);
   const topRowRef = useRef<HTMLDivElement | null>(null);
   const [runs] = useState<HomeRun[]>(() => applyWRTag(mockRuns.map(normalizeHomeRun)));
-  const [activeSeason, setActiveSeason] = useState(getDefaultSeason(SEASONS));
+  const [activeSeasonInternal, setActiveSeasonInternal] = useState(getDefaultSeason(SEASONS));
   const [activeTab] = useState<"main" | "festival">("main");
   const [filterBracket, setFilterBracket] = useState<Bracket | null>(null);
   const [filterPlatform, setFilterPlatform] = useState<Platform | null>(null);
@@ -975,6 +981,8 @@ export function RunHomePage({
   const [isOtherMenuOpen, setIsOtherMenuOpen] = useState(false);
   const [showTopScrollLeft, setShowTopScrollLeft] = useState(false);
   const [showTopScrollRight, setShowTopScrollRight] = useState(false);
+  const activeSeason = selectedSeason ?? activeSeasonInternal;
+  const setActiveSeason = onSelectedSeasonChange ?? setActiveSeasonInternal;
 
   const includeIds = useMemo(() => parseAttackerInput(includeInput), [includeInput]);
   const excludeIds = useMemo(() => parseAttackerInput(excludeInput), [excludeInput]);
@@ -1038,47 +1046,49 @@ export function RunHomePage({
 
   return (
     <HomeShell>
-      <nav className="bg-white sticky top-0 z-40 border-b border-[#ebebeb]">
-        <div className="max-w-[1280px] mx-auto px-4 md:px-6 py-2 md:py-3 flex items-center justify-between header-font">
-          <div className="flex items-center gap-4 md:gap-6">
-            <h1 className="text-[26px] md:text-[38px] font-semibold tracking-tight text-black">{APP_TITLE}</h1>
-            <div className="relative">
-              <select
-                className="appearance-none bg-white border border-black/30 rounded-full pl-3 md:pl-4 pr-12 md:pr-14 py-1.5 text-[16px] md:text-[20px] font-medium text-black"
-                value={activeSeason}
-                onChange={(event) => setActiveSeason(event.target.value)}
+      {embedded ? null : (
+        <nav className="bg-white sticky top-0 z-40 border-b border-[#ebebeb]">
+          <div className="max-w-[1280px] mx-auto px-4 md:px-6 py-2 md:py-3 flex items-center justify-between header-font">
+            <div className="flex items-center gap-4 md:gap-6">
+              <h1 className="text-[26px] md:text-[38px] font-semibold tracking-tight text-black">{APP_TITLE}</h1>
+              <div className="relative">
+                <select
+                  className="appearance-none bg-white border border-black/30 rounded-full pl-3 md:pl-4 pr-12 md:pr-14 py-1.5 text-[16px] md:text-[20px] font-medium text-black"
+                  value={activeSeason}
+                  onChange={(event) => setActiveSeason(event.target.value)}
+                >
+                  {SEASONS.map((season) => (
+                    <option key={season} value={season}>
+                      {season}
+                    </option>
+                  ))}
+                </select>
+                <span className="pointer-events-none absolute right-4 md:right-5 top-1/2 -translate-y-1/2 text-black/70">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M6 9l6 6 6-6" />
+                  </svg>
+                </span>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-3 md:gap-4">
+              <button
+                type="button"
+                onClick={() => {
+                  window.scrollTo({ top: 0, behavior: "smooth" });
+                  onRequestSubmit();
+                }}
+                className="bg-black text-white rounded-full text-[16px] md:text-[20px] font-medium flex items-center justify-center md:justify-start gap-0 md:gap-2 w-9 h-9 md:w-auto md:h-auto px-0 md:px-5 py-0 md:py-2.5"
               >
-                {SEASONS.map((season) => (
-                  <option key={season} value={season}>
-                    {season}
-                  </option>
-                ))}
-              </select>
-              <span className="pointer-events-none absolute right-4 md:right-5 top-1/2 -translate-y-1/2 text-black/70">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M6 9l6 6 6-6" />
-                </svg>
-              </span>
+                <span className="md:hidden flex items-center justify-center w-full h-full text-[20px] leading-none">+</span>
+                <span className="hidden md:inline text-[22px] leading-none">+</span>
+                <span className="hidden md:inline">{SUBMIT_LABEL}</span>
+              </button>
+              <div className="w-9 h-9 rounded-full border border-black/30 bg-white" aria-label="User avatar" />
             </div>
           </div>
-
-          <div className="flex items-center gap-3 md:gap-4">
-            <button
-              type="button"
-              onClick={() => {
-                window.scrollTo({ top: 0, behavior: "smooth" });
-                onRequestSubmit();
-              }}
-              className="bg-black text-white rounded-full text-[16px] md:text-[20px] font-medium flex items-center justify-center md:justify-start gap-0 md:gap-2 w-9 h-9 md:w-auto md:h-auto px-0 md:px-5 py-0 md:py-2.5"
-            >
-              <span className="md:hidden flex items-center justify-center w-full h-full text-[20px] leading-none">+</span>
-              <span className="hidden md:inline text-[22px] leading-none">+</span>
-              <span className="hidden md:inline">{SUBMIT_LABEL}</span>
-            </button>
-            <div className="w-9 h-9 rounded-full border border-black/30 bg-white" aria-label="User avatar" />
-          </div>
-        </div>
-      </nav>
+        </nav>
+      )}
 
       {activeTab === "main" ? (
         <div

--- a/src/components/RunSubmitPage.tsx
+++ b/src/components/RunSubmitPage.tsx
@@ -1182,7 +1182,7 @@ function BottomActionButtons({
   );
 }
 
-export function RunSubmitPage({ onBack }: { onBack: () => void }) {
+export function RunSubmitPage({ onBack, embedded = false }: { onBack: () => void; embedded?: boolean }) {
   const [initialState] = useState(() => loadInitialDraftState());
   const [draft, setDraft] = useState<SubmitDraft>(initialState.draft);
   const [errors, setErrors] = useState<FieldErrors>({});
@@ -1550,7 +1550,28 @@ export function RunSubmitPage({ onBack }: { onBack: () => void }) {
   return (
     <>
       <main className="min-h-screen bg-white text-[#333333]">
-        <nav className="sticky top-0 z-40 border-b border-[#ebebeb] bg-white shadow-[0_1px_0_rgba(0,0,0,0.02)]">
+        {embedded ? (
+          <div className="border-b border-[#ebebeb] bg-white">
+            <div className="header-font mx-auto flex max-w-[1600px] items-center gap-3 px-4 py-3 md:px-6">
+              <button
+                type="button"
+                onClick={onBack}
+                className="grid h-10 w-10 place-items-center rounded-full bg-[#f2f2f2] text-black"
+                aria-label="記録一覧へ戻る"
+              >
+                <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M19 12H5" />
+                  <path d="M11 6L5 12L11 18" />
+                </svg>
+              </button>
+              <div>
+                <div className="text-[20px] font-semibold tracking-tight text-black md:text-[28px]">記録申請</div>
+                <div className="text-[12px] text-[#9999b1] md:text-[13px]">3 step flow</div>
+              </div>
+            </div>
+          </div>
+        ) : null}
+        <nav className={embedded ? "hidden" : "sticky top-0 z-40 border-b border-[#ebebeb] bg-white shadow-[0_1px_0_rgba(0,0,0,0.02)]"}>
           <div className="header-font mx-auto flex max-w-[1600px] items-center justify-between gap-3 px-4 py-3 md:px-6">
             <div className="flex items-center gap-3">
               <button

--- a/src/components/RunSubmitPage.tsx
+++ b/src/components/RunSubmitPage.tsx
@@ -1552,11 +1552,11 @@ export function RunSubmitPage({ onBack, embedded = false }: { onBack: () => void
       <main className="min-h-screen bg-white text-[#333333]">
         {embedded ? (
           <div className="border-b border-[#ebebeb] bg-white">
-            <div className="header-font mx-auto flex max-w-[1600px] items-center gap-3 px-4 py-3 md:px-6">
+            <div className="header-font mx-auto flex min-h-[52px] max-w-[1600px] items-center gap-3 px-4 py-2 md:px-6">
               <button
                 type="button"
                 onClick={onBack}
-                className="grid h-10 w-10 place-items-center rounded-full bg-[#f2f2f2] text-black"
+                className="grid h-9 w-9 place-items-center rounded-full bg-[#f2f2f2] text-black"
                 aria-label="記録一覧へ戻る"
               >
                 <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
@@ -1564,10 +1564,7 @@ export function RunSubmitPage({ onBack, embedded = false }: { onBack: () => void
                   <path d="M11 6L5 12L11 18" />
                 </svg>
               </button>
-              <div>
-                <div className="text-[20px] font-semibold tracking-tight text-black md:text-[28px]">記録申請</div>
-                <div className="text-[12px] text-[#9999b1] md:text-[13px]">3 step flow</div>
-              </div>
+              <div className="text-[16px] font-semibold tracking-tight text-black md:text-[18px]">記録申請</div>
             </div>
           </div>
         ) : null}

--- a/src/components/UiIcons.tsx
+++ b/src/components/UiIcons.tsx
@@ -6,20 +6,29 @@ type IconProps = {
 
 export function LikeIcon({ className = "h-4 w-4" }: IconProps) {
   return (
-    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M7 11v9H4v-9h3zm3.6-6.5L7 11v9h9.1c.8 0 1.5-.5 1.7-1.2l1.7-6.1c.3-1.1-.5-2.2-1.7-2.2H13V6c0-1.1-.9-2-2-2h-.4z" />
+    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
     </svg>
   );
 }
 
 export function ShareIcon({ className = "h-4 w-4" }: IconProps) {
   return (
-    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <circle cx="18" cy="5" r="2.5" />
-      <circle cx="6" cy="12" r="2.5" />
-      <circle cx="18" cy="19" r="2.5" />
-      <path d="M8.2 10.9L15.7 6.4" />
-      <path d="M8.2 13.1l7.5 4.5" />
+    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="18" cy="5" r="3" />
+      <circle cx="6" cy="12" r="3" />
+      <circle cx="18" cy="19" r="3" />
+      <line x1="8.59" x2="15.42" y1="13.51" y2="17.49" />
+      <line x1="15.41" x2="8.59" y1="6.51" y2="10.49" />
+    </svg>
+  );
+}
+
+export function CompareViewIcon({ className = "h-4 w-4" }: IconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+      <line x1="12" y1="3" x2="12" y2="21" />
     </svg>
   );
 }
@@ -72,10 +81,12 @@ export function PlatformMobileIcon({ className = "h-4 w-4" }: IconProps) {
 
 export function PlatformPs5Icon({ className = "h-4 w-4" }: IconProps) {
   return (
-    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M3 13c0-1.8 1.6-3 3.4-3h11.2c1.8 0 3.4 1.2 3.4 3v2.1c0 1.3-1.1 2.4-2.4 2.4-1.1 0-1.9-.7-2.3-1.5l-1-1.9H8.7l-1 1.9c-.4.8-1.2 1.5-2.3 1.5C4.1 17.5 3 16.4 3 15.1V13z" />
-      <path d="M9.5 11.5h5" />
-      <path d="M12 9.5v4" />
+    <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <line x1="6" x2="10" y1="12" y2="12" />
+      <line x1="8" x2="8" y1="10" y2="14" />
+      <line x1="15" x2="15.01" y1="13" y2="13" />
+      <line x1="18" x2="18.01" y1="11" y2="11" />
+      <rect width="20" height="12" x="2" y="6" rx="2" />
     </svg>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -13,3 +13,4 @@ if (rootElement) {
     </StrictMode>,
   );
 }
+


### PR DESCRIPTION
## 概要
- 全画面共通のグローバルヘッダーと、ハンバーガーメニュー起点のサイドメニュー drawer を実装しました
- `home / detail / submit / chat / question / exchange / event / notifications / account` の導線を `RootApp` に統合しました
- `docs/mocks/sidebar.mock.tsx` は参照資料として残し、production 実装は `src/` 側に新設しています

## 変更内容
- `AppShell` と `PlaceholderPage` を追加し、アプリ全体を共通 shell 配下で描画する構成に変更
- サイドメニューは常設 sidebar ではなく、全画面共通の drawer に統一
- サイドメニューの項目順・アカウント導線・外部リンク導線を整理
  - リーダーボード
  - イベント情報
  - 情報交換
  - 雑談
  - 質問
  - 鶴見調整プランナー
  - AutoSplit
- ホーム、記録詳細、記録申請の各画面を shell 配下に載せ替え、重複していた global UI を整理
- 記録詳細の右カラムは `使用編成` / `類似編成の記録` の密度と視認性を再調整
- ホーム上段 3 ブロックの余白・角丸・アクションアイコンのバランスを調整
- 共通 UI アイコンを見直し、like / share / compare / comment / platform 周りを指定デザインに寄せました

## 実装意図
- compare drawer と submit flow のレイアウトを壊さないため、desktop 常設 sidebar ではなく drawer 統一を採用しています
- 今フェーズではページ追加の受け皿を先に揃えることを優先し、大きな再設計は避けて `src/` に最小限の共通 shell を追加しました
- 詳細画面とホーム画面の局所調整は、情報の優先順位が見えにくかった箇所だけを対象にしています

## 確認内容
- `npm run build`

## 補足
- 通知、アカウント、イベント情報、雑談、質問、情報交換は placeholder です
- 比較ビュー本体の構造は維持し、サイドメニュー導線と detail 側の見た目調整に留めています