### PR TITLE
ホーム/記録詳細/申請画面のダークUI調整といいね表現の改善

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -144,12 +144,12 @@ function QuestionIcon({ className, active = false }: IconProps) {
         <circle cx="12" cy="12" r="9" fill="currentColor" />
         <path
           d="M9.6 9.3a2.4 2.4 0 1 1 4.2 1.5c-.7.7-1.5 1.1-1.8 2.2"
-          stroke="#0f141c"
+          stroke="#212121"
           strokeWidth="1.9"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
-        <path d="M12 16.8h.01" stroke="#0f141c" strokeWidth="2.2" strokeLinecap="round" />
+        <path d="M12 16.8h.01" stroke="#212121" strokeWidth="2.2" strokeLinecap="round" />
       </svg>
     );
   }
@@ -188,7 +188,7 @@ function CalendarIcon({ className, active = false }: IconProps) {
     return (
       <svg viewBox="0 0 24 24" className={classNames("shrink-0", className)} fill="currentColor" aria-hidden="true">
         <path d="M8 3a1 1 0 0 1 1 1v1h6V4a1 1 0 1 1 2 0v1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h1V4a1 1 0 0 1 1-1Z" />
-        <path d="M6 10.25h12v1.5H6Z" fill="#0f141c" opacity="0.35" />
+        <path d="M6 10.25h12v1.5H6Z" fill="#212121" opacity="0.35" />
       </svg>
     );
   }
@@ -289,7 +289,7 @@ function DrawerSection({
       {items.map((item) => {
         const Icon = item.icon;
         const active = item.kind === "route" ? isNavActive(routeName, item.route) : false;
-        const itemClassName = "group flex w-full items-center gap-4 rounded-full px-4 py-3 text-left transition-all hover:bg-[#171d28]";
+        const itemClassName = "group flex w-full items-center gap-4 rounded-full px-4 py-3 text-left transition-all hover:bg-[#272727]";
         const labelClassName = classNames(
           "whitespace-nowrap text-[20px] transition-colors",
           active ? "font-bold text-[#d9d9d9]" : "font-normal text-[#d9d9d9] group-hover:text-[#d9d9d9]",
@@ -333,11 +333,11 @@ function DrawerBody({
 }) {
   return (
     <>
-      <div className="flex justify-start border-b border-[#2a3140] px-4 py-8 sm:px-6">
+      <div className="flex justify-start border-b border-[#343434] px-4 py-8 sm:px-6">
         <button
           type="button"
           onClick={() => onNavigate("account")}
-          className="flex w-full max-w-[240px] flex-col gap-3 rounded-[24px] p-3 text-left transition-colors hover:bg-[#171d28]"
+          className="flex w-full max-w-[240px] flex-col gap-3 rounded-[24px] p-3 text-left transition-colors hover:bg-[#272727]"
         >
           <div className="flex items-center justify-between gap-4">
             <div className="relative flex size-[36px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#d9d9d9]">
@@ -354,7 +354,7 @@ function DrawerBody({
         </button>
       </div>
 
-      <div className="border-b border-[#2a3140]">
+      <div className="border-b border-[#343434]">
         <DrawerSection items={primaryNavItems} routeName={routeName} onNavigate={onNavigate} onExternalSelect={onClose} />
       </div>
 
@@ -382,7 +382,7 @@ function GlobalDrawer({
   return (
     <aside
       className={classNames(
-        "fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-y-auto border-r border-[#2a3140] bg-[#0f141c] text-[#d9d9d9] transition-transform duration-300 ease-in-out sm:w-[320px]",
+        "fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-y-auto border-r border-[#343434] bg-[#000000] text-[#d9d9d9] transition-transform duration-300 ease-in-out sm:w-[320px]",
         isOpen ? "translate-x-0" : "-translate-x-full",
       )}
       aria-hidden={!isOpen}
@@ -414,10 +414,10 @@ function GlobalHeader({
   onVersionChange: (version: string) => void;
 }) {
   const utilityButtonClass =
-    "relative rounded-full p-2 text-[#d9d9d9] transition-colors hover:bg-[#171d28] hover:text-[#d9d9d9] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#657086]";
+    "relative rounded-full p-2 text-[#d9d9d9] transition-colors hover:bg-[#272727] hover:text-[#d9d9d9] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6a6a6a]";
 
   return (
-    <header className="sticky top-0 z-30 h-[80px] shrink-0 border-b border-[#2a3140] bg-[#0f141c]">
+    <header className="sticky top-0 z-30 h-[80px] shrink-0 border-b border-[#343434] bg-[#000000]">
       <div className="header-font flex h-full items-center justify-between gap-4 px-4 py-4 md:px-6">
         <div className="flex min-w-0 items-center gap-4 sm:gap-6">
           <button type="button" className="text-[#d9d9d9] transition-colors hover:text-[#d9d9d9]" onClick={onMenuClick} aria-label="\u30e1\u30cb\u30e5\u30fc\u3092\u958b\u304f">
@@ -438,10 +438,10 @@ function GlobalHeader({
             <select
               value={version}
               onChange={(event) => onVersionChange(event.target.value)}
-              className="min-w-[104px] appearance-none rounded-full border border-[#2f3949] bg-[#171d28] py-2 pl-4 pr-10 text-[12px] font-normal text-[#d9d9d9] outline-none transition-colors hover:border-[#445066] focus:border-[#657086] sm:text-[14px] md:text-[16px]"
+              className="min-w-[104px] appearance-none rounded-full border border-[#3a3a3a] bg-[#272727] py-2 pl-4 pr-10 text-[12px] font-normal text-[#d9d9d9] outline-none transition-colors hover:border-[#505050] focus:border-[#6a6a6a] sm:text-[14px] md:text-[16px]"
             >
               {versionOptions.map((option) => (
-                <option key={option} value={option} className="bg-[#171d28] text-[#d9d9d9]">
+                <option key={option} value={option} className="bg-[#272727] text-[#d9d9d9]">
                   {option}
                 </option>
               ))}
@@ -456,7 +456,7 @@ function GlobalHeader({
             onClick={onRequestSubmit}
             className={classNames(
               "flex items-center gap-2 rounded-full px-3 py-2 transition-colors sm:px-4",
-              routeName === "submit" ? "bg-white text-[#111111]" : "bg-[#2a3140] text-[#d9d9d9] hover:bg-[#364055]",
+              routeName === "submit" ? "bg-white text-[#111111]" : "bg-[#272727] text-[#d9d9d9] hover:bg-[#313131]",
             )}
           >
             <PlusIcon className="size-5" />
@@ -467,10 +467,10 @@ function GlobalHeader({
             type="button"
             onClick={() => onNavigate("notifications")}
             aria-label="\u901a\u77e5"
-            className={classNames(utilityButtonClass, routeName === "notifications" && "bg-[#2a3140] text-[#d9d9d9] hover:bg-[#2a3140]")}
+            className={classNames(utilityButtonClass, routeName === "notifications" && "bg-[#272727] text-[#d9d9d9] hover:bg-[#272727]")}
           >
             <BellIcon className="size-6 sm:size-7" />
-            {hasUnreadNotifications ? <span className="absolute top-1 right-1 block size-2.5 rounded-full border-2 border-[#0f141c] bg-red-500" /> : null}
+            {hasUnreadNotifications ? <span className="absolute top-1 right-1 block size-2.5 rounded-full border-2 border-[#000000] bg-red-500" /> : null}
           </button>
 
           <button

--- a/src/components/RecordDetailPage.tsx
+++ b/src/components/RecordDetailPage.tsx
@@ -28,6 +28,12 @@ const collapsedCopyStyle: CSSProperties = {
   WebkitLineClamp: 3,
 };
 
+const DETAIL_PANEL_SHELL_CLASS = "relative overflow-hidden rounded-[20px] bg-[#3d3c3d] drop-shadow-xl";
+const DETAIL_PANEL_INNER_CLASS = "relative z-[1] m-[2px] rounded-[18px] bg-[#323132] text-white/90";
+const DETAIL_MUTED_SURFACE_CLASS = "rounded-[16px] border border-white/10 bg-[#272727]";
+const DETAIL_ICON_BUTTON_CLASS =
+  "grid h-9 w-9 place-items-center rounded-full border border-white/10 bg-[#272727] text-white/82 transition hover:bg-white/[0.12] hover:text-white";
+
 function postYouTubeCommand(iframe: HTMLIFrameElement | null, command: "playVideo" | "pauseVideo") {
   iframe?.contentWindow?.postMessage(
     JSON.stringify({
@@ -114,7 +120,9 @@ function PillButton({
       type="button"
       onClick={onClick}
       className={`inline-flex items-center justify-center gap-2 rounded-[42px] px-[14px] py-[7px] text-[14px] font-medium leading-none transition duration-150 hover:-translate-y-[1px] hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)] md:text-[15px] ${
-        dark || active ? "bg-[#333333] text-white" : "bg-[#f2f2f2] text-black"
+        dark || active
+          ? "border border-black/50 bg-black text-white"
+          : "border border-white/10 bg-[#272727] text-white/90 hover:bg-[#303030]"
       } ${className}`}
     >
       {children}
@@ -137,30 +145,37 @@ function TinyBadge({ label, highlighted = false }: { label: string; highlighted?
 }
 
 function SectionTitle({ children }: { children: ReactNode }) {
-  return <div className="text-[16px] font-bold leading-none text-black md:text-[18px]">{children}</div>;
+  return <div className="text-[16px] font-bold leading-none text-white/90 md:text-[18px]">{children}</div>;
 }
 
 function SidebarPanel({ children }: { children: ReactNode }) {
-  return <section className="w-full rounded-[16px] border border-[#ebebeb] bg-white p-[16px] shadow-[0_4px_12px_rgba(0,0,0,0.05)]">{children}</section>;
+  return (
+    <section className={`w-full ${DETAIL_PANEL_SHELL_CLASS}`}>
+      <div className={`${DETAIL_PANEL_INNER_CLASS} p-[16px]`}>
+        <div className="pointer-events-none absolute -left-[30%] -top-[44%] h-[220px] w-[220px] rounded-full bg-white/18 blur-[72px]" />
+        <div className="relative z-[1]">{children}</div>
+      </div>
+    </section>
+  );
 }
 
 function SidebarSectionHeader({ title, meta }: { title: ReactNode; meta?: ReactNode }) {
   return (
     <div className="flex items-start justify-between gap-[12px]">
       <SectionTitle>{title}</SectionTitle>
-      {meta ? <div className="shrink-0 text-[12px] font-medium text-[#8d93a3] md:text-[13px]">{meta}</div> : null}
+      {meta ? <div className="shrink-0 text-[12px] font-medium text-white/52 md:text-[13px]">{meta}</div> : null}
     </div>
   );
 }
 
 function LoadoutEntryCard({ entry }: { entry: PartyLoadoutEntry }) {
   return (
-    <div className="rounded-[16px] border border-[#eceff3] bg-[#fbfbfc] p-[12px] md:p-[14px]">
+    <div className="rounded-[16px] border border-white/10 bg-[#272727] p-[12px] md:p-[14px]">
       <div className="flex items-start gap-[12px] md:gap-[14px]">
         <CharacterIcon characterId={entry.characterId} alt={entry.characterName} fallbackLabel={entry.characterName} size={56} />
         <div className="min-w-0 flex-1">
-          <div className="truncate text-[16px] font-semibold leading-[1.2] text-black md:text-[17px]">{entry.characterName}</div>
-          <div className="mt-[5px] truncate text-[13px] leading-[1.45] text-[#8f94a3] md:text-[14px]">{entry.weaponName}</div>
+          <div className="truncate text-[16px] font-semibold leading-[1.2] text-white/92 md:text-[17px]">{entry.characterName}</div>
+          <div className="mt-[5px] truncate text-[13px] leading-[1.45] text-white/56 md:text-[14px]">{entry.weaponName}</div>
           <div className="mt-[10px] flex flex-wrap gap-[8px]">
             <TinyBadge label={`C${entry.cons}`} highlighted={entry.cons === 6} />
             <TinyBadge label={`R${entry.refine}`} highlighted={entry.refine === 5} />
@@ -173,7 +188,7 @@ function LoadoutEntryCard({ entry }: { entry: PartyLoadoutEntry }) {
 
 function SimilarityReasonChip({ label }: { label: string }) {
   return (
-    <span className="inline-flex items-center rounded-full bg-[#f2f4f7] px-[10px] py-[5px] text-[11px] font-medium leading-none text-[#5f6678] md:text-[12px]">
+    <span className="inline-flex items-center rounded-full border border-white/10 bg-[#272727] px-[10px] py-[5px] text-[11px] font-medium leading-none text-white/68 md:text-[12px]">
       {label}
     </span>
   );
@@ -212,7 +227,7 @@ function TagChip({ tag }: { tag: string }) {
   const platformParts = parsePlatformTag(tag);
 
   return (
-    <span className="inline-flex items-center gap-[6px] rounded-[42px] bg-white px-[10px] py-[5px] text-[12px] text-black md:px-[12px] md:py-[6px] md:text-[13px]">
+    <span className="inline-flex items-center gap-[6px] rounded-[42px] border border-white/10 bg-[#272727] px-[10px] py-[5px] text-[12px] text-white/85 md:px-[12px] md:py-[6px] md:text-[13px]">
       {platformParts ? (
         <span className="inline-flex items-center gap-[4px]">
           {platformParts.map((platform, index) => (
@@ -241,7 +256,7 @@ function VideoFrame({
   const embedUrl = getYouTubeEmbedUrl(videoUrl, { autoplay, mute, enableJsApi: true });
 
   return (
-    <div className="aspect-[669/380] w-full overflow-hidden rounded-[12px] border border-[#ebebeb] bg-[#d9d9d9] shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
+    <div className="aspect-[669/380] w-full overflow-hidden rounded-[16px] border border-white/10 bg-[#272727] shadow-[0_20px_40px_rgba(0,0,0,0.28)]">
       {embedUrl ? (
         <iframe
           ref={iframeRef}
@@ -260,32 +275,32 @@ function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.R
   const partyLoadout = getPartyLoadout(run);
 
   return (
-    <div className="flex min-h-full flex-col gap-[16px] bg-white px-3 py-3">
+    <div className="flex min-h-full flex-col gap-[16px] bg-[#212121] px-3 py-3 text-white/90">
       <VideoFrame title={run.title} videoUrl={run.videoUrl} iframeRef={iframeRef} mute />
 
       <div className="flex flex-col gap-[12px]">
         <div className="flex flex-col gap-[12px]">
-          <div className="text-[16px] font-bold leading-none text-black md:text-[18px]">{run.title}</div>
+          <div className="text-[16px] font-bold leading-none text-white md:text-[18px]">{run.title}</div>
           <div className="flex items-center justify-between gap-[12px]">
             <div className="flex min-w-0 items-center gap-[12px]">
               <CircleAvatar label={run.userName} size={40} />
-              <div className="truncate text-[16px] font-bold leading-none text-black md:text-[18px]">{run.userName}</div>
+              <div className="truncate text-[16px] font-bold leading-none text-white md:text-[18px]">{run.userName}</div>
             </div>
-            <div className="inline-flex shrink-0 items-center gap-[6px] rounded-[42px] bg-[#f2f2f2] px-[10px] py-[5px] text-[12px] text-black md:text-[13px]">
+            <div className="inline-flex shrink-0 items-center gap-[6px] rounded-[42px] border border-white/10 bg-[#272727] px-[10px] py-[5px] text-[12px] text-white/82 md:text-[13px]">
               <PlatformIcon platform={run.platform} className="h-[13px] w-[13px]" />
               <span>{run.platform}</span>
             </div>
           </div>
         </div>
 
-        <div className="w-full rounded-[12px] border border-[#ebebeb] bg-[#f5f6f8] p-[12px]">
-          <div className="flex items-center gap-x-[16px] overflow-x-auto whitespace-nowrap text-[13px] text-black md:gap-x-[18px] md:text-[14px]">
+        <div className={`w-full ${DETAIL_MUTED_SURFACE_CLASS} p-[12px]`}>
+          <div className="flex items-center gap-x-[16px] overflow-x-auto whitespace-nowrap text-[13px] text-white/74 md:gap-x-[18px] md:text-[14px]">
             <span>ver : {run.versionLabel}</span>
             <span>{run.postedLabel}</span>
             <PlatformLabel platform={run.platform} />
           </div>
           <div className="mt-[12px] space-y-[12px]">
-            <p className="whitespace-pre-line text-[14px] leading-[1.75] text-black md:text-[15px]">{run.summary}</p>
+            <p className="whitespace-pre-line text-[14px] leading-[1.75] text-white/88 md:text-[15px]">{run.summary}</p>
             <div className="flex flex-wrap gap-[10px] md:gap-[12px]">
               {run.tags.map((tag) => (
                 <TagChip key={`${run.id}-${tag}`} tag={tag} />
@@ -364,16 +379,16 @@ function CompareDrawer({
 
   return (
     <div className={embedded ? "fixed top-[80px] right-0 bottom-0 z-20 hidden lg:block" : "fixed inset-y-0 right-0 z-50 hidden lg:block"} aria-modal="false" role="complementary">
-      <div className="flex h-full w-[50vw] flex-col border-l border-[#ebebeb] bg-white shadow-[-12px_0_24px_rgba(0,0,0,0.08)]">
-        <div className="flex min-h-[52px] items-center justify-between border-b border-[#ebebeb] px-4 py-2">
+      <div className="flex h-full w-[50vw] flex-col border-l border-white/10 bg-[#212121] shadow-[-20px_0_40px_rgba(0,0,0,0.35)]">
+        <div className="flex min-h-[52px] items-center justify-between border-b border-white/10 bg-[#212121] px-4 py-2">
           <div className="min-w-0">
-            <div className="text-[16px] font-semibold text-black md:text-[18px]">比較ビュー</div>
+            <div className="text-[16px] font-semibold text-white/92 md:text-[18px]">比較ビュー</div>
           </div>
           <div className="flex items-center gap-2">
             <button
               type="button"
               onClick={onToggleSync}
-              className="inline-flex h-9 items-center justify-center gap-2 rounded-[42px] bg-[#f2f2f2] px-4 text-[13px] font-medium text-black transition hover:bg-[#e8e8e8]"
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-[42px] border border-white/10 bg-[#272727] px-4 text-[13px] font-medium text-white transition hover:bg-[#303030]"
             >
               {syncPlaying ? <PauseIcon className="h-4 w-4" /> : <PlayIcon className="h-4 w-4" />}
               <span>{syncPlaying ? "同期停止" : "同時再生"}</span>
@@ -382,7 +397,7 @@ function CompareDrawer({
               type="button"
               aria-label="比較ビューを閉じる"
               onClick={onClose}
-              className="grid h-9 w-9 place-items-center rounded-full bg-[#f2f2f2] text-black transition hover:bg-[#e8e8e8]"
+              className={DETAIL_ICON_BUTTON_CLASS}
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
                 <path d="M6 6l12 12" />
@@ -392,7 +407,7 @@ function CompareDrawer({
           </div>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto bg-[#fbfbfb]">
+        <div className="min-h-0 flex-1 overflow-y-auto bg-[#212121]">
           <CompareRunPane run={comparedRun} iframeRef={comparedIframeRef} />
         </div>
       </div>
@@ -419,7 +434,7 @@ function SimilarActionMenu({
         type="button"
         onClick={onToggle}
         aria-label="類似記録の操作"
-        className="grid h-9 w-9 place-items-center rounded-full border border-[#dde2ea] bg-white text-[#5f6678] transition hover:bg-[#f5f6f8]"
+        className={DETAIL_ICON_BUTTON_CLASS}
       >
         <svg viewBox="0 0 24 24" className="h-4 w-4" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="5" r="1.8" />
@@ -428,10 +443,10 @@ function SimilarActionMenu({
         </svg>
       </button>
       {isOpen ? (
-        <div className="absolute right-0 top-full z-20 mt-2 w-[180px] rounded-[16px] border border-[#ebebeb] bg-white p-2 shadow-[0_4px_12px_rgba(0,0,0,0.05)]">
+        <div className="absolute right-0 top-full z-20 mt-2 w-[180px] rounded-[16px] border border-white/10 bg-[#323132] p-2 shadow-[0_20px_40px_rgba(0,0,0,0.28)]">
           <button
             type="button"
-            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-black hover:bg-[#f2f2f2]"
+            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-white/90 hover:bg-white/[0.08]"
             onClick={() => onAction("like")}
           >
             <LikeIcon className="h-4 w-4" />
@@ -439,7 +454,7 @@ function SimilarActionMenu({
           </button>
           <button
             type="button"
-            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-black hover:bg-[#f2f2f2]"
+            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-white/90 hover:bg-white/[0.08]"
             onClick={() => onAction("share")}
           >
             <ShareIcon className="h-4 w-4" />
@@ -447,7 +462,7 @@ function SimilarActionMenu({
           </button>
           <button
             type="button"
-            className="hidden h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-black hover:bg-[#f2f2f2] lg:flex"
+            className="hidden h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-white/90 hover:bg-white/[0.08] lg:flex"
             onClick={() => onAction("compare")}
           >
             <CompareViewIcon className="h-4 w-4" />
@@ -481,16 +496,16 @@ function SimilarRunCard({
   return (
     <article
       className={`rounded-[16px] border p-[14px] transition-colors ${
-        isCompareQueued ? "border-[#d5dbe5] bg-[#f7f8fa]" : "border-[#eceff3] bg-[#fcfcfd] hover:bg-white"
+        isCompareQueued ? "border-white/20 bg-[#3b3a3b]" : "border-white/10 bg-[#323132] hover:bg-[#353435]"
       }`}
     >
       <div className="flex items-start gap-[10px]">
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-[12px]">
             <div className="min-w-0 flex-1">
-              <div className="truncate text-[15px] font-semibold leading-[1.4] text-black md:text-[16px]">{match.run.title}</div>
-              <div className="mt-[6px] flex flex-wrap items-center gap-x-[8px] gap-y-[4px] text-[12px] text-[#8f94a3] md:text-[13px]">
-                <span className="font-medium text-[#5f6678]">{match.run.userName}</span>
+              <div className="truncate text-[15px] font-semibold leading-[1.4] text-white/92 md:text-[16px]">{match.run.title}</div>
+              <div className="mt-[6px] flex flex-wrap items-center gap-x-[8px] gap-y-[4px] text-[12px] text-white/52 md:text-[13px]">
+                <span className="font-medium text-white/78">{match.run.userName}</span>
                 <span>{match.run.postedLabel}</span>
                 <PlatformLabel platform={match.run.platform} iconClassName="h-[13px] w-[13px]" />
               </div>
@@ -500,7 +515,7 @@ function SimilarRunCard({
             </div>
           </div>
 
-          <div className="mt-[12px] rounded-[16px] border border-[#eceff3] bg-[#f5f6f8] px-[10px] py-[9px]">
+          <div className="mt-[12px] rounded-[16px] border border-white/10 bg-[#272727] px-[10px] py-[9px]">
             <div className="flex items-center justify-between gap-[8px]">
               {match.run.party.map((member) => {
                 const characterName = characterDb[member.characterId]?.name ?? member.characterId;
@@ -668,27 +683,27 @@ export function RecordDetailPage({
 
   return (
     <>
-      <main className={`bg-white text-[#333333] transition-[width] duration-300 ${mainSurfaceClass}`}>
+      <main className={`bg-[#212121] text-white/90 transition-[width] duration-300 ${mainSurfaceClass}`}>
         {embedded ? (
-          <div className="border-b border-[#ebebeb] bg-white">
+          <div className="border-b border-white/10 bg-[#212121]">
             <div className={`header-font mx-auto flex min-h-[52px] max-w-[1600px] items-center gap-3 px-4 py-2 ${forceMobileLayout ? "" : "md:px-6"}`}>
               {onBack ? (
                 <button
                   type="button"
                   onClick={onBack}
                   aria-label="一覧へ戻る"
-                  className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[#f2f2f2] text-black transition hover:bg-[#e8e8e8]"
+                  className={`${DETAIL_ICON_BUTTON_CLASS} shrink-0`}
                 >
                   <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                     <path d="M15 5L8 12L15 19" />
                   </svg>
                 </button>
               ) : null}
-              <div className="min-w-0 text-[16px] font-semibold tracking-tight text-black md:text-[18px]">記録詳細</div>
+              <div className="min-w-0 text-[16px] font-semibold tracking-tight text-white/92 md:text-[18px]">記録詳細</div>
             </div>
           </div>
         ) : null}
-        <nav className={embedded ? "hidden" : "sticky top-0 z-40 border-b border-[#ebebeb] bg-white shadow-[0_1px_0_rgba(0,0,0,0.02)]"}>
+        <nav className={embedded ? "hidden" : "sticky top-0 z-40 border-b border-white/10 bg-[#212121] shadow-[0_1px_0_rgba(255,255,255,0.04)]"}>
           <div className={`header-font mx-auto flex max-w-[1600px] items-center justify-between px-4 py-2 ${forceMobileLayout ? "min-h-[52px]" : "md:px-6 md:py-3"}`}>
             <div className={`flex items-center ${forceMobileLayout ? "gap-3" : "gap-4 md:gap-6"}`}>
               {onBack ? (
@@ -696,17 +711,17 @@ export function RecordDetailPage({
                   type="button"
                   onClick={onBack}
                   aria-label="一覧へ戻る"
-                  className="grid h-9 w-9 shrink-0 place-items-center rounded-full bg-[#f2f2f2] text-black transition hover:bg-[#e8e8e8]"
+                  className={`${DETAIL_ICON_BUTTON_CLASS} shrink-0`}
                 >
                   <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                     <path d="M15 5L8 12L15 19" />
                   </svg>
                 </button>
               ) : null}
-              <h1 className={`font-semibold tracking-tight text-black ${forceMobileLayout ? "text-[24px]" : "text-[26px] md:text-[38px]"}`}>精鋭狩りDB</h1>
+              <h1 className={`font-semibold tracking-tight text-white ${forceMobileLayout ? "text-[24px]" : "text-[26px] md:text-[38px]"}`}>精鋭狩りDB</h1>
               <div className="relative">
                 <select
-                  className={`appearance-none rounded-full border border-black/30 bg-white py-1.5 pl-3 pr-10 font-medium text-black ${forceMobileLayout ? "text-[15px]" : "text-[16px] md:pl-4 md:pr-12 md:text-[20px]"}`}
+                  className={`appearance-none rounded-full border border-white/10 bg-[#272727] py-1.5 pl-3 pr-10 font-medium text-[#d9d9d9] ${forceMobileLayout ? "text-[15px]" : "text-[16px] md:pl-4 md:pr-12 md:text-[20px]"}`}
                   value={headerVersion}
                   onChange={(event) => setHeaderVersion(event.target.value)}
                 >
@@ -716,7 +731,7 @@ export function RecordDetailPage({
                     </option>
                   ))}
                 </select>
-                <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-black/70">
+                <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-white/60">
                   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                     <path d="M6 9l6 6 6-6" />
                   </svg>
@@ -728,7 +743,7 @@ export function RecordDetailPage({
               <button
                 type="button"
                 onClick={onRequestSubmit}
-                className={`flex h-9 w-9 items-center justify-center rounded-full bg-black text-white ${forceMobileLayout ? "" : "md:h-auto md:w-auto md:gap-2 md:px-5 md:py-2.5 md:text-[20px]"}`}
+                className={`flex h-9 w-9 items-center justify-center rounded-full border border-white/12 bg-[#272727] text-white ${forceMobileLayout ? "" : "md:h-auto md:w-auto md:gap-2 md:px-5 md:py-2.5 md:text-[20px]"}`}
               >
                 <span className="text-[20px] leading-none md:text-[22px]">＋</span>
                 <span className={forceMobileLayout ? "hidden" : "hidden md:inline"}>記録提出</span>
@@ -744,11 +759,11 @@ export function RecordDetailPage({
 
             <div className="flex flex-col gap-[12px]">
               <div className="flex flex-col gap-[12px]">
-                <div className="text-[16px] font-bold leading-none text-black md:text-[18px]">{currentRun.title}</div>
+                <div className="text-[16px] font-bold leading-none text-white md:text-[18px]">{currentRun.title}</div>
                 <div className={`flex gap-[12px] ${compareOpen ? "flex-col items-start" : "items-center justify-between"}`}>
                   <div className="flex min-w-0 items-center gap-[12px]">
                     <CircleAvatar label={currentRun.userName} size={40} />
-                    <div className="truncate text-[16px] font-bold leading-none text-black md:text-[18px]">{currentRun.userName}</div>
+                    <div className="truncate text-[16px] font-bold leading-none text-white md:text-[18px]">{currentRun.userName}</div>
                   </div>
                   <div className={`flex gap-[12px] md:gap-[12px] ${compareOpen ? "w-full shrink min-w-0 flex-wrap" : "shrink-0 flex-nowrap"}`}>
                     <PillButton active={liked} onClick={() => setLiked((previous) => !previous)} className="min-h-[36px] min-w-[92px]">
@@ -763,9 +778,9 @@ export function RecordDetailPage({
                 </div>
               </div>
 
-              <div className="w-full rounded-[12px] border border-[#ebebeb] bg-[#f5f6f8] p-[12px]">
+              <div className={`w-full ${DETAIL_MUTED_SURFACE_CLASS} p-[12px]`}>
                 <div className={`flex gap-[16px] ${compareOpen ? "flex-col items-start whitespace-normal" : "items-center justify-between whitespace-nowrap"}`}>
-                  <div className={`flex min-w-0 gap-x-[16px] text-[13px] text-black md:gap-x-[18px] md:text-[14px] ${compareOpen ? "flex-wrap items-center gap-y-[6px]" : "items-center"}`}>
+                  <div className={`flex min-w-0 gap-x-[16px] text-[13px] text-white/74 md:gap-x-[18px] md:text-[14px] ${compareOpen ? "flex-wrap items-center gap-y-[6px]" : "items-center"}`}>
                     <span>ver : {currentRun.versionLabel}</span>
                     <span>{currentRun.postedLabel}</span>
                     <PlatformLabel platform={currentRun.platform} />
@@ -774,7 +789,7 @@ export function RecordDetailPage({
                     <button
                       type="button"
                       onClick={() => setDescriptionExpanded((previous) => !previous)}
-                      className={`shrink-0 text-right text-black ${forceMobileLayout ? "text-[13px]" : "text-[13px] md:text-[14px]"}`}
+                      className={`shrink-0 text-right text-white/78 ${forceMobileLayout ? "text-[13px]" : "text-[13px] md:text-[14px]"}`}
                     >
                       ...もっと見る
                     </button>
@@ -783,7 +798,7 @@ export function RecordDetailPage({
 
                 {shouldShowExpandedArea ? (
                   <div className="mt-[12px] space-y-[12px]">
-                    <p className={`whitespace-pre-line leading-[1.75] text-black ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`} style={descriptionExpanded ? undefined : collapsedCopyStyle}>
+                    <p className={`whitespace-pre-line leading-[1.75] text-white/88 ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`} style={descriptionExpanded ? undefined : collapsedCopyStyle}>
                       {currentRun.summary}
                     </p>
                     <div className="flex flex-wrap gap-[10px] md:gap-[12px]">
@@ -801,12 +816,12 @@ export function RecordDetailPage({
                 <SectionTitle>{comments.length}件のコメント</SectionTitle>
                 <form onSubmit={handleCommentSubmit} className="flex w-full items-center gap-[8px]">
                   <CircleAvatar label="You" size={36} />
-                  <div className="flex flex-1 items-center justify-between border-b border-[#d9d9d9] p-[8px] transition focus-within:border-[#b9b9cc]">
+                  <div className="flex flex-1 items-center justify-between border-b border-white/12 p-[8px] transition focus-within:border-white/30">
                     <input
                       value={commentDraft}
                       onChange={(event) => setCommentDraft(event.target.value)}
                       placeholder="コメントする..."
-                      className={`min-w-0 flex-1 border-none bg-transparent text-black outline-none ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}
+                      className={`min-w-0 flex-1 border-none bg-transparent text-white outline-none placeholder:text-white/36 ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}
                     />
                     <PillButton className="ml-[8px] min-h-[30px] shrink-0 whitespace-nowrap px-[12px] py-[5px] text-[12px] md:text-[13px]">送信</PillButton>
                   </div>
@@ -818,11 +833,11 @@ export function RecordDetailPage({
                   <article key={comment.id} className="flex items-start gap-[12px]">
                     <CircleAvatar label={comment.userName} size={40} />
                     <div className="flex min-w-0 flex-1 flex-col gap-[8px] justify-center">
-                      <div className={`flex flex-wrap items-center gap-[8px] text-black ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>
+                      <div className={`flex flex-wrap items-center gap-[8px] text-white/88 ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>
                         <span>{comment.userName}</span>
-                        <span className="text-[#9999b1]">{comment.postedLabel}</span>
+                        <span className="text-white/42">{comment.postedLabel}</span>
                       </div>
-                      <div className={`leading-[1.75] text-[#3d3d3d] ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>{comment.body}</div>
+                      <div className={`leading-[1.75] text-white/74 ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>{comment.body}</div>
                       <div className={`flex gap-[12px] md:gap-[12px] ${compareOpen ? "w-full shrink min-w-0 flex-wrap" : "shrink-0 flex-nowrap"}`}>
                         <PillButton className="px-[8px] py-[4px] text-[11px] md:text-[12px]">
                           <LikeIcon className="h-3 w-3" />
@@ -874,7 +889,7 @@ export function RecordDetailPage({
                     })}
                   </div>
                 ) : (
-                  <div className="rounded-[16px] border border-dashed border-[#d9dee7] bg-[#fbfbfc] px-[14px] py-[16px] text-[13px] leading-[1.7] text-[#8f94a3]">
+                  <div className="rounded-[16px] border border-dashed border-white/14 bg-[#272727] px-[14px] py-[16px] text-[13px] leading-[1.7] text-white/52">
                     近い条件の記録はまだありません。
                   </div>
                 )}

--- a/src/components/RecordDetailPage.tsx
+++ b/src/components/RecordDetailPage.tsx
@@ -33,6 +33,7 @@ const DETAIL_PANEL_INNER_CLASS = "relative z-[1] m-[2px] rounded-[18px] bg-[#323
 const DETAIL_MUTED_SURFACE_CLASS = "rounded-[16px] border border-white/10 bg-[#272727]";
 const DETAIL_ICON_BUTTON_CLASS =
   "grid h-9 w-9 place-items-center rounded-full border border-white/10 bg-[#272727] text-white/82 transition hover:bg-white/[0.12] hover:text-white";
+const DETAIL_LIKE_ACTIVE_ICON_CLASS = "text-[#ff8ea1]";
 
 function postYouTubeCommand(iframe: HTMLIFrameElement | null, command: "playVideo" | "pauseVideo") {
   iframe?.contentWindow?.postMessage(
@@ -449,7 +450,7 @@ function SimilarActionMenu({
             className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-white/90 hover:bg-white/[0.08]"
             onClick={() => onAction("like")}
           >
-            <LikeIcon className="h-4 w-4" />
+            <LikeIcon filled={liked} className={`h-4 w-4 ${liked ? DETAIL_LIKE_ACTIVE_ICON_CLASS : ""}`} />
             <span>{liked ? "いいね解除" : "いいね"}</span>
           </button>
           <button
@@ -552,6 +553,7 @@ export function RecordDetailPage({
   const [shared, setShared] = useState(false);
   const [commentDraft, setCommentDraft] = useState("");
   const [comments, setComments] = useState(currentRun?.comments ?? []);
+  const [commentLikeState, setCommentLikeState] = useState<Record<string, boolean>>({});
   const [openMenuRunId, setOpenMenuRunId] = useState<string | null>(null);
   const [compareQueuedRunId, setCompareQueuedRunId] = useState<string | null>(null);
   const [syncPlaying, setSyncPlaying] = useState(false);
@@ -593,6 +595,7 @@ export function RecordDetailPage({
     setShared(false);
     setCommentDraft("");
     setComments(currentRun.comments);
+    setCommentLikeState({});
     setOpenMenuRunId(null);
     setCompareQueuedRunId(null);
     setSyncPlaying(false);
@@ -681,6 +684,13 @@ export function RecordDetailPage({
     });
   };
 
+  const toggleCommentLike = (commentId: string) => {
+    setCommentLikeState((previousState) => ({
+      ...previousState,
+      [commentId]: !previousState[commentId],
+    }));
+  };
+
   return (
     <>
       <main className={`bg-[#212121] text-white/90 transition-[width] duration-300 ${mainSurfaceClass}`}>
@@ -766,8 +776,12 @@ export function RecordDetailPage({
                     <div className="truncate text-[16px] font-bold leading-none text-white md:text-[18px]">{currentRun.userName}</div>
                   </div>
                   <div className={`flex gap-[12px] md:gap-[12px] ${compareOpen ? "w-full shrink min-w-0 flex-wrap" : "shrink-0 flex-nowrap"}`}>
-                    <PillButton active={liked} onClick={() => setLiked((previous) => !previous)} className="min-h-[36px] min-w-[92px]">
-                      <LikeIcon className="h-4 w-4" />
+                    <PillButton
+                      active={liked}
+                      onClick={() => setLiked((previous) => !previous)}
+                      className={`min-h-[36px] min-w-[92px] ${liked ? "border border-white/10 bg-[#272727] text-white/90 hover:bg-[#303030]" : ""}`}
+                    >
+                      <LikeIcon filled={liked} className={`h-4 w-4 ${liked ? DETAIL_LIKE_ACTIVE_ICON_CLASS : ""}`} />
                       <span>いいね</span>
                     </PillButton>
                     <PillButton active={shared} onClick={() => setShared((previous) => !previous)} className="min-h-[36px] min-w-[92px]">
@@ -839,8 +853,8 @@ export function RecordDetailPage({
                       </div>
                       <div className={`leading-[1.75] text-white/74 ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>{comment.body}</div>
                       <div className={`flex gap-[12px] md:gap-[12px] ${compareOpen ? "w-full shrink min-w-0 flex-wrap" : "shrink-0 flex-nowrap"}`}>
-                        <PillButton className="px-[8px] py-[4px] text-[11px] md:text-[12px]">
-                          <LikeIcon className="h-3 w-3" />
+                        <PillButton className="px-[8px] py-[4px] text-[11px] md:text-[12px]" onClick={() => toggleCommentLike(comment.id)}>
+                          <LikeIcon filled={Boolean(commentLikeState[comment.id])} className={`h-3 w-3 ${commentLikeState[comment.id] ? DETAIL_LIKE_ACTIVE_ICON_CLASS : ""}`} />
                           <span>いいね</span>
                         </PillButton>
                         <PillButton className="px-[8px] py-[4px] text-[11px] md:text-[12px]">返信</PillButton>

--- a/src/components/RunHomePage.tsx
+++ b/src/components/RunHomePage.tsx
@@ -42,8 +42,8 @@ const OFFMETA_PICKUP_LABEL = "\u958b\u62d3\u8005 \u4f7f\u7528\u73875%\u672a\u6e8
 const NO_RESULTS_LABEL = "\u8a18\u9332\u304c\u898b\u3064\u304b\u308a\u307e\u305b\u3093";
 const NO_RESULTS_COPY = "\u6761\u4ef6\u3092\u5909\u66f4\u3059\u308b\u304b\u3001\u65b0\u3057\u3044\u8a18\u9332\u306e\u8ffd\u52a0\u3092\u304a\u5f85\u3061\u304f\u3060\u3055\u3044\u3002";
 const OTHER_RULESET_TABS = ["Npui別", "武器別", "マルチPUI", "マルチUI", "マルチUA"];
-const HOME_SECTION_PANEL_CLASS = "relative overflow-hidden rounded-[20px] bg-[#3d3c3d] drop-shadow-xl";
-const HOME_SECTION_PANEL_INNER_CLASS = "relative z-[1] m-[2px] rounded-[18px] bg-[#323132] text-white/90";
+const HOME_SECTION_PANEL_CLASS = "relative overflow-hidden rounded-[20px] bg-[#323232] drop-shadow-xl";
+const HOME_SECTION_PANEL_INNER_CLASS = "relative z-[1] m-[2px] rounded-[18px] bg-[#282828] text-white/90";
 const HOME_SECTION_TITLE_CLASS = "text-[17px] md:text-[18px] font-bold tracking-[0.01em] text-white";
 const HOME_SECTION_REFLECTION_TOP_CLASS =
   "pointer-events-none absolute inset-x-[18px] top-[1px] h-[22px] rounded-full bg-[linear-gradient(180deg,rgba(255,255,255,0.22),rgba(255,255,255,0.05)_42%,rgba(255,255,255,0))] blur-[10px]";
@@ -719,10 +719,10 @@ function LeaderboardRow({
         </div>
         <div className="hidden items-center gap-3 md:flex">
           <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-            <LikeIcon size={14} className="text-black" />
+            <LikeIcon size={14} className="text-current" />
           </button>
           <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-            <CommentIcon size={14} className="text-black" />
+            <CommentIcon size={14} className="text-current" />
           </button>
           <div className="w-20 text-right text-[22px] font-semibold text-white">{run.time}</div>
           <a
@@ -747,10 +747,10 @@ function LeaderboardRow({
         </div>
         <div className="flex items-center gap-2">
           <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-            <LikeIcon size={13} className="text-black" />
+            <LikeIcon size={13} className="text-current" />
           </button>
           <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-            <CommentIcon size={13} className="text-black" />
+            <CommentIcon size={13} className="text-current" />
           </button>
           <a
             className={HOME_ICON_BUTTON_CLASS}
@@ -966,7 +966,7 @@ function FilterModal({
 }
 
 function HomeShell({ children }: { children: ReactNode }) {
-  return <div className="min-h-screen bg-[#00050D] pb-20 font-sans text-[#333333]">{children}</div>;
+  return <div className="min-h-screen bg-[#212121] pb-20 font-sans text-[#333333]">{children}</div>;
 }
 
 export function RunHomePage({
@@ -1115,7 +1115,7 @@ export function RunHomePage({
           style={{ backgroundImage: `url(${HERO_IMAGE_URL})` }}
           aria-label="Hero visual"
         >
-          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-[#00050D]" />
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-[#212121]" />
           <div className="absolute top-4 left-1/2 -translate-x-1/2 w-[90%] max-w-4xl bg-black/15 backdrop-blur-sm rounded-full border border-white/30 px-4 py-2">
             <div className="flex items-center justify-between text-sm font-medium text-white">
               {[...PRIMARY_RULESET_TABS, OTHER_TAB_LABEL].map((label) => (

--- a/src/components/RunHomePage.tsx
+++ b/src/components/RunHomePage.tsx
@@ -45,6 +45,10 @@ const OTHER_RULESET_TABS = ["Npui別", "武器別", "マルチPUI", "マルチUI
 const HOME_SECTION_PANEL_CLASS = "relative overflow-hidden rounded-[20px] bg-[#3d3c3d] drop-shadow-xl";
 const HOME_SECTION_PANEL_INNER_CLASS = "relative z-[1] m-[2px] rounded-[18px] bg-[#323132] text-white/90";
 const HOME_SECTION_TITLE_CLASS = "text-[17px] md:text-[18px] font-bold tracking-[0.01em] text-white";
+const HOME_SECTION_REFLECTION_TOP_CLASS =
+  "pointer-events-none absolute inset-x-[18px] top-[1px] h-[22px] rounded-full bg-[linear-gradient(180deg,rgba(255,255,255,0.22),rgba(255,255,255,0.05)_42%,rgba(255,255,255,0))] blur-[10px]";
+const HOME_SECTION_REFLECTION_CORNER_CLASS =
+  "pointer-events-none absolute -left-[10%] -top-[24%] h-44 w-72 rounded-full bg-white/52 blur-[60px]";
 const HOME_ICON_BUTTON_CLASS =
   "flex h-8 w-8 items-center justify-center rounded-full border border-white/12 bg-white/[0.08] text-white/78 transition-colors hover:bg-white/[0.14] hover:text-white";
 const HOME_PRIMARY_BUTTON_CLASS =
@@ -1172,7 +1176,8 @@ export function RunHomePage({
               <div className="relative">
                 <div ref={topRowRef} className="flex gap-5 overflow-x-auto no-scrollbar" onScroll={updateTopScrollButtons}>
                   <div className={`${HOME_SECTION_PANEL_CLASS} min-w-[820px] flex-shrink-0`}>
-                    <div className="pointer-events-none absolute h-48 w-56 -left-1/2 -top-1/2 bg-white blur-[50px]" />
+                    <div className={HOME_SECTION_REFLECTION_TOP_CLASS} />
+                    <div className={HOME_SECTION_REFLECTION_CORNER_CLASS} />
                     <div className={`${HOME_SECTION_PANEL_INNER_CLASS} p-5`}>
                       <div className={`${HOME_SECTION_TITLE_CLASS} mb-4`}>{TOP_PLAYERS_LABEL}</div>
                       <div className="grid min-w-[860px] grid-cols-4 gap-5">
@@ -1200,7 +1205,8 @@ export function RunHomePage({
                   </div>
 
                   <div className={`${HOME_SECTION_PANEL_CLASS} min-w-[300px] flex-shrink-0`}>
-                    <div className="pointer-events-none absolute h-48 w-56 -left-1/2 -top-1/2 bg-white blur-[50px]" />
+                    <div className={HOME_SECTION_REFLECTION_TOP_CLASS} />
+                    <div className={HOME_SECTION_REFLECTION_CORNER_CLASS} />
                     <div className={`${HOME_SECTION_PANEL_INNER_CLASS} p-5`}>
                       <div className={`${HOME_SECTION_TITLE_CLASS} mb-4`}>{FEATURED_PLAYERS_LABEL}</div>
                       <div className="space-y-3">
@@ -1291,7 +1297,8 @@ export function RunHomePage({
             </div>
 
             <div ref={leaderboardRef} className={`${HOME_SECTION_PANEL_CLASS} mb-10`}>
-              <div className="pointer-events-none absolute h-48 w-56 -left-1/2 -top-1/2 bg-white blur-[50px]" />
+              <div className={HOME_SECTION_REFLECTION_TOP_CLASS} />
+              <div className={HOME_SECTION_REFLECTION_CORNER_CLASS} />
               <div className={`${HOME_SECTION_PANEL_INNER_CLASS} p-5 md:p-6`}>
                 <div className="mb-5 text-[18px] font-bold tracking-[0.01em] text-white md:text-[20px]">{LEADERBOARD_LABEL}</div>
                 <div className="mb-5 flex items-center justify-center">

--- a/src/components/RunHomePage.tsx
+++ b/src/components/RunHomePage.tsx
@@ -51,6 +51,7 @@ const HOME_SECTION_REFLECTION_CORNER_CLASS =
   "pointer-events-none absolute -left-[10%] -top-[24%] h-44 w-72 rounded-full bg-white/52 blur-[60px]";
 const HOME_ICON_BUTTON_CLASS =
   "flex h-8 w-8 items-center justify-center rounded-full border border-white/12 bg-white/[0.08] text-white/78 transition-colors hover:bg-white/[0.14] hover:text-white";
+const HOME_LIKE_ACTIVE_ICON_CLASS = "text-[#ff8ea1]";
 const HOME_PRIMARY_BUTTON_CLASS =
   "inline-flex h-10 items-center justify-center rounded-full border border-white/12 bg-white/[0.08] px-4 text-[13px] font-semibold tracking-[0.01em] text-white transition-colors hover:bg-white/[0.14]";
 
@@ -437,11 +438,12 @@ function TimerIcon({ size = 16, className = "" }: { size?: number; className?: s
   );
 }
 
-function LikeIcon({ size = 16, className = "" }: { size?: number; className?: string }) {
+function LikeIcon({ size = 16, className = "", filled = false }: { size?: number; className?: string; filled?: boolean }) {
   return (
     <svg width={size} height={size} viewBox="0 0 24 24" fill="none" className={className} aria-hidden="true">
       <path
         d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"
+        fill={filled ? "currentColor" : "none"}
         stroke="currentColor"
         strokeWidth="2"
         strokeLinecap="round"
@@ -598,12 +600,16 @@ function TopPlayerCard({
   label,
   run,
   theme,
+  liked,
+  onToggleLike,
   onView,
   onSelect,
 }: {
   label: string;
   run: HomeRun | null;
   theme: { gradient: string };
+  liked: boolean;
+  onToggleLike: () => void;
   onView: () => void;
   onSelect: (runId: string) => void;
 }) {
@@ -643,8 +649,15 @@ function TopPlayerCard({
       </div>
       <div className="relative z-10 flex flex-1 flex-col gap-4 bg-[#323132] p-4 text-white/90">
         <div className="flex items-center justify-end gap-2 text-white">
-          <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-            <LikeIcon size={14} className="text-current" />
+          <button
+            type="button"
+            className={HOME_ICON_BUTTON_CLASS}
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleLike();
+            }}
+          >
+            <LikeIcon size={14} filled={liked} className={liked ? HOME_LIKE_ACTIVE_ICON_CLASS : "text-current"} />
           </button>
           <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
             <CommentIcon size={14} className="text-current" />
@@ -682,10 +695,14 @@ function TopPlayerCard({
 function LeaderboardRow({
   run,
   index,
+  liked,
+  onToggleLike,
   onSelect,
 }: {
   run: HomeRun;
   index: number;
+  liked: boolean;
+  onToggleLike: () => void;
   onSelect: (runId: string) => void;
 }) {
   const PlatformIcon = PLATFORM_ICONS[run.platform] ?? PLATFORM_ICONS.PC;
@@ -718,8 +735,15 @@ function LeaderboardRow({
           </div>
         </div>
         <div className="hidden items-center gap-3 md:flex">
-          <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-            <LikeIcon size={14} className="text-current" />
+          <button
+            type="button"
+            className={HOME_ICON_BUTTON_CLASS}
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleLike();
+            }}
+          >
+            <LikeIcon size={14} filled={liked} className={liked ? HOME_LIKE_ACTIVE_ICON_CLASS : "text-current"} />
           </button>
           <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
             <CommentIcon size={14} className="text-current" />
@@ -746,8 +770,15 @@ function LeaderboardRow({
           </div>
         </div>
         <div className="flex items-center gap-2">
-          <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-            <LikeIcon size={13} className="text-current" />
+          <button
+            type="button"
+            className={HOME_ICON_BUTTON_CLASS}
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleLike();
+            }}
+          >
+            <LikeIcon size={13} filled={liked} className={liked ? HOME_LIKE_ACTIVE_ICON_CLASS : "text-current"} />
           </button>
           <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
             <CommentIcon size={13} className="text-current" />
@@ -1000,6 +1031,7 @@ export function RunHomePage({
   const [isOtherMenuOpen, setIsOtherMenuOpen] = useState(false);
   const [showTopScrollLeft, setShowTopScrollLeft] = useState(false);
   const [showTopScrollRight, setShowTopScrollRight] = useState(false);
+  const [likedRunState, setLikedRunState] = useState<Record<string, boolean>>({});
   const activeSeason = selectedSeason ?? activeSeasonInternal;
   const setActiveSeason = onSelectedSeasonChange ?? setActiveSeasonInternal;
 
@@ -1061,6 +1093,13 @@ export function RunHomePage({
 
   const openRunDetail = (runId: string) => {
     onSelectRun(runId);
+  };
+
+  const toggleHomeLike = (runId: string) => {
+    setLikedRunState((previous) => ({
+      ...previous,
+      [runId]: !previous[runId],
+    }));
   };
 
   return (
@@ -1186,20 +1225,30 @@ export function RunHomePage({
                           { label: "High 1st", bracket: 3 as Bracket, theme: { gradient: "from-[#2c3e3d] to-[#1e2c2b]" } },
                           { label: "Middle 1st", bracket: 2 as Bracket, theme: { gradient: "from-[#3d2a4a] to-[#2b1f35]" } },
                           { label: "Low 1st", bracket: 1 as Bracket, theme: { gradient: "from-[#4a3528] to-[#2f231c]" } },
-                        ].map((item) => (
-                          <TopPlayerCard
-                            key={item.label}
-                            label={item.label}
-                            run={getBestRun(heroRuns.filter((run) => run.bracket === item.bracket))}
-                            theme={item.theme}
-                            onView={() => {
-                              setFilterBracket(item.bracket);
-                              setLeaderboardView("rta");
-                              scrollToLeaderboard();
-                            }}
-                            onSelect={openRunDetail}
-                          />
-                        ))}
+                        ].map((item) => {
+                          const topRun = getBestRun(heroRuns.filter((run) => run.bracket === item.bracket));
+
+                          return (
+                            <TopPlayerCard
+                              key={item.label}
+                              label={item.label}
+                              run={topRun}
+                              theme={item.theme}
+                              liked={Boolean(topRun && likedRunState[topRun.id])}
+                              onToggleLike={() => {
+                                if (topRun) {
+                                  toggleHomeLike(topRun.id);
+                                }
+                              }}
+                              onView={() => {
+                                setFilterBracket(item.bracket);
+                                setLeaderboardView("rta");
+                                scrollToLeaderboard();
+                              }}
+                              onSelect={openRunDetail}
+                            />
+                          );
+                        })}
                       </div>
                     </div>
                   </div>
@@ -1213,50 +1262,65 @@ export function RunHomePage({
                         {[
                           { title: FIRST_POST_LABEL, run: getBestRun(heroRuns.filter((run) => run.tags.includes("New"))) },
                           { title: OFFMETA_PICKUP_LABEL, run: getBestRun(heroRuns.filter((run) => run.tags.includes("OffMeta"))) },
-                        ].map((item) => (
-                          <div
-                            key={item.title}
-                            className="relative cursor-pointer overflow-hidden rounded-[16px] border border-[#4a494b] bg-[#323132] p-4 shadow-[0_12px_24px_rgba(0,0,0,0.24)] transition-transform hover:-translate-y-0.5 hover:shadow-[0_16px_30px_rgba(0,0,0,0.3)]"
-                            onClick={() => {
-                              if (item.run) {
-                                openRunDetail(item.run.id);
-                              }
-                            }}
-                          >
-                            <div className="absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-white/10 to-transparent pointer-events-none" />
-                            <div className="pr-8 text-[15px] font-semibold leading-snug text-white">{item.title}</div>
-                            {item.run ? (
-                              <div className="mt-3 space-y-3">
-                                <div className="text-[14px] font-semibold text-white/88">{item.run.userName}</div>
-                                <div className="space-y-3">
-                                  <div className="flex items-center justify-end gap-2 text-white">
-                                    <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-                                      <LikeIcon size={14} className="text-current" />
-                                    </button>
-                                    <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-                                      <CommentIcon size={14} className="text-current" />
-                                    </button>
-                                  </div>
-                                  <div className="rounded-[12px] border border-white/10 bg-white/[0.08] p-3">
-                                    <div className="flex items-center gap-2.5">
-                                      {item.run.party.map((member, index) => (
-                                        <CharacterImage
-                                          key={`${item.run?.id}-${member.characterId}-${index}`}
-                                          characterId={member.characterId}
-                                          alt={characterDb[member.characterId]?.name ?? member.characterId}
-                                          variant="circle"
-                                          className="h-9 w-9 rounded-full object-cover"
+                        ].map((item) => {
+                          const featuredRun = item.run;
+
+                          return (
+                            <div
+                              key={item.title}
+                              className="relative cursor-pointer overflow-hidden rounded-[16px] border border-[#4a494b] bg-[#323132] p-4 shadow-[0_12px_24px_rgba(0,0,0,0.24)] transition-transform hover:-translate-y-0.5 hover:shadow-[0_16px_30px_rgba(0,0,0,0.3)]"
+                              onClick={() => {
+                                if (featuredRun) {
+                                  openRunDetail(featuredRun.id);
+                                }
+                              }}
+                            >
+                              <div className="absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-white/10 to-transparent pointer-events-none" />
+                              <div className="pr-8 text-[15px] font-semibold leading-snug text-white">{item.title}</div>
+                              {featuredRun ? (
+                                <div className="mt-3 space-y-3">
+                                  <div className="text-[14px] font-semibold text-white/88">{featuredRun.userName}</div>
+                                  <div className="space-y-3">
+                                    <div className="flex items-center justify-end gap-2 text-white">
+                                      <button
+                                        type="button"
+                                        className={HOME_ICON_BUTTON_CLASS}
+                                        onClick={(event) => {
+                                          event.stopPropagation();
+                                          toggleHomeLike(featuredRun.id);
+                                        }}
+                                      >
+                                        <LikeIcon
+                                          size={14}
+                                          filled={Boolean(likedRunState[featuredRun.id])}
+                                          className={likedRunState[featuredRun.id] ? HOME_LIKE_ACTIVE_ICON_CLASS : "text-current"}
                                         />
-                                      ))}
+                                      </button>
+                                      <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
+                                        <CommentIcon size={14} className="text-current" />
+                                      </button>
+                                    </div>
+                                    <div className="rounded-[12px] border border-white/10 bg-white/[0.08] p-3">
+                                      <div className="flex items-center gap-2.5">
+                                        {featuredRun.party.map((member, index) => (
+                                          <CharacterImage
+                                            key={`${featuredRun.id}-${member.characterId}-${index}`}
+                                            characterId={member.characterId}
+                                            alt={characterDb[member.characterId]?.name ?? member.characterId}
+                                            variant="circle"
+                                            className="h-9 w-9 rounded-full object-cover"
+                                          />
+                                        ))}
+                                      </div>
                                     </div>
                                   </div>
                                 </div>
-                              </div>
-                            ) : (
-                              <div className="mt-2 text-sm text-white/55">{LOADING_LABEL}</div>
-                            )}
-                          </div>
-                        ))}
+                              ) : (
+                                <div className="mt-2 text-sm text-white/55">{LOADING_LABEL}</div>
+                              )}
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
                   </div>
@@ -1358,7 +1422,7 @@ export function RunHomePage({
               </div>
               <div>
                 {leaderboardRuns.map((run, index) => (
-                  <LeaderboardRow key={run.id} run={run} index={index} onSelect={openRunDetail} />
+                  <LeaderboardRow key={run.id} run={run} index={index} liked={Boolean(likedRunState[run.id])} onToggleLike={() => toggleHomeLike(run.id)} onSelect={openRunDetail} />
                 ))}
               </div>
             </div>
@@ -1387,11 +1451,11 @@ export function RunHomePage({
         ) : null}
       </main>
 
-      <footer className="mt-20 border-t border-[#ebebeb] bg-white py-12">
-        <div className="max-w-7xl mx-auto px-4 text-center text-[#909399] text-sm">
-          <div className="flex items-center justify-center gap-2 mb-4 opacity-70">
+      <footer className="mt-20 border-t border-white/10 bg-[#212121] py-12">
+        <div className="max-w-7xl mx-auto px-4 text-center text-sm text-white/52">
+          <div className="mb-4 flex items-center justify-center gap-2 text-white/74">
             <TimerIcon size={20} />
-            <span className="font-bold text-lg">Teyvat EliteDB</span>
+            <span className="text-lg font-bold">Teyvat EliteDB</span>
           </div>
           <p className="mb-2">Community Driven Elite Hunting RTA Database (Prototype)</p>
           <p>Created based on R&apos;s concept &amp; Community Feedback.</p>

--- a/src/components/RunHomePage.tsx
+++ b/src/components/RunHomePage.tsx
@@ -42,12 +42,13 @@ const OFFMETA_PICKUP_LABEL = "\u958b\u62d3\u8005 \u4f7f\u7528\u73875%\u672a\u6e8
 const NO_RESULTS_LABEL = "\u8a18\u9332\u304c\u898b\u3064\u304b\u308a\u307e\u305b\u3093";
 const NO_RESULTS_COPY = "\u6761\u4ef6\u3092\u5909\u66f4\u3059\u308b\u304b\u3001\u65b0\u3057\u3044\u8a18\u9332\u306e\u8ffd\u52a0\u3092\u304a\u5f85\u3061\u304f\u3060\u3055\u3044\u3002";
 const OTHER_RULESET_TABS = ["Npui別", "武器別", "マルチPUI", "マルチUI", "マルチUA"];
-const HOME_SECTION_PANEL_CLASS = "bg-white rounded-[20px] border border-black/10 shadow-sm";
-const HOME_SECTION_TITLE_CLASS = "text-[17px] md:text-[18px] font-bold tracking-[0.01em] text-black";
+const HOME_SECTION_PANEL_CLASS = "relative overflow-hidden rounded-[20px] bg-[#3d3c3d] drop-shadow-xl";
+const HOME_SECTION_PANEL_INNER_CLASS = "relative z-[1] m-[2px] rounded-[18px] bg-[#323132] text-white/90";
+const HOME_SECTION_TITLE_CLASS = "text-[17px] md:text-[18px] font-bold tracking-[0.01em] text-white";
 const HOME_ICON_BUTTON_CLASS =
-  "flex h-8 w-8 items-center justify-center rounded-full border border-[#dcdfe6] bg-white text-black transition-colors hover:bg-black/5";
+  "flex h-8 w-8 items-center justify-center rounded-full border border-white/12 bg-white/[0.08] text-white/78 transition-colors hover:bg-white/[0.14] hover:text-white";
 const HOME_PRIMARY_BUTTON_CLASS =
-  "inline-flex h-10 items-center justify-center rounded-full border border-[#d8dde6] bg-[#f5f6f8] px-4 text-[13px] font-semibold tracking-[0.01em] text-black transition-colors hover:border-[#c8ced8] hover:bg-[#eceff3]";
+  "inline-flex h-10 items-center justify-center rounded-full border border-white/12 bg-white/[0.08] px-4 text-[13px] font-semibold tracking-[0.01em] text-white transition-colors hover:bg-white/[0.14]";
 
 const AMBR_NAME_MAP: Record<string, string> = {
   amber: "Ambor",
@@ -604,14 +605,14 @@ function TopPlayerCard({
 }) {
   if (!run) {
     return (
-      <div className="flex h-full flex-col overflow-hidden rounded-[16px] border border-[#e8eaef] bg-white shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md">
+      <div className="flex h-full flex-col overflow-hidden rounded-[16px] border border-[#4a494b] bg-[#2b2a2b] shadow-[0_12px_24px_rgba(0,0,0,0.28)] transition-all hover:-translate-y-0.5 hover:shadow-[0_16px_30px_rgba(0,0,0,0.32)]">
         <div className={`relative h-24 w-full bg-gradient-to-r ${theme.gradient}`}>
           <div className="absolute top-4 left-4 z-10 space-y-1">
             <div className="text-[17px] font-bold leading-tight tracking-[0.01em] text-white drop-shadow-md md:text-[18px]">{label}</div>
           </div>
         </div>
-        <div className="relative z-10 flex flex-1 flex-col justify-between gap-4 bg-white p-4">
-          <div className="text-sm text-[#606266]">{LOADING_LABEL}</div>
+        <div className="relative z-10 flex flex-1 flex-col justify-between gap-4 bg-[#323132] p-4 text-white/90">
+          <div className="text-sm text-white/55">{LOADING_LABEL}</div>
           <button type="button" onClick={onView} className={`${HOME_PRIMARY_BUTTON_CLASS} w-full`}>
             {VIEW_RANKING_LABEL}
           </button>
@@ -622,7 +623,7 @@ function TopPlayerCard({
 
   return (
     <div
-      className="flex h-full cursor-pointer flex-col overflow-hidden rounded-[16px] border border-[#e8eaef] bg-white shadow-sm transition-all hover:-translate-y-0.5 hover:shadow-md"
+      className="flex h-full cursor-pointer flex-col overflow-hidden rounded-[16px] border border-[#4a494b] bg-[#2b2a2b] shadow-[0_12px_24px_rgba(0,0,0,0.28)] transition-all hover:-translate-y-0.5 hover:shadow-[0_16px_30px_rgba(0,0,0,0.32)]"
       onClick={() => onSelect(run.id)}
     >
       <div className={`relative h-24 w-full bg-gradient-to-r ${theme.gradient}`}>
@@ -636,16 +637,16 @@ function TopPlayerCard({
           className="pointer-events-none absolute -right-5 -bottom-5 z-0 h-auto w-44 object-cover opacity-85 drop-shadow-lg"
         />
       </div>
-      <div className="relative z-10 flex flex-1 flex-col gap-4 bg-white p-4">
-        <div className="flex items-center justify-end gap-2 text-black">
+      <div className="relative z-10 flex flex-1 flex-col gap-4 bg-[#323132] p-4 text-white/90">
+        <div className="flex items-center justify-end gap-2 text-white">
           <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-            <LikeIcon size={14} className="text-black" />
+            <LikeIcon size={14} className="text-current" />
           </button>
           <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-            <CommentIcon size={14} className="text-black" />
+            <CommentIcon size={14} className="text-current" />
           </button>
         </div>
-        <div className="rounded-[12px] border border-[#eceff3] bg-[#f7f8fa] p-3">
+        <div className="rounded-[12px] border border-white/10 bg-white/[0.08] p-3">
           <div className="flex items-center justify-between gap-2">
             {run.party.map((member, index) => (
               <CharacterImage
@@ -657,7 +658,7 @@ function TopPlayerCard({
               />
             ))}
           </div>
-          <div className="mt-3 text-center text-[24px] font-semibold leading-none text-black">{run.time}</div>
+          <div className="mt-3 text-center text-[24px] font-semibold leading-none text-white">{run.time}</div>
         </div>
         <button
           type="button"
@@ -686,13 +687,13 @@ function LeaderboardRow({
   const PlatformIcon = PLATFORM_ICONS[run.platform] ?? PLATFORM_ICONS.PC;
 
   return (
-    <div className="cursor-pointer border-t border-[#ebebeb] py-4" onClick={() => onSelect(run.id)}>
+    <div className="cursor-pointer border-t border-white/10 py-4 text-white/90" onClick={() => onSelect(run.id)}>
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div className="flex min-w-0 items-center gap-3 md:gap-5">
-          <div className="flex w-6 items-center justify-center text-black/70">
+          <div className="flex w-6 items-center justify-center text-white/45">
             <RankMoveIcon move={run.rankMove} className="h-5 w-5" />
           </div>
-          <div className="w-9 text-center text-[20px] font-semibold md:w-10 md:text-[22px]">{index + 1}</div>
+          <div className="w-9 text-center text-[20px] font-semibold text-white md:w-10 md:text-[22px]">{index + 1}</div>
           <CharacterImage
             characterId={run.mainAttackerId}
             alt={characterDb[run.mainAttackerId]?.name ?? run.mainAttackerId}
@@ -701,15 +702,15 @@ function LeaderboardRow({
           />
           <div className="min-w-0 flex-1">
             <div className="flex min-w-0 items-center gap-2">
-              <div className="truncate text-[17px] font-semibold md:text-[19px]">{run.userName}</div>
-              <div className="hidden rounded-full border border-black/10 bg-black/[0.04] px-2.5 py-1 text-[11px] font-medium md:inline-flex">
+              <div className="truncate text-[17px] font-semibold text-white md:text-[19px]">{run.userName}</div>
+              <div className="hidden rounded-full border border-white/12 bg-white/[0.08] px-2.5 py-1 text-[11px] font-medium text-white/72 md:inline-flex">
                 {getBracketLabel(run.bracket)}
               </div>
             </div>
           </div>
-          <div className="ml-auto text-[20px] font-semibold md:hidden">{run.time}</div>
-          <div className="hidden h-9 w-9 items-center justify-center rounded-full border border-black/10 bg-black/[0.04] md:flex">
-            <PlatformIcon className="h-[18px] w-[18px] text-black" />
+          <div className="ml-auto text-[20px] font-semibold text-white md:hidden">{run.time}</div>
+          <div className="hidden h-9 w-9 items-center justify-center rounded-full border border-white/12 bg-white/[0.08] md:flex">
+            <PlatformIcon className="h-[18px] w-[18px] text-white/78" />
           </div>
         </div>
         <div className="hidden items-center gap-3 md:flex">
@@ -719,7 +720,7 @@ function LeaderboardRow({
           <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
             <CommentIcon size={14} className="text-black" />
           </button>
-          <div className="w-20 text-right text-[22px] font-semibold">{run.time}</div>
+          <div className="w-20 text-right text-[22px] font-semibold text-white">{run.time}</div>
           <a
             className={HOME_ICON_BUTTON_CLASS}
             href={run.videoUrl}
@@ -735,9 +736,9 @@ function LeaderboardRow({
       </div>
       <div className="mt-2 flex items-center justify-between gap-3 md:hidden">
         <div className="flex items-center gap-2">
-          <div className="rounded-full border border-black/10 bg-black/[0.04] px-2 py-0.5 text-[11px] font-medium">{getBracketLabel(run.bracket)}</div>
-          <div className="flex h-8 w-8 items-center justify-center rounded-full border border-black/10 bg-black/[0.04]">
-            <PlatformIcon className="h-3.5 w-3.5 text-black" />
+          <div className="rounded-full border border-white/12 bg-white/[0.08] px-2 py-0.5 text-[11px] font-medium text-white/72">{getBracketLabel(run.bracket)}</div>
+          <div className="flex h-8 w-8 items-center justify-center rounded-full border border-white/12 bg-white/[0.08]">
+            <PlatformIcon className="h-3.5 w-3.5 text-white/78" />
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -961,7 +962,7 @@ function FilterModal({
 }
 
 function HomeShell({ children }: { children: ReactNode }) {
-  return <div className="min-h-screen text-[#333333] font-sans pb-20 bg-[#f0f2f5]">{children}</div>;
+  return <div className="min-h-screen bg-[#00050D] pb-20 font-sans text-[#333333]">{children}</div>;
 }
 
 export function RunHomePage({
@@ -1110,7 +1111,7 @@ export function RunHomePage({
           style={{ backgroundImage: `url(${HERO_IMAGE_URL})` }}
           aria-label="Hero visual"
         >
-          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-[#f0f2f5]" />
+          <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-[#00050D]" />
           <div className="absolute top-4 left-1/2 -translate-x-1/2 w-[90%] max-w-4xl bg-black/15 backdrop-blur-sm rounded-full border border-white/30 px-4 py-2">
             <div className="flex items-center justify-between text-sm font-medium text-white">
               {[...PRIMARY_RULESET_TABS, OTHER_TAB_LABEL].map((label) => (
@@ -1170,79 +1171,87 @@ export function RunHomePage({
             <div className="relative z-10 -mt-40 md:-mt-72 mb-12">
               <div className="relative">
                 <div ref={topRowRef} className="flex gap-5 overflow-x-auto no-scrollbar" onScroll={updateTopScrollButtons}>
-                  <div className={`${HOME_SECTION_PANEL_CLASS} min-w-[820px] flex-shrink-0 p-5`}>
-                    <div className={`${HOME_SECTION_TITLE_CLASS} mb-4`}>{TOP_PLAYERS_LABEL}</div>
-                    <div className="grid min-w-[860px] grid-cols-4 gap-5">
-                      {[
-                        { label: "Unlimited 1st", bracket: 4 as Bracket, theme: { gradient: "from-[#274060] to-[#1b2f45]" } },
-                        { label: "High 1st", bracket: 3 as Bracket, theme: { gradient: "from-[#2c3e3d] to-[#1e2c2b]" } },
-                        { label: "Middle 1st", bracket: 2 as Bracket, theme: { gradient: "from-[#3d2a4a] to-[#2b1f35]" } },
-                        { label: "Low 1st", bracket: 1 as Bracket, theme: { gradient: "from-[#4a3528] to-[#2f231c]" } },
-                      ].map((item) => (
-                        <TopPlayerCard
-                          key={item.label}
-                          label={item.label}
-                          run={getBestRun(heroRuns.filter((run) => run.bracket === item.bracket))}
-                          theme={item.theme}
-                          onView={() => {
-                            setFilterBracket(item.bracket);
-                            setLeaderboardView("rta");
-                            scrollToLeaderboard();
-                          }}
-                          onSelect={openRunDetail}
-                        />
-                      ))}
+                  <div className={`${HOME_SECTION_PANEL_CLASS} min-w-[820px] flex-shrink-0`}>
+                    <div className="pointer-events-none absolute h-48 w-56 -left-1/2 -top-1/2 bg-white blur-[50px]" />
+                    <div className={`${HOME_SECTION_PANEL_INNER_CLASS} p-5`}>
+                      <div className={`${HOME_SECTION_TITLE_CLASS} mb-4`}>{TOP_PLAYERS_LABEL}</div>
+                      <div className="grid min-w-[860px] grid-cols-4 gap-5">
+                        {[
+                          { label: "Unlimited 1st", bracket: 4 as Bracket, theme: { gradient: "from-[#274060] to-[#1b2f45]" } },
+                          { label: "High 1st", bracket: 3 as Bracket, theme: { gradient: "from-[#2c3e3d] to-[#1e2c2b]" } },
+                          { label: "Middle 1st", bracket: 2 as Bracket, theme: { gradient: "from-[#3d2a4a] to-[#2b1f35]" } },
+                          { label: "Low 1st", bracket: 1 as Bracket, theme: { gradient: "from-[#4a3528] to-[#2f231c]" } },
+                        ].map((item) => (
+                          <TopPlayerCard
+                            key={item.label}
+                            label={item.label}
+                            run={getBestRun(heroRuns.filter((run) => run.bracket === item.bracket))}
+                            theme={item.theme}
+                            onView={() => {
+                              setFilterBracket(item.bracket);
+                              setLeaderboardView("rta");
+                              scrollToLeaderboard();
+                            }}
+                            onSelect={openRunDetail}
+                          />
+                        ))}
+                      </div>
                     </div>
                   </div>
 
-                  <div className={`${HOME_SECTION_PANEL_CLASS} min-w-[300px] flex-shrink-0 p-5`}>
-                    <div className={`${HOME_SECTION_TITLE_CLASS} mb-4`}>{FEATURED_PLAYERS_LABEL}</div>
-                    <div className="space-y-3">
-                      {[
-                        { title: FIRST_POST_LABEL, run: getBestRun(heroRuns.filter((run) => run.tags.includes("New"))) },
-                        { title: OFFMETA_PICKUP_LABEL, run: getBestRun(heroRuns.filter((run) => run.tags.includes("OffMeta"))) },
-                      ].map((item) => (
-                        <div
-                          key={item.title}
-                          className="relative cursor-pointer overflow-hidden rounded-[16px] border border-black/10 bg-[#fcfcfd] p-4 shadow-sm transition-transform hover:-translate-y-0.5 hover:shadow-md"
-                          onClick={() => {
-                            if (item.run) {
-                              openRunDetail(item.run.id);
-                            }
-                          }}
-                        >
-                          <div className="absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-black/5 to-transparent pointer-events-none" />
-                          <div className="pr-8 text-[15px] font-semibold leading-snug text-black">{item.title}</div>
-                          {item.run ? (
-                            <div className="mt-3 space-y-3">
-                              <div className="text-[14px] font-semibold text-black">{item.run.userName}</div>
-                              <div className="space-y-3">
-                                <div className="flex items-center justify-end gap-2 text-black">
-                                  <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-                                    <LikeIcon size={14} className="text-black" />
-                                  </button>
-                                  <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
-                                    <CommentIcon size={14} className="text-black" />
-                                  </button>
-                                </div>
-                                <div className="flex items-center gap-2.5">
-                                  {item.run.party.map((member, index) => (
-                                    <CharacterImage
-                                      key={`${item.run?.id}-${member.characterId}-${index}`}
-                                      characterId={member.characterId}
-                                      alt={characterDb[member.characterId]?.name ?? member.characterId}
-                                      variant="circle"
-                                      className="h-9 w-9 rounded-full object-cover"
-                                    />
-                                  ))}
+                  <div className={`${HOME_SECTION_PANEL_CLASS} min-w-[300px] flex-shrink-0`}>
+                    <div className="pointer-events-none absolute h-48 w-56 -left-1/2 -top-1/2 bg-white blur-[50px]" />
+                    <div className={`${HOME_SECTION_PANEL_INNER_CLASS} p-5`}>
+                      <div className={`${HOME_SECTION_TITLE_CLASS} mb-4`}>{FEATURED_PLAYERS_LABEL}</div>
+                      <div className="space-y-3">
+                        {[
+                          { title: FIRST_POST_LABEL, run: getBestRun(heroRuns.filter((run) => run.tags.includes("New"))) },
+                          { title: OFFMETA_PICKUP_LABEL, run: getBestRun(heroRuns.filter((run) => run.tags.includes("OffMeta"))) },
+                        ].map((item) => (
+                          <div
+                            key={item.title}
+                            className="relative cursor-pointer overflow-hidden rounded-[16px] border border-[#4a494b] bg-[#323132] p-4 shadow-[0_12px_24px_rgba(0,0,0,0.24)] transition-transform hover:-translate-y-0.5 hover:shadow-[0_16px_30px_rgba(0,0,0,0.3)]"
+                            onClick={() => {
+                              if (item.run) {
+                                openRunDetail(item.run.id);
+                              }
+                            }}
+                          >
+                            <div className="absolute top-0 left-0 right-0 h-8 bg-gradient-to-b from-white/10 to-transparent pointer-events-none" />
+                            <div className="pr-8 text-[15px] font-semibold leading-snug text-white">{item.title}</div>
+                            {item.run ? (
+                              <div className="mt-3 space-y-3">
+                                <div className="text-[14px] font-semibold text-white/88">{item.run.userName}</div>
+                                <div className="space-y-3">
+                                  <div className="flex items-center justify-end gap-2 text-white">
+                                    <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
+                                      <LikeIcon size={14} className="text-current" />
+                                    </button>
+                                    <button type="button" className={HOME_ICON_BUTTON_CLASS} onClick={(event) => event.stopPropagation()}>
+                                      <CommentIcon size={14} className="text-current" />
+                                    </button>
+                                  </div>
+                                  <div className="rounded-[12px] border border-white/10 bg-white/[0.08] p-3">
+                                    <div className="flex items-center gap-2.5">
+                                      {item.run.party.map((member, index) => (
+                                        <CharacterImage
+                                          key={`${item.run?.id}-${member.characterId}-${index}`}
+                                          characterId={member.characterId}
+                                          alt={characterDb[member.characterId]?.name ?? member.characterId}
+                                          variant="circle"
+                                          className="h-9 w-9 rounded-full object-cover"
+                                        />
+                                      ))}
+                                    </div>
+                                  </div>
                                 </div>
                               </div>
-                            </div>
-                          ) : (
-                            <div className="mt-2 text-sm text-[#606266]">{LOADING_LABEL}</div>
-                          )}
-                        </div>
-                      ))}
+                            ) : (
+                              <div className="mt-2 text-sm text-white/55">{LOADING_LABEL}</div>
+                            )}
+                          </div>
+                        ))}
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -1281,40 +1290,42 @@ export function RunHomePage({
               </div>
             </div>
 
-            <div ref={leaderboardRef} className={`${HOME_SECTION_PANEL_CLASS} mb-10 p-5 md:p-6`}>
-              <div className="mb-5 text-[18px] font-bold tracking-[0.01em] text-black md:text-[20px]">{LEADERBOARD_LABEL}</div>
-              <div className="mb-5 flex items-center justify-center">
-                <div className="flex items-center border border-[#dcdfe6] rounded-full overflow-hidden w-full max-w-[520px] md:min-w-[520px]">
-                  {[
-                    { key: "rta", label: "RTAランキング", shortLabel: "RTA" },
-                    { key: "char", label: "キャラTOPプレイヤー", shortLabel: "キャラTOP" },
-                    { key: "fes", label: "祭典フェス", shortLabel: "フェス" },
-                  ].map((item) => (
-                    <button
-                      key={item.key}
-                      type="button"
-                      onClick={() => setLeaderboardView(item.key as "rta" | "char" | "fes")}
-                      className={`flex-1 px-4 py-2.5 text-[13px] font-semibold transition-colors md:text-[14px] ${
-                        leaderboardView === item.key ? "bg-black text-white" : "bg-white text-black"
-                      }`}
-                      title={item.label}
-                      aria-label={item.label}
-                    >
-                      <span className="md:hidden">{item.shortLabel}</span>
-                      <span className="hidden md:inline">{item.label}</span>
-                    </button>
-                  ))}
+            <div ref={leaderboardRef} className={`${HOME_SECTION_PANEL_CLASS} mb-10`}>
+              <div className="pointer-events-none absolute h-48 w-56 -left-1/2 -top-1/2 bg-white blur-[50px]" />
+              <div className={`${HOME_SECTION_PANEL_INNER_CLASS} p-5 md:p-6`}>
+                <div className="mb-5 text-[18px] font-bold tracking-[0.01em] text-white md:text-[20px]">{LEADERBOARD_LABEL}</div>
+                <div className="mb-5 flex items-center justify-center">
+                  <div className="flex items-center overflow-hidden rounded-full border border-white/12 bg-[#262526]/70 w-full max-w-[520px] md:min-w-[520px]">
+                    {[
+                      { key: "rta", label: "RTAランキング", shortLabel: "RTA" },
+                      { key: "char", label: "キャラTOPプレイヤー", shortLabel: "キャラTOP" },
+                      { key: "fes", label: "祭典フェス", shortLabel: "フェス" },
+                    ].map((item) => (
+                      <button
+                        key={item.key}
+                        type="button"
+                        onClick={() => setLeaderboardView(item.key as "rta" | "char" | "fes")}
+                        className={`flex-1 px-4 py-2.5 text-[13px] font-semibold transition-colors md:text-[14px] ${
+                          leaderboardView === item.key ? "bg-white text-[#1f1f20]" : "bg-transparent text-white/68 hover:bg-white/8 hover:text-white"
+                        }`}
+                        title={item.label}
+                        aria-label={item.label}
+                      >
+                        <span className="md:hidden">{item.shortLabel}</span>
+                        <span className="hidden md:inline">{item.label}</span>
+                      </button>
+                    ))}
+                  </div>
                 </div>
-              </div>
-              <div className="mb-4 flex items-center">
-                <button
-                  type="button"
-                  className="flex h-10 w-10 items-center justify-center rounded-full border border-[#dcdfe6] transition-colors hover:bg-black/5"
-                  onClick={() => setIsFilterOpen(true)}
-                >
-                  <FilterFunnelIcon className="w-5 h-5 text-black" />
-                </button>
-              </div>
+                <div className="mb-4 flex items-center">
+                  <button
+                    type="button"
+                    className="flex h-10 w-10 items-center justify-center rounded-full border border-white/12 text-white/78 transition-colors hover:bg-white/10 hover:text-white"
+                    onClick={() => setIsFilterOpen(true)}
+                  >
+                    <FilterFunnelIcon className="w-5 h-5" />
+                  </button>
+                </div>
               <div className="mb-5 flex items-center justify-between text-[13px] font-semibold md:text-[14px]">
                 {[
                   { label: ALL_LABEL, shortLabel: ALL_LABEL, value: null },
@@ -1329,8 +1340,8 @@ export function RunHomePage({
                     onClick={() => setFilterBracket(item.value)}
                     className={`flex-1 border-b-2 pb-3 text-center ${
                       filterBracket === item.value || (item.value === null && filterBracket === null)
-                        ? "border-black text-black"
-                        : "border-transparent text-[#909399] hover:text-black"
+                        ? "border-white text-white"
+                        : "border-transparent text-white/38 hover:text-white/72"
                     }`}
                   >
                     <span className="md:hidden">{item.shortLabel}</span>
@@ -1343,6 +1354,7 @@ export function RunHomePage({
                   <LeaderboardRow key={run.id} run={run} index={index} onSelect={openRunDetail} />
                 ))}
               </div>
+            </div>
             </div>
           </>
         ) : null}

--- a/src/components/RunSubmitPage.tsx
+++ b/src/components/RunSubmitPage.tsx
@@ -1636,8 +1636,8 @@ export function RunSubmitPage({ onBack, embedded = false }: { onBack: () => void
 
                 <label className="block">
                   <FieldTitle quiet>タイム</FieldTitle>
-                  <div className="mt-2 flex items-center gap-2 md:gap-3">
-                    <MockFieldBox className="w-[84px] md:w-[96px]">
+                  <div className="mt-2 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 md:gap-3 md:px-8">
+                    <MockFieldBox className="min-w-0">
                       <input
                         value={timeInput.hours}
                         onChange={(event) => updateTimeInput("hours", event.target.value.replace(/[^\d]/g, "").slice(0, 2))}
@@ -1648,7 +1648,7 @@ export function RunSubmitPage({ onBack, embedded = false }: { onBack: () => void
                       />
                     </MockFieldBox>
                     <span className="text-[24px] font-bold text-[#9999b1] md:text-[28px]">:</span>
-                    <MockFieldBox className="w-[108px] md:w-[128px]">
+                    <MockFieldBox className="min-w-0">
                       <input
                         value={timeInput.minutes}
                         onChange={(event) => updateTimeInput("minutes", event.target.value.replace(/[^\d]/g, "").slice(0, 2))}
@@ -1659,7 +1659,7 @@ export function RunSubmitPage({ onBack, embedded = false }: { onBack: () => void
                       />
                     </MockFieldBox>
                     <span className="text-[24px] font-bold text-[#9999b1] md:text-[28px]">:</span>
-                    <MockFieldBox className="w-[108px] md:w-[128px]">
+                    <MockFieldBox className="min-w-0">
                       <input
                         value={timeInput.seconds}
                         onChange={(event) => updateTimeInput("seconds", event.target.value.replace(/[^\d]/g, "").slice(0, 2))}

--- a/src/components/UiIcons.tsx
+++ b/src/components/UiIcons.tsx
@@ -2,12 +2,13 @@ import type { Platform } from "../data/mockRuns";
 
 type IconProps = {
   className?: string;
+  filled?: boolean;
 };
 
-export function LikeIcon({ className = "h-4 w-4" }: IconProps) {
+export function LikeIcon({ className = "h-4 w-4", filled = false }: IconProps) {
   return (
     <svg viewBox="0 0 24 24" className={className} fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-      <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" />
+      <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z" fill={filled ? "currentColor" : "none"} />
     </svg>
   );
 }


### PR DESCRIPTION
## 変更内容
- ホーム画面の上段3ブロックの質感・反射・色味を調整し、背景やフッターをダークトーンで統一しました。
- 記録詳細画面と比較ビューもホーム側のダークトーンに寄せ、概要欄や操作面の配色を整理しました。
- 記録申請画面ではタイム入力欄をコンテナ追従レイアウトに修正し、プレイ人数と同じ左右余白に揃えました。
- ホーム画面と記録詳細画面のいいね操作は、押下時にハートアイコンだけ色付きかつ塗りつぶしになるように統一しました。
- グローバルヘッダー / サイドメニューの背景を黒に寄せ、アイコンやテキスト色の一貫性も合わせています。

## 実装理由
- 今回の変更はレイアウトの作り直しではなく、既存の密度や導線を崩さずに黒基調の質感を整えることを優先しました。
- ホーム上段3ブロックは、外枠・内側面・反射だけを定数で調整し、子カード側には不要な影響を広げない構成にしています。
- いいね表現はボタン全体の状態変化ではなく、アイコンの色と塗りだけを切り替えることで、他のアクションとの役割差を明確にしました。
- タイム入力欄は固定幅をやめ、Step 1 の他フィールドと同じ余白ルールに寄せて、想定外の横幅崩れを防いでいます。

## 確認内容
- `npm run build`