### PR TITLE
home/detailのライト配色を現行UI向けに復帰

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -278,21 +278,36 @@ function DrawerSection({
   routeName,
   onNavigate,
   onExternalSelect,
+  lightChrome,
 }: {
   items: NavItem[];
   routeName: ShellRouteName;
   onNavigate: (route: ShellDestination) => void;
   onExternalSelect: () => void;
+  lightChrome: boolean;
 }) {
   return (
     <div className="flex flex-col gap-4 px-4 py-8 sm:px-6">
       {items.map((item) => {
         const Icon = item.icon;
         const active = item.kind === "route" ? isNavActive(routeName, item.route) : false;
-        const itemClassName = "group flex w-full items-center gap-4 rounded-full px-4 py-3 text-left transition-all hover:bg-[#272727]";
+        const itemClassName = classNames(
+          "group flex w-full items-center gap-4 rounded-full px-4 py-3 text-left transition-all",
+          lightChrome ? "hover:bg-[#f1f3f6]" : "hover:bg-[#272727]",
+        );
         const labelClassName = classNames(
           "whitespace-nowrap text-[20px] transition-colors",
-          active ? "font-bold text-[#d9d9d9]" : "font-normal text-[#d9d9d9] group-hover:text-[#d9d9d9]",
+          lightChrome
+            ? active
+              ? "font-bold text-[#111827]"
+              : "font-normal text-[#4b5563] group-hover:text-[#111827]"
+            : active
+              ? "font-bold text-[#d9d9d9]"
+              : "font-normal text-[#d9d9d9] group-hover:text-[#d9d9d9]",
+        );
+        const iconClassName = classNames(
+          "size-6 shrink-0",
+          lightChrome ? (active ? "text-[#111827]" : "text-[#7b8493]") : active ? "text-[#d9d9d9]" : "text-[#8b95a7]",
         );
 
         if (item.kind === "external") {
@@ -305,7 +320,7 @@ function DrawerSection({
               onClick={onExternalSelect}
               className={itemClassName}
             >
-              <Icon className="size-6 shrink-0 text-[#8b95a7]" />
+              <Icon className={classNames("size-6 shrink-0", lightChrome ? "text-[#7b8493]" : "text-[#8b95a7]")} />
               <span className={labelClassName}>{item.label}</span>
             </a>
           );
@@ -313,7 +328,7 @@ function DrawerSection({
 
         return (
           <button key={item.key} type="button" onClick={() => onNavigate(item.route)} className={itemClassName}>
-            <Icon active={active} className={classNames("size-6 shrink-0", active ? "text-[#d9d9d9]" : "text-[#8b95a7]")} />
+            <Icon active={active} className={iconClassName} />
             <span className={labelClassName}>{item.label}</span>
           </button>
         );
@@ -326,39 +341,44 @@ function DrawerBody({
   routeName,
   onNavigate,
   onClose,
+  lightChrome,
 }: {
   routeName: ShellRouteName;
   onNavigate: (route: ShellDestination) => void;
   onClose: () => void;
+  lightChrome: boolean;
 }) {
   return (
     <>
-      <div className="flex justify-start border-b border-[#343434] px-4 py-8 sm:px-6">
+      <div className={classNames("flex justify-start border-b px-4 py-8 sm:px-6", lightChrome ? "border-[#e5e7eb]" : "border-[#343434]")}>
         <button
           type="button"
           onClick={() => onNavigate("account")}
-          className="flex w-full max-w-[240px] flex-col gap-3 rounded-[24px] p-3 text-left transition-colors hover:bg-[#272727]"
+          className={classNames(
+            "flex w-full max-w-[240px] flex-col gap-3 rounded-[24px] p-3 text-left transition-colors",
+            lightChrome ? "hover:bg-[#f1f3f6]" : "hover:bg-[#272727]",
+          )}
         >
           <div className="flex items-center justify-between gap-4">
             <div className="relative flex size-[36px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#d9d9d9]">
               <UserIcon className="size-5 text-gray-500" />
             </div>
-            <span className="rounded-full p-1 text-[#8b95a7]" aria-hidden="true">
+            <span className={classNames("rounded-full p-1", lightChrome ? "text-[#7b8493]" : "text-[#8b95a7]")} aria-hidden="true">
               <MoreIcon className="size-5" />
             </span>
           </div>
           <div className="flex flex-col gap-1">
-            <p className="truncate text-[16px] font-bold text-[#d9d9d9]">{"アカウント名"}</p>
-            <p className="truncate text-[12px] font-normal text-[#8b95a7]">{"いいねをもらった数：０"}</p>
+            <p className={classNames("truncate text-[16px] font-bold", lightChrome ? "text-[#111827]" : "text-[#d9d9d9]")}>{"アカウント名"}</p>
+            <p className={classNames("truncate text-[12px] font-normal", lightChrome ? "text-[#7b8493]" : "text-[#8b95a7]")}>{"いいねをもらった数：０"}</p>
           </div>
         </button>
       </div>
 
-      <div className="border-b border-[#343434]">
-        <DrawerSection items={primaryNavItems} routeName={routeName} onNavigate={onNavigate} onExternalSelect={onClose} />
+      <div className={classNames("border-b", lightChrome ? "border-[#e5e7eb]" : "border-[#343434]")}>
+        <DrawerSection items={primaryNavItems} routeName={routeName} onNavigate={onNavigate} onExternalSelect={onClose} lightChrome={lightChrome} />
       </div>
 
-      <DrawerSection items={externalToolItems} routeName={routeName} onNavigate={onNavigate} onExternalSelect={onClose} />
+      <DrawerSection items={externalToolItems} routeName={routeName} onNavigate={onNavigate} onExternalSelect={onClose} lightChrome={lightChrome} />
     </>
   );
 }
@@ -368,11 +388,13 @@ function GlobalDrawer({
   routeName,
   onClose,
   onNavigate,
+  lightChrome,
 }: {
   isOpen: boolean;
   routeName: ShellRouteName;
   onClose: () => void;
   onNavigate: (route: ShellDestination) => void;
+  lightChrome: boolean;
 }) {
   const handleNavigate = (route: ShellDestination) => {
     onNavigate(route);
@@ -382,12 +404,15 @@ function GlobalDrawer({
   return (
     <aside
       className={classNames(
-        "fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-y-auto border-r border-[#343434] bg-[#000000] text-[#d9d9d9] transition-transform duration-300 ease-in-out sm:w-[320px]",
+        "fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-y-auto border-r transition-transform duration-300 ease-in-out sm:w-[320px]",
+        lightChrome
+          ? "border-[#e5e7eb] bg-white text-[#333333] shadow-[18px_0_44px_rgba(31,41,55,0.12)]"
+          : "border-[#343434] bg-[#000000] text-[#d9d9d9]",
         isOpen ? "translate-x-0" : "-translate-x-full",
       )}
       aria-hidden={!isOpen}
     >
-      <DrawerBody routeName={routeName} onNavigate={handleNavigate} onClose={onClose} />
+      <DrawerBody routeName={routeName} onNavigate={handleNavigate} onClose={onClose} lightChrome={lightChrome} />
     </aside>
   );
 }
@@ -413,14 +438,21 @@ function GlobalHeader({
   onRequestSubmit: () => void;
   onVersionChange: (version: string) => void;
 }) {
-  const utilityButtonClass =
-    "relative rounded-full p-2 text-[#d9d9d9] transition-colors hover:bg-[#272727] hover:text-[#d9d9d9] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6a6a6a]";
+  const lightChrome = routeName === "home" || routeName === "detail";
+  const utilityButtonClass = lightChrome
+    ? "relative rounded-full p-2 text-[#4b5563] transition-colors hover:bg-[#f1f3f6] hover:text-[#111827] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#cfd6e2]"
+    : "relative rounded-full p-2 text-[#d9d9d9] transition-colors hover:bg-[#272727] hover:text-[#d9d9d9] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#6a6a6a]";
 
   return (
-    <header className="sticky top-0 z-30 h-[80px] shrink-0 border-b border-[#343434] bg-[#000000]">
+    <header className={classNames("sticky top-0 z-30 h-[80px] shrink-0 border-b", lightChrome ? "border-[#e5e7eb] bg-white shadow-[0_1px_0_rgba(17,24,39,0.03)]" : "border-[#343434] bg-[#000000]")}>
       <div className="header-font flex h-full items-center justify-between gap-4 px-4 py-4 md:px-6">
         <div className="flex min-w-0 items-center gap-4 sm:gap-6">
-          <button type="button" className="text-[#d9d9d9] transition-colors hover:text-[#d9d9d9]" onClick={onMenuClick} aria-label="\u30e1\u30cb\u30e5\u30fc\u3092\u958b\u304f">
+          <button
+            type="button"
+            className={classNames("transition-colors", lightChrome ? "text-[#333333] hover:text-[#111827]" : "text-[#d9d9d9] hover:text-[#d9d9d9]")}
+            onClick={onMenuClick}
+            aria-label="\u30e1\u30cb\u30e5\u30fc\u3092\u958b\u304f"
+          >
             <MenuIcon className="size-7" />
           </button>
 
@@ -428,7 +460,10 @@ function GlobalHeader({
             <button
               type="button"
               onClick={onTitleClick}
-              className="whitespace-nowrap text-[20px] font-semibold tracking-tight text-[#d9d9d9] transition-opacity hover:opacity-85 md:text-[32px]"
+              className={classNames(
+                "whitespace-nowrap text-[20px] font-semibold tracking-tight transition-opacity hover:opacity-85 md:text-[32px]",
+                lightChrome ? "text-[#111827]" : "text-[#d9d9d9]",
+              )}
             >
               {"\u7cbe\u92ed\u72e9\u308aDB"}
             </button>
@@ -438,15 +473,20 @@ function GlobalHeader({
             <select
               value={version}
               onChange={(event) => onVersionChange(event.target.value)}
-              className="min-w-[104px] appearance-none rounded-full border border-[#3a3a3a] bg-[#272727] py-2 pl-4 pr-10 text-[12px] font-normal text-[#d9d9d9] outline-none transition-colors hover:border-[#505050] focus:border-[#6a6a6a] sm:text-[14px] md:text-[16px]"
+              className={classNames(
+                "min-w-[104px] appearance-none rounded-full border py-2 pl-4 pr-10 text-[12px] font-normal outline-none transition-colors sm:text-[14px] md:text-[16px]",
+                lightChrome
+                  ? "border-black/30 bg-white text-black hover:border-black/45 focus:border-black/60"
+                  : "border-[#3a3a3a] bg-[#272727] text-[#d9d9d9] hover:border-[#505050] focus:border-[#6a6a6a]",
+              )}
             >
               {versionOptions.map((option) => (
-                <option key={option} value={option} className="bg-[#272727] text-[#d9d9d9]">
+                <option key={option} value={option} className={lightChrome ? "bg-white text-black" : "bg-[#272727] text-[#d9d9d9]"}>
                   {option}
                 </option>
               ))}
             </select>
-            <ChevronDownIcon className="pointer-events-none absolute top-1/2 right-3 size-5 -translate-y-1/2 text-[#8b95a7]" />
+            <ChevronDownIcon className={classNames("pointer-events-none absolute top-1/2 right-3 size-5 -translate-y-1/2", lightChrome ? "text-black/70" : "text-[#8b95a7]")} />
           </div>
         </div>
 
@@ -456,7 +496,11 @@ function GlobalHeader({
             onClick={onRequestSubmit}
             className={classNames(
               "flex items-center gap-2 rounded-full px-3 py-2 transition-colors sm:px-4",
-              routeName === "submit" ? "bg-white text-[#111111]" : "bg-[#272727] text-[#d9d9d9] hover:bg-[#313131]",
+              routeName === "submit"
+                ? "bg-white text-[#111111]"
+                : lightChrome
+                  ? "bg-[#111827] text-white hover:bg-[#263142]"
+                  : "bg-[#272727] text-[#d9d9d9] hover:bg-[#313131]",
             )}
           >
             <PlusIcon className="size-5" />
@@ -467,10 +511,14 @@ function GlobalHeader({
             type="button"
             onClick={() => onNavigate("notifications")}
             aria-label="\u901a\u77e5"
-            className={classNames(utilityButtonClass, routeName === "notifications" && "bg-[#272727] text-[#d9d9d9] hover:bg-[#272727]")}
+            className={classNames(
+              utilityButtonClass,
+              routeName === "notifications" &&
+                (lightChrome ? "bg-[#eef1f5] text-[#111827] hover:bg-[#eef1f5]" : "bg-[#272727] text-[#d9d9d9] hover:bg-[#272727]"),
+            )}
           >
             <BellIcon className="size-6 sm:size-7" />
-            {hasUnreadNotifications ? <span className="absolute top-1 right-1 block size-2.5 rounded-full border-2 border-[#000000] bg-red-500" /> : null}
+            {hasUnreadNotifications ? <span className={classNames("absolute top-1 right-1 block size-2.5 rounded-full border-2 bg-red-500", lightChrome ? "border-white" : "border-[#000000]")} /> : null}
           </button>
 
           <button
@@ -479,7 +527,7 @@ function GlobalHeader({
             aria-label="\u30a2\u30ab\u30a6\u30f3\u30c8"
             className={classNames(
               "flex size-[32px] shrink-0 items-center justify-center overflow-hidden rounded-full bg-[#d9d9d9] transition-opacity hover:opacity-80 sm:size-[36px]",
-              routeName === "account" && "ring-2 ring-[#657086]",
+              routeName === "account" && (lightChrome ? "ring-2 ring-[#9aa7ba]" : "ring-2 ring-[#657086]"),
             )}
           >
             <UserIcon className="size-5 text-gray-600" />
@@ -512,6 +560,7 @@ export function AppShell({
   children: ReactNode;
 }) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const lightChrome = routeName === "home" || routeName === "detail";
 
   useEffect(() => {
     if (!isDrawerOpen) {
@@ -550,6 +599,7 @@ export function AppShell({
         routeName={routeName}
         onClose={() => setIsDrawerOpen(false)}
         onNavigate={onNavigate}
+        lightChrome={lightChrome}
       />
 
       <div className="flex min-h-screen">
@@ -566,7 +616,7 @@ export function AppShell({
             onVersionChange={onVersionChange}
           />
 
-          <main className="min-w-0 flex-1 bg-[#f0f2f5] text-[#333333]">{children}</main>
+          <main className={classNames("min-w-0 flex-1 text-[#333333]", lightChrome ? "bg-[#f5f6f8]" : "bg-[#f0f2f5]")}>{children}</main>
         </div>
       </div>
     </div>

--- a/src/features/home/config.ts
+++ b/src/features/home/config.ts
@@ -106,24 +106,25 @@ export const HOME_BRACKET_FILTER_OPTIONS: Array<{ label: string; shortLabel: str
 ];
 
 export const HOME_PANEL_CLASSES = {
-  sectionPanel: "relative overflow-hidden rounded-[20px] bg-[#323232] drop-shadow-xl",
-  sectionPanelInner: "relative z-[1] m-[2px] rounded-[18px] bg-[#282828] text-white/90",
-  featuredPanel: "relative overflow-hidden rounded-[20px] bg-[#3a3a3a] drop-shadow-xl",
-  featuredPanelInner: "relative z-[1] m-[2px] rounded-[18px] bg-[#2f2f2f] text-white/90",
-  sectionTitle: "text-[17px] md:text-[18px] font-bold tracking-[0.01em] text-white",
+  sectionPanel: "relative overflow-hidden rounded-[20px] bg-transparent shadow-[0_24px_34px_-30px_rgba(37,44,58,0.30)]",
+  sectionPanelInner: "relative z-[1] m-[2px] rounded-[18px] border border-white/80 bg-white text-[#333333] shadow-[inset_0_1px_0_rgba(255,255,255,0.95)]",
+  featuredPanel: "relative overflow-hidden rounded-[20px] bg-transparent shadow-[0_24px_34px_-30px_rgba(37,44,58,0.30)]",
+  featuredPanelInner: "relative z-[1] m-[2px] rounded-[18px] border border-white/80 bg-white text-[#333333] shadow-[inset_0_1px_0_rgba(255,255,255,0.95)]",
+  sectionTitle: "text-[17px] md:text-[18px] font-bold tracking-[0.01em] text-[#111827]",
   reflectionTop:
-    "pointer-events-none absolute inset-x-[18px] top-[1px] h-[22px] rounded-full bg-[linear-gradient(180deg,rgba(255,255,255,0.22),rgba(255,255,255,0.05)_42%,rgba(255,255,255,0))] blur-[10px]",
-  reflectionCorner: "pointer-events-none absolute -left-[10%] -top-[24%] h-44 w-72 rounded-full bg-white/52 blur-[60px]",
+    "pointer-events-none absolute inset-x-[18px] top-[1px] h-[22px] rounded-full bg-[linear-gradient(180deg,rgba(255,255,255,0.82),rgba(226,235,245,0.30)_44%,rgba(255,255,255,0))] blur-[10px]",
+  reflectionCorner:
+    "pointer-events-none absolute -left-[10%] -top-[24%] h-44 w-72 rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.72),rgba(226,235,245,0.18)_48%,rgba(255,255,255,0)_72%)] blur-[60px]",
 } as const;
 
 export const HOME_BUTTON_CLASSES = {
-  icon: "flex h-8 w-8 items-center justify-center rounded-full border border-white/12 bg-white/[0.08] text-white/78 transition-colors hover:bg-white/[0.14] hover:text-white",
+  icon: "flex h-8 w-8 items-center justify-center rounded-full border border-[#d8dde6] bg-white text-[#333333] transition-colors hover:bg-[#f1f3f6]",
   primary:
-    "inline-flex h-10 items-center justify-center rounded-full border border-white/12 bg-white/[0.08] px-4 text-[13px] font-semibold tracking-[0.01em] text-white transition-colors hover:bg-white/[0.14]",
+    "inline-flex h-10 items-center justify-center rounded-full border border-[#d8dde6] bg-[#f7f8fa] px-4 text-[13px] font-semibold tracking-[0.01em] text-[#333333] transition-colors hover:border-[#c8ced8] hover:bg-[#eef1f5]",
 } as const;
 
 export const HOME_LAYOUT_CLASSES = {
-  leaderboardFullBleed: "relative left-1/2 right-1/2 w-screen -translate-x-1/2 overflow-hidden bg-[#212121]",
+  leaderboardFullBleed: "relative left-1/2 right-1/2 w-screen -translate-x-1/2 overflow-hidden bg-[#f5f6f8]",
   leaderboardInner: "mx-auto max-w-7xl px-5 sm:px-6 lg:px-8",
 } as const;
 

--- a/src/features/home/filterDrawer/CharacterTab.tsx
+++ b/src/features/home/filterDrawer/CharacterTab.tsx
@@ -8,7 +8,7 @@ const ELEMENT_FILTER_LABEL = "元素絞り込み";
 const CHARACTER_LIST_LABEL = "キャラクター一覧";
 
 function filterButtonTone(active: boolean, activeClass: string) {
-  return active ? activeClass : "border-white/12 bg-white/[0.05] text-white/70 hover:bg-white/10 hover:text-white";
+  return active ? activeClass : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]";
 }
 
 type CharacterTabProps = {
@@ -41,21 +41,21 @@ export function CharacterTab({
   return (
     <>
       <section className="space-y-2 [&>div:first-child]:hidden">
-        <div className="text-[12px] font-medium text-white/48">{SEARCH_LABEL}</div>
+        <div className="text-[12px] font-medium text-[#8d93a3]">{SEARCH_LABEL}</div>
         <label className="relative block">
-          <SearchIcon size={16} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-white/36" />
+          <SearchIcon size={16} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[#8d93a3]" />
           <input
             type="text"
             value={characterSearchValue}
             onChange={(event) => onCharacterSearchChange(event.target.value)}
             placeholder={characterSearchPlaceholder}
-            className="h-11 w-full rounded-[14px] border border-white/10 bg-white/[0.04] pl-11 pr-4 text-[14px] text-white placeholder:text-white/28 outline-none transition-colors focus:border-white/24"
+            className="h-11 w-full rounded-[14px] border border-[#d8dde6] bg-[#f7f8fa] pl-11 pr-4 text-[14px] text-[#333333] placeholder:text-[#8d93a3] outline-none transition-colors focus:border-[#9aa7ba] focus:bg-white"
           />
         </label>
       </section>
 
       <section className="space-y-3 [&>div:first-child]:hidden">
-        <div className="text-[12px] font-medium text-white/48">{ELEMENT_FILTER_LABEL}</div>
+        <div className="text-[12px] font-medium text-[#8d93a3]">{ELEMENT_FILTER_LABEL}</div>
         <div className="space-y-3">
           <div className="flex flex-wrap gap-2">
             {elementFilterOptions.map((option) => (
@@ -64,7 +64,7 @@ export function CharacterTab({
                 type="button"
                 className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${filterButtonTone(
                   selectedElement === option.key,
-                  "border-transparent bg-white text-[#151515]",
+                  "border-transparent bg-[#111827] text-white",
                 )}`}
                 onClick={() => onToggleElementFilter(option.key)}
               >
@@ -76,7 +76,7 @@ export function CharacterTab({
       </section>
 
       <section className="space-y-3 [&>div:first-child]:hidden">
-        <div className="text-[12px] font-medium text-white/48">{CHARACTER_LIST_LABEL}</div>
+        <div className="text-[12px] font-medium text-[#8d93a3]">{CHARACTER_LIST_LABEL}</div>
         <div className="grid grid-cols-4 gap-3 sm:grid-cols-5">
           {visibleCharacters.map((character) => {
             const isInclude = draftFilters[activeTab].includeIds.includes(character.id);
@@ -88,17 +88,17 @@ export function CharacterTab({
                 type="button"
                 className={`relative rounded-[16px] border p-2 text-center transition-all ${
                   isExclude
-                    ? "border-[#8d575d] bg-[#43292d]/70"
+                    ? "border-[#efc9b0] bg-[#fff7f2]"
                     : isInclude
-                      ? "border-cyan-300 bg-cyan-400/12"
-                      : "border-white/10 bg-white/[0.04] hover:border-white/20"
+                      ? "border-[#8fc7d8] bg-[#eef9fc]"
+                      : "border-[#e5e7eb] bg-[#f7f8fa] hover:border-[#c8ced8] hover:bg-white"
                 }`}
                 onClick={() => onToggleCharacter(character.id)}
               >
                 {isInclude || isExclude ? (
                   <div
                     className={`absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-full text-[11px] font-bold ${
-                      isExclude ? "bg-[#b96b74] text-white" : "bg-cyan-300 text-[#141414]"
+                      isExclude ? "bg-[#c27642] text-white" : "bg-[#6bbbd0] text-white"
                     }`}
                   >
                     {isExclude ? "-" : "+"}
@@ -106,14 +106,14 @@ export function CharacterTab({
                 ) : null}
                 <div className="flex flex-col items-center">
                   <CharacterImage characterId={character.id} variant="circle" alt={character.name} className="h-14 w-14 rounded-full object-cover" />
-                  <div className="mt-2 truncate text-[11px] font-medium text-white/76">{character.name}</div>
+                  <div className="mt-2 truncate text-[11px] font-medium text-[#5f6678]">{character.name}</div>
                 </div>
               </button>
             );
           })}
         </div>
         {visibleCharacters.length === 0 ? (
-          <div className="rounded-[16px] border border-dashed border-white/10 bg-white/[0.02] px-4 py-8 text-center text-[13px] text-white/42">
+          <div className="rounded-[16px] border border-dashed border-[#d8dde6] bg-[#f7f8fa] px-4 py-8 text-center text-[13px] text-[#8d93a3]">
             {emptyCharacterResultLabel}
           </div>
         ) : null}

--- a/src/features/home/filterDrawer/TagTab.tsx
+++ b/src/features/home/filterDrawer/TagTab.tsx
@@ -25,15 +25,15 @@ export function TagTab({
   return (
     <>
       <section className="space-y-2 [&>div:first-child]:hidden">
-        <div className="text-[12px] font-medium text-white/48">{SEARCH_LABEL}</div>
+        <div className="text-[12px] font-medium text-[#8d93a3]">{SEARCH_LABEL}</div>
         <label className="relative block">
-          <SearchIcon size={16} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-white/36" />
+          <SearchIcon size={16} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[#8d93a3]" />
           <input
             type="text"
             value={tagSearch}
             onChange={(event) => onTagSearchChange(event.target.value)}
             placeholder={tagSearchPlaceholder}
-            className="h-11 w-full rounded-[14px] border border-white/10 bg-white/[0.04] pl-11 pr-4 text-[14px] text-white placeholder:text-white/28 outline-none transition-colors focus:border-white/24"
+            className="h-11 w-full rounded-[14px] border border-[#d8dde6] bg-[#f7f8fa] pl-11 pr-4 text-[14px] text-[#333333] placeholder:text-[#8d93a3] outline-none transition-colors focus:border-[#9aa7ba] focus:bg-white"
           />
         </label>
       </section>
@@ -42,7 +42,7 @@ export function TagTab({
         {visibleTagGroups.length > 0 ? (
           visibleTagGroups.map((group) => (
             <div key={group.key} className="space-y-2">
-              <div className="text-[12px] font-medium text-white/42">{group.label}</div>
+              <div className="text-[12px] font-medium text-[#8d93a3]">{group.label}</div>
               <div className="flex flex-wrap gap-2">
                 {group.tags.map((tag) => {
                   const isInclude = draftFilters.tags.includeIds.includes(tag);
@@ -54,10 +54,10 @@ export function TagTab({
                       type="button"
                       className={`inline-flex min-h-9 items-center rounded-full border px-3 py-2 text-[12px] font-medium transition-colors ${
                         isExclude
-                          ? "border-[#8d575d] bg-[#43292d] text-white"
+                          ? "border-[#efc9b0] bg-[#fff7f2] text-[#b6611e]"
                           : isInclude
-                            ? "border-transparent bg-white text-[#151515]"
-                            : "border-white/12 bg-white/[0.04] text-white/72 hover:bg-white/10 hover:text-white"
+                            ? "border-transparent bg-[#111827] text-white"
+                            : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"
                       }`}
                       onClick={() => onToggleTag(tag)}
                     >
@@ -69,7 +69,7 @@ export function TagTab({
             </div>
           ))
         ) : (
-          <div className="rounded-[16px] border border-dashed border-white/10 bg-white/[0.02] px-4 py-8 text-center text-[13px] text-white/42">
+          <div className="rounded-[16px] border border-dashed border-[#d8dde6] bg-[#f7f8fa] px-4 py-8 text-center text-[13px] text-[#8d93a3]">
             {emptyTagResultLabel}
           </div>
         )}

--- a/src/features/home/sections/ActiveFilterChipStrip.tsx
+++ b/src/features/home/sections/ActiveFilterChipStrip.tsx
@@ -12,7 +12,7 @@ export function ActiveFilterChipStrip({ chips, onRemove }: ActiveFilterChipStrip
 
   return (
     <>
-      <p className="ml-3 mr-2 text-[14px] font-medium text-white/42">{"\uFF1A"}</p>
+      <p className="ml-3 mr-2 text-[14px] font-medium text-[#8d93a3]">{"\uFF1A"}</p>
       <div className="flex flex-wrap items-center gap-2">
         {chips.map((chip) => (
           <button
@@ -20,8 +20,8 @@ export function ActiveFilterChipStrip({ chips, onRemove }: ActiveFilterChipStrip
             type="button"
             className={`inline-flex h-8 items-center justify-center gap-1.5 rounded-full px-2.5 text-[11px] font-medium transition-colors ${
               chip.isExclude
-                ? "border border-[#6e4a4a] text-white/76 hover:bg-[#3a2626]"
-                : "border border-white/12 text-white/78 hover:bg-white/10 hover:text-white"
+                ? "border border-[#efc9b0] bg-[#fff7f2] text-[#b6611e] hover:bg-[#fbf1ea]"
+                : "border border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"
             }`}
             onClick={() => onRemove(chip)}
           >

--- a/src/features/home/sections/Footer.tsx
+++ b/src/features/home/sections/Footer.tsx
@@ -2,9 +2,9 @@ import { TimerIcon } from "../ui/icons";
 
 export function Footer() {
   return (
-    <footer className="border-t border-white/10 bg-[#212121] py-12">
-      <div className="max-w-7xl mx-auto px-4 text-center text-sm text-white/52">
-        <div className="mb-4 flex items-center justify-center gap-2 text-white/74">
+    <footer className="border-t border-[#e5e7eb] bg-white py-12">
+      <div className="max-w-7xl mx-auto px-4 text-center text-sm text-[#8d93a3]">
+        <div className="mb-4 flex items-center justify-center gap-2 text-[#5f6678]">
           <TimerIcon size={20} />
           <span className="text-lg font-bold">Teyvat EliteDB</span>
         </div>

--- a/src/features/home/sections/Hero.tsx
+++ b/src/features/home/sections/Hero.tsx
@@ -27,7 +27,7 @@ export function Hero({
       style={{ backgroundImage: `url(${heroImageUrl})` }}
       aria-label="Hero visual"
     >
-      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-[#212121]" />
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-transparent to-[#f5f6f8]" />
       <div className="absolute top-4 left-1/2 -translate-x-1/2 w-[90%] max-w-4xl bg-black/15 backdrop-blur-sm rounded-full border border-white/30 px-4 py-2">
         <div className="flex items-center justify-between text-sm font-medium text-white">
           {[...primaryRulesetTabs, otherTabLabel].map((label) => {

--- a/src/features/home/sections/LeaderboardSection.tsx
+++ b/src/features/home/sections/LeaderboardSection.tsx
@@ -36,18 +36,18 @@ export function LeaderboardSection({
     <div ref={leaderboardRef} className={HOME_LAYOUT_CLASSES.leaderboardFullBleed}>
       <div className={HOME_LAYOUT_CLASSES.leaderboardInner}>
         <div className="pt-12 pb-14 md:pt-14 md:pb-16">
-          <div className="mb-8 flex items-center border-t border-white/10 pt-8">
-            <div className="text-[18px] font-bold tracking-[0.01em] text-white md:text-[20px]">{HOME_LABELS.leaderboardLabel}</div>
+          <div className="mb-8 flex items-center border-t border-[#e5e7eb] pt-8">
+            <div className="text-[18px] font-bold tracking-[0.01em] text-[#111827] md:text-[20px]">{HOME_LABELS.leaderboardLabel}</div>
           </div>
           <div className="mb-8 flex items-center justify-center">
-            <div className="flex items-center overflow-hidden rounded-full border border-white/12 bg-[#262526]/70 w-full max-w-[520px] md:min-w-[520px]">
+            <div className="flex items-center overflow-hidden rounded-full border border-[#dcdfe6] bg-white w-full max-w-[520px] md:min-w-[520px]">
               {HOME_LEADERBOARD_VIEW_OPTIONS.map((item) => (
                 <button
                   key={item.key}
                   type="button"
                   onClick={() => onLeaderboardViewChange(item.key)}
                   className={`flex-1 px-4 py-2.5 text-[13px] font-semibold transition-colors md:text-[14px] ${
-                    leaderboardView === item.key ? "bg-white text-[#1f1f20]" : "bg-transparent text-white/68 hover:bg-white/8 hover:text-white"
+                    leaderboardView === item.key ? "bg-black text-white" : "bg-white text-black hover:bg-[#f7f7f7]"
                   }`}
                   title={item.label}
                   aria-label={item.label}
@@ -61,7 +61,7 @@ export function LeaderboardSection({
           <div className="mb-8 flex flex-wrap items-center gap-y-3">
             <button
               type="button"
-              className="inline-flex h-11 items-center justify-center gap-2 rounded-full border border-white/12 px-5 text-[13px] font-semibold tracking-[0.01em] text-white/78 transition-colors hover:bg-white/10 hover:text-white [&>div]:hidden [&>span:last-of-type]:hidden"
+              className="inline-flex h-11 items-center justify-center gap-2 rounded-full border border-[#d8dde6] bg-white px-5 text-[13px] font-semibold tracking-[0.01em] text-[#333333] transition-colors hover:bg-[#eef1f5] [&>div]:hidden [&>span:last-of-type]:hidden"
               onClick={onOpenFilter}
             >
               <FilterFunnelIcon className="w-5 h-5" />
@@ -81,8 +81,8 @@ export function LeaderboardSection({
                 onClick={() => onFilterBracketChange(item.value)}
                 className={`flex-1 border-b-2 pb-3 text-center ${
                   filterBracket === item.value || (item.value === null && filterBracket === null)
-                    ? "border-white text-white"
-                    : "border-transparent text-white/38 hover:text-white/72"
+                    ? "border-[#111827] text-[#111827]"
+                    : "border-transparent text-[#8d93a3] hover:text-[#333333]"
                 }`}
               >
                 <span className="md:hidden">{item.shortLabel}</span>
@@ -108,4 +108,3 @@ export function LeaderboardSection({
     </div>
   );
 }
-

--- a/src/features/home/sections/Shell.tsx
+++ b/src/features/home/sections/Shell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
 
 export function Shell({ children }: { children: ReactNode }) {
-  return <div className="min-h-screen bg-[#212121] pb-20 font-sans text-[#333333]">{children}</div>;
+  return <div className="min-h-screen bg-[#f5f6f8] pb-20 font-sans text-[#333333]">{children}</div>;
 }

--- a/src/features/home/sections/TopPanelsCarousel.tsx
+++ b/src/features/home/sections/TopPanelsCarousel.tsx
@@ -61,4 +61,3 @@ export function TopPanelsCarousel({
     </div>
   );
 }
-

--- a/src/features/home/ui/FilterDrawer.tsx
+++ b/src/features/home/ui/FilterDrawer.tsx
@@ -103,17 +103,17 @@ export function FilterDrawer({
   const visibleCharacters = activeTab === "tags" ? [] : getVisibleCharacters(activeTab);
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/65 backdrop-blur-[2px]" onClick={onClose}>
+    <div className="fixed inset-0 z-50 bg-black/35 backdrop-blur-[2px]" onClick={onClose}>
       <div
-        className="absolute inset-y-0 right-0 flex w-full max-w-[720px] flex-col border-l border-white/10 bg-[#191919] text-white shadow-[-24px_0_60px_rgba(0,0,0,0.35)]"
+        className="absolute inset-y-0 right-0 flex w-full max-w-[720px] flex-col border-l border-[#e5e7eb] bg-white text-[#333333] shadow-[-24px_0_60px_rgba(31,41,55,0.16)]"
         onClick={(event) => event.stopPropagation()}
       >
-        <div className="shrink-0 border-b border-white/10">
+        <div className="shrink-0 border-b border-[#e5e7eb]">
           <div className="flex items-start justify-between gap-4 px-5 py-5 md:px-6">
-            <div className="text-[24px] font-semibold text-white">{title}</div>
+            <div className="text-[24px] font-semibold text-[#111827]">{title}</div>
             <button
               type="button"
-              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-white/12 bg-white/[0.05] text-white/72"
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[#d8dde6] bg-[#f7f8fa] text-[#5f6678] transition-colors hover:bg-[#eef1f5] hover:text-[#111827]"
               onClick={onClose}
               aria-label="Close"
             >
@@ -129,7 +129,7 @@ export function FilterDrawer({
                 key={tab.key}
                 type="button"
                 className={`-mb-px flex-1 shrink-0 border-b-2 pb-4 text-center transition-colors ${
-                  activeTab === tab.key ? "border-white text-white" : "border-transparent text-white/38 hover:text-white/72"
+                  activeTab === tab.key ? "border-[#111827] text-[#111827]" : "border-transparent text-[#8d93a3] hover:text-[#333333]"
                 }`}
                 onClick={() => setActiveTab(tab.key)}
               >
@@ -144,7 +144,7 @@ export function FilterDrawer({
             <section className="space-y-4">
               <div className="flex justify-center">
                 <div
-                  className="flex w-full max-w-[320px] items-center overflow-hidden rounded-full border border-white/12 bg-[#262526]/70 sm:max-w-[360px]"
+                  className="flex w-full max-w-[320px] items-center overflow-hidden rounded-full border border-[#d8dde6] bg-[#edf1f5] sm:max-w-[360px]"
                   aria-label="Selection target"
                 >
                   {filterTargetOptions.map((option) => (
@@ -152,7 +152,7 @@ export function FilterDrawer({
                       key={`${activeTab}-target-${option.key}`}
                       type="button"
                       className={`flex-1 px-5 py-2 text-[13px] font-semibold transition-colors sm:px-7 ${
-                        selectionTarget === option.key ? "bg-white text-[#1f1f20]" : "bg-transparent text-white/68 hover:bg-white/8 hover:text-white"
+                        selectionTarget === option.key ? "bg-[#111827] text-white" : "bg-transparent text-[#5f6678] hover:bg-white hover:text-[#111827]"
                       }`}
                       onClick={() =>
                         setSelectionTargets((current) => ({
@@ -170,7 +170,7 @@ export function FilterDrawer({
               <div className="flex items-center justify-end gap-3">
                 <span
                   className={`text-[11px] font-semibold tracking-[0.08em] transition-colors ${
-                    draftFilters[activeTab].includeMode === "or" ? "text-white/82" : "text-white/40"
+                    draftFilters[activeTab].includeMode === "or" ? "text-[#333333]" : "text-[#8d93a3]"
                   }`}
                 >
                   OR
@@ -191,7 +191,7 @@ export function FilterDrawer({
                 </div>
                 <span
                   className={`text-[11px] font-semibold tracking-[0.08em] transition-colors ${
-                    draftFilters[activeTab].includeMode === "and" ? "text-white/82" : "text-white/40"
+                    draftFilters[activeTab].includeMode === "and" ? "text-[#333333]" : "text-[#8d93a3]"
                   }`}
                 >
                   AND
@@ -240,17 +240,17 @@ export function FilterDrawer({
           </div>
         </div>
 
-        <div className="grid shrink-0 grid-cols-[1fr_minmax(220px,360px)_1fr] items-center gap-3 border-t border-white/10 px-5 py-4 md:px-6">
+        <div className="grid shrink-0 grid-cols-[1fr_minmax(220px,360px)_1fr] items-center gap-3 border-t border-[#e5e7eb] px-5 py-4 md:px-6">
           <button
             type="button"
-            className="justify-self-start text-[13px] font-medium text-white/54 underline decoration-white/20 underline-offset-4"
+            className="justify-self-start text-[13px] font-medium text-[#5f6678] underline decoration-[#c8ced8] underline-offset-4 hover:text-[#333333]"
             onClick={resetDraft}
           >
             {resetLabel}
           </button>
           <button
             type="button"
-            className="w-full rounded-full border border-white bg-white px-6 py-2.5 text-[13px] font-semibold text-[#5f6373] transition-colors hover:bg-white/90 hover:text-[#4d5160]"
+            className="w-full rounded-full border border-[#111827] bg-[#111827] px-6 py-2.5 text-[13px] font-semibold text-white transition-colors hover:bg-[#263142]"
             onClick={() => {
               onApply(cloneHomeFilterState(draftFilters));
               onClose();

--- a/src/features/home/ui/LeaderboardRow.tsx
+++ b/src/features/home/ui/LeaderboardRow.tsx
@@ -24,17 +24,17 @@ export function LeaderboardRow({
       return baseClass;
     }
 
-    return `${baseClass} ring-2 ring-white/90 shadow-[0_0_0_1px_rgba(255,255,255,0.18)]`;
+    return `${baseClass} ring-2 ring-[#9aa7ba] shadow-[0_0_0_1px_rgba(154,167,186,0.22)]`;
   };
 
   return (
-    <div className="cursor-pointer border-t border-white/10 py-4 text-white/90" onClick={() => onSelect(run.id)}>
+    <div className="cursor-pointer border-t border-[#e5e7eb] py-4 text-[#333333] transition-colors hover:bg-white/55" onClick={() => onSelect(run.id)}>
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div className="flex min-w-0 items-center gap-3 md:gap-5">
-          <div className="flex w-6 items-center justify-center text-white/45">
+          <div className="flex w-6 items-center justify-center text-[#8d93a3]">
             <RankMoveIcon move={run.rankMove} className="h-5 w-5" />
           </div>
-          <div className="w-9 text-center text-[20px] font-semibold text-white md:w-10 md:text-[22px]">{index + 1}</div>
+          <div className="w-9 text-center text-[20px] font-semibold text-[#111827] md:w-10 md:text-[22px]">{index + 1}</div>
           <div className="flex shrink-0 items-center gap-1 md:hidden">
             {run.party.map((member, memberIndex) => (
               <CharacterImage
@@ -59,39 +59,39 @@ export function LeaderboardRow({
           </div>
           <div className="hidden min-w-0 flex-1 md:block">
             <div className="flex min-w-0 items-center gap-2">
-              <div className="truncate text-[17px] font-semibold text-white md:text-[19px]">{run.userName}</div>
+              <div className="truncate text-[17px] font-semibold text-[#111827] md:text-[19px]">{run.userName}</div>
               {displayGroup ? (
-                <div className="hidden max-w-[180px] truncate rounded-full border border-white/14 bg-white/[0.08] px-2.5 py-1 text-[11px] font-medium text-white/82 md:inline-flex">
+                <div className="hidden max-w-[180px] truncate rounded-full border border-[#d8dde6] bg-[#f7f8fa] px-2.5 py-1 text-[11px] font-medium text-[#5f6678] md:inline-flex">
                   {displayGroup.label}
                 </div>
               ) : null}
-              <div className="hidden rounded-full border border-white/12 bg-white/[0.08] px-2.5 py-1 text-[11px] font-medium text-white/72 md:inline-flex">
+              <div className="hidden rounded-full border border-[#d8dde6] bg-[#f7f8fa] px-2.5 py-1 text-[11px] font-medium text-[#5f6678] md:inline-flex">
                 {getBracketLabel(run.bracket as Bracket)}
               </div>
             </div>
           </div>
-          <div className="ml-auto text-[20px] font-semibold text-white md:hidden">{run.time}</div>
-          <div className="hidden h-9 w-9 items-center justify-center rounded-full border border-white/12 bg-white/[0.08] md:flex">
-            <PlatformIcon className="h-[18px] w-[18px] text-white/78" />
+          <div className="ml-auto text-[20px] font-semibold text-[#111827] md:hidden">{run.time}</div>
+          <div className="hidden h-9 w-9 items-center justify-center rounded-full border border-[#d8dde6] bg-white md:flex">
+            <PlatformIcon className="h-[18px] w-[18px] text-[#5f6678]" />
           </div>
         </div>
         <div className="hidden items-center gap-3 md:flex">
-          <div className="w-20 text-right text-[22px] font-semibold text-white">{run.time}</div>
+          <div className="w-20 text-right text-[22px] font-semibold text-[#111827]">{run.time}</div>
         </div>
       </div>
       <div className="mt-2 flex min-w-0 items-center gap-3 md:hidden">
         <div className="w-6 shrink-0" aria-hidden="true" />
         <div className="w-9 shrink-0" aria-hidden="true" />
-        <div className="min-w-0 flex-1 truncate text-[15px] font-semibold text-white">{run.userName}</div>
+        <div className="min-w-0 flex-1 truncate text-[15px] font-semibold text-[#111827]">{run.userName}</div>
         <div className="flex items-center gap-2">
           {displayGroup ? (
-            <div className="max-w-[120px] truncate rounded-full border border-white/14 bg-white/[0.08] px-2 py-0.5 text-[11px] font-medium text-white/82">
+            <div className="max-w-[120px] truncate rounded-full border border-[#d8dde6] bg-[#f7f8fa] px-2 py-0.5 text-[11px] font-medium text-[#5f6678]">
               {displayGroup.label}
             </div>
           ) : null}
-          <div className="rounded-full border border-white/12 bg-white/[0.08] px-2 py-0.5 text-[11px] font-medium text-white/72">{getBracketLabel(run.bracket as Bracket)}</div>
-          <div className="flex h-8 w-8 items-center justify-center rounded-full border border-white/12 bg-white/[0.08]">
-            <PlatformIcon className="h-3.5 w-3.5 text-white/78" />
+          <div className="rounded-full border border-[#d8dde6] bg-[#f7f8fa] px-2 py-0.5 text-[11px] font-medium text-[#5f6678]">{getBracketLabel(run.bracket as Bracket)}</div>
+          <div className="flex h-8 w-8 items-center justify-center rounded-full border border-[#d8dde6] bg-white">
+            <PlatformIcon className="h-3.5 w-3.5 text-[#5f6678]" />
           </div>
         </div>
       </div>

--- a/src/features/home/ui/TopPlayerCard.tsx
+++ b/src/features/home/ui/TopPlayerCard.tsx
@@ -11,7 +11,7 @@ export function TopPlayerCard({
   actionLabel = "ランキングを見る",
   onAction,
   loadingLabel = "集計中...",
-  primaryButtonClass = "inline-flex h-10 items-center justify-center rounded-full border border-white/12 bg-white/[0.08] px-4 text-[13px] font-semibold tracking-[0.01em] text-white transition-colors hover:bg-white/[0.14]",
+  primaryButtonClass = "inline-flex h-10 items-center justify-center rounded-full border border-[#d8dde6] bg-[#f7f8fa] px-4 text-[13px] font-semibold tracking-[0.01em] text-[#333333] transition-colors hover:border-[#c8ced8] hover:bg-[#eef1f5]",
 }: {
   label: string;
   run: HomeRun | null;
@@ -25,14 +25,14 @@ export function TopPlayerCard({
 }) {
   if (!run) {
     return (
-      <div className="flex h-full flex-col overflow-hidden rounded-[16px] border border-[#4a494b] bg-[#2b2a2b] shadow-[0_12px_24px_rgba(0,0,0,0.28)] transition-all hover:-translate-y-0.5 hover:shadow-[0_16px_30px_rgba(0,0,0,0.32)]">
+      <div className="flex h-full flex-col overflow-hidden rounded-[16px] border border-[#e5e7eb] bg-white shadow-[0_12px_24px_rgba(31,41,55,0.08)] transition-all hover:-translate-y-0.5 hover:shadow-[0_16px_30px_rgba(31,41,55,0.12)]">
         <div className={`relative h-24 w-full bg-gradient-to-r ${theme.gradient}`}>
           <div className="absolute top-4 left-4 z-10 space-y-1">
             <div className="text-[17px] font-bold leading-tight tracking-[0.01em] text-white drop-shadow-md md:text-[18px]">{label}</div>
           </div>
         </div>
-        <div className="relative z-10 flex flex-1 flex-col justify-between gap-4 bg-[#323132] p-4 text-white/90">
-          <div className="text-sm text-white/55">{loadingLabel}</div>
+        <div className="relative z-10 flex flex-1 flex-col justify-between gap-4 bg-white p-4 text-[#333333]">
+          <div className="text-sm text-[#5f6678]">{loadingLabel}</div>
           <button type="button" onClick={onAction ?? onView} className={`${primaryButtonClass} w-full`}>
             {actionLabel}
           </button>
@@ -43,7 +43,7 @@ export function TopPlayerCard({
 
   return (
     <div
-      className="flex h-full cursor-pointer flex-col overflow-hidden rounded-[16px] border border-[#4a494b] bg-[#2b2a2b] shadow-[0_12px_24px_rgba(0,0,0,0.28)] transition-all hover:-translate-y-0.5 hover:shadow-[0_16px_30px_rgba(0,0,0,0.32)]"
+      className="flex h-full cursor-pointer flex-col overflow-hidden rounded-[16px] border border-[#e5e7eb] bg-white shadow-[0_12px_24px_rgba(31,41,55,0.08)] transition-all hover:-translate-y-0.5 hover:shadow-[0_16px_30px_rgba(31,41,55,0.12)]"
       onClick={() => onSelect(run.id)}
     >
       <div className={`relative h-24 w-full bg-gradient-to-r ${theme.gradient}`}>
@@ -57,8 +57,8 @@ export function TopPlayerCard({
           className="pointer-events-none absolute -right-5 -bottom-5 z-0 h-auto w-44 object-cover opacity-85 drop-shadow-lg"
         />
       </div>
-      <div className="relative z-10 flex flex-1 flex-col gap-4 bg-[#323132] p-4 text-white/90">
-        <div className="rounded-[12px] border border-white/10 bg-white/[0.08] p-3">
+      <div className="relative z-10 flex flex-1 flex-col gap-4 bg-white p-4 text-[#333333]">
+        <div className="rounded-[12px] border border-[#eceff3] bg-[#f7f8fa] p-3">
           <div className="flex items-center justify-between gap-2">
             {run.party.map((member, index) => (
               <CharacterImage
@@ -70,7 +70,7 @@ export function TopPlayerCard({
               />
             ))}
           </div>
-          <div className="mt-3 text-center text-[24px] font-semibold leading-none text-white">{run.time}</div>
+          <div className="mt-3 text-center text-[24px] font-semibold leading-none text-[#111827]">{run.time}</div>
         </div>
         <button
           type="button"
@@ -86,5 +86,4 @@ export function TopPlayerCard({
     </div>
   );
 }
-
 

--- a/src/features/recordDetail/Page.tsx
+++ b/src/features/recordDetail/Page.tsx
@@ -168,7 +168,7 @@ export function RecordDetailPage({
 
   return (
     <>
-      <main className={`bg-[#212121] text-white/90 transition-[width] duration-300 ${mainSurfaceClass}`}>
+      <main className={`bg-[#f5f6f8] text-[#333333] transition-[width] duration-300 ${mainSurfaceClass}`}>
         <Header
           embedded={embedded}
           forceMobileLayout={forceMobileLayout}

--- a/src/features/recordDetail/config.ts
+++ b/src/features/recordDetail/config.ts
@@ -7,9 +7,10 @@ export const collapsedCopyStyle: CSSProperties = {
   WebkitLineClamp: 3,
 };
 
-export const DETAIL_PANEL_SHELL_CLASS = "relative overflow-hidden rounded-[20px] bg-[#3d3c3d] drop-shadow-xl";
-export const DETAIL_PANEL_INNER_CLASS = "relative z-[1] m-[2px] rounded-[18px] bg-[#323132] text-white/90";
-export const DETAIL_MUTED_SURFACE_CLASS = "rounded-[16px] border border-white/10 bg-[#272727]";
+export const DETAIL_PANEL_SHELL_CLASS =
+  "relative overflow-hidden rounded-[20px] bg-[linear-gradient(135deg,#ffffff_0%,#f1eadf_34%,#dfe8f2_68%,#f8f6f1_100%)] shadow-[0_18px_34px_rgba(37,44,58,0.10)]";
+export const DETAIL_PANEL_INNER_CLASS = "relative z-[1] m-[2px] rounded-[18px] bg-white text-[#333333]";
+export const DETAIL_MUTED_SURFACE_CLASS = "rounded-[16px] border border-[#e5e7eb] bg-[#f7f8fa]";
 export const DETAIL_ICON_BUTTON_CLASS =
-  "grid h-9 w-9 place-items-center rounded-full border border-white/10 bg-[#272727] text-white/82 transition hover:bg-white/[0.12] hover:text-white";
+  "grid h-9 w-9 place-items-center rounded-full border border-[#d8dde6] bg-white text-[#333333] transition hover:bg-[#eef1f5]";
 export const DETAIL_LIKE_ACTIVE_ICON_CLASS = "text-[#ff8ea1]";

--- a/src/features/recordDetail/sections/CompareDrawer.tsx
+++ b/src/features/recordDetail/sections/CompareDrawer.tsx
@@ -19,18 +19,18 @@ function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.R
   const partyBuildItems = getPartyBuildItems(run);
 
   return (
-    <div className="flex min-h-full flex-col gap-[16px] bg-[#212121] px-3 py-3 text-white/90">
+    <div className="flex min-h-full flex-col gap-[16px] bg-[#f5f6f8] px-3 py-3 text-[#333333]">
       <VideoFrame title={run.title} videoUrl={run.videoUrl} iframeRef={iframeRef} mute />
 
       <div className="flex flex-col gap-[12px]">
         <div className="flex flex-col gap-[12px]">
-          <div className="text-[16px] font-bold leading-none text-white md:text-[18px]">{run.title}</div>
+          <div className="text-[16px] font-bold leading-none text-[#111827] md:text-[18px]">{run.title}</div>
           <div className="flex items-center justify-between gap-[12px]">
             <div className="flex min-w-0 items-center gap-[12px]">
               <CircleAvatar label={run.userName} size={40} />
-              <div className="truncate text-[16px] font-bold leading-none text-white md:text-[18px]">{run.userName}</div>
+              <div className="truncate text-[16px] font-bold leading-none text-[#111827] md:text-[18px]">{run.userName}</div>
             </div>
-            <div className="inline-flex shrink-0 items-center gap-[6px] rounded-[42px] border border-white/10 bg-[#272727] px-[10px] py-[5px] text-[12px] text-white/82 md:text-[13px]">
+            <div className="inline-flex shrink-0 items-center gap-[6px] rounded-[42px] border border-[#d8dde6] bg-white px-[10px] py-[5px] text-[12px] text-[#333333] md:text-[13px]">
               <PlatformIcon platform={run.platform} className="h-[13px] w-[13px]" />
               <span>{run.platform}</span>
             </div>
@@ -38,13 +38,13 @@ function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.R
         </div>
 
         <div className={`w-full ${DETAIL_MUTED_SURFACE_CLASS} p-[12px]`}>
-          <div className="flex items-center gap-x-[16px] overflow-x-auto whitespace-nowrap text-[13px] text-white/74 md:gap-x-[18px] md:text-[14px]">
+          <div className="flex items-center gap-x-[16px] overflow-x-auto whitespace-nowrap text-[13px] text-[#5f6678] md:gap-x-[18px] md:text-[14px]">
             <span>ver : {run.versionLabel}</span>
             <span>{run.postedLabel}</span>
             <PlatformLabel platform={run.platform} />
           </div>
           <div className="mt-[12px] space-y-[12px]">
-            <p className="whitespace-pre-line text-[14px] leading-[1.75] text-white/88 md:text-[15px]">{run.summary}</p>
+            <p className="whitespace-pre-line text-[14px] leading-[1.75] text-[#333333] md:text-[15px]">{run.summary}</p>
             <div className="flex flex-wrap gap-[10px] md:gap-[12px]">
               {run.tags.map((tag) => (
                 <TagChip key={`${run.id}-${tag}`} tag={tag} />
@@ -122,16 +122,16 @@ export function CompareDrawer({
 
   return (
     <div className={embedded ? "fixed top-[80px] right-0 bottom-0 z-20 hidden lg:block" : "fixed inset-y-0 right-0 z-50 hidden lg:block"} aria-modal="false" role="complementary">
-      <div className="flex h-full w-[50vw] flex-col border-l border-white/10 bg-[#212121] shadow-[-20px_0_40px_rgba(0,0,0,0.35)]">
-        <div className="flex min-h-[52px] items-center justify-between border-b border-white/10 bg-[#212121] px-4 py-2">
+      <div className="flex h-full w-[50vw] flex-col border-l border-[#e5e7eb] bg-[#f5f6f8] shadow-[-20px_0_40px_rgba(31,41,55,0.16)]">
+        <div className="flex min-h-[52px] items-center justify-between border-b border-[#e5e7eb] bg-white px-4 py-2">
           <div className="min-w-0">
-            <div className="text-[16px] font-semibold text-white/92 md:text-[18px]">比較ビュー</div>
+            <div className="text-[16px] font-semibold text-[#111827] md:text-[18px]">比較ビュー</div>
           </div>
           <div className="flex items-center gap-2">
             <button
               type="button"
               onClick={onToggleSync}
-              className="inline-flex h-9 items-center justify-center gap-2 rounded-[42px] border border-white/10 bg-[#272727] px-4 text-[13px] font-medium text-white transition hover:bg-[#303030]"
+              className="inline-flex h-9 items-center justify-center gap-2 rounded-[42px] border border-[#d8dde6] bg-[#f7f8fa] px-4 text-[13px] font-medium text-[#333333] transition hover:bg-[#eef1f5]"
             >
               {syncPlaying ? <PauseIcon className="h-4 w-4" /> : <PlayIcon className="h-4 w-4" />}
               <span>{syncPlaying ? "同期停止" : "同時再生"}</span>
@@ -150,7 +150,7 @@ export function CompareDrawer({
           </div>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto bg-[#212121]">
+        <div className="min-h-0 flex-1 overflow-y-auto bg-[#f5f6f8]">
           <CompareRunPane run={comparedRun} iframeRef={comparedIframeRef} />
         </div>
       </div>

--- a/src/features/recordDetail/sections/Header.tsx
+++ b/src/features/recordDetail/sections/Header.tsx
@@ -21,7 +21,7 @@ export function Header({
   return (
     <>
       {embedded ? (
-        <div className="border-b border-white/10 bg-[#212121]">
+        <div className="border-b border-[#e5e7eb] bg-white">
           <div className={`header-font mx-auto flex min-h-[52px] max-w-[1600px] items-center gap-3 px-4 py-2 ${forceMobileLayout ? "" : "md:px-6"}`}>
             {onBack ? (
               <button
@@ -35,11 +35,11 @@ export function Header({
                 </svg>
               </button>
             ) : null}
-            <div className="min-w-0 text-[16px] font-semibold tracking-tight text-white/92 md:text-[18px]">記録詳細</div>
+            <div className="min-w-0 text-[16px] font-semibold tracking-tight text-[#111827] md:text-[18px]">記録詳細</div>
           </div>
         </div>
       ) : null}
-      <nav className={embedded ? "hidden" : "sticky top-0 z-40 border-b border-white/10 bg-[#212121] shadow-[0_1px_0_rgba(255,255,255,0.04)]"}>
+      <nav className={embedded ? "hidden" : "sticky top-0 z-40 border-b border-[#e5e7eb] bg-white shadow-[0_1px_0_rgba(17,24,39,0.03)]"}>
         <div className={`header-font mx-auto flex max-w-[1600px] items-center justify-between px-4 py-2 ${forceMobileLayout ? "min-h-[52px]" : "md:px-6 md:py-3"}`}>
           <div className={`flex items-center ${forceMobileLayout ? "gap-3" : "gap-4 md:gap-6"}`}>
             {onBack ? (
@@ -54,10 +54,10 @@ export function Header({
                 </svg>
               </button>
             ) : null}
-            <h1 className={`font-semibold tracking-tight text-white ${forceMobileLayout ? "text-[24px]" : "text-[26px] md:text-[38px]"}`}>精鋭狩りDB</h1>
+            <h1 className={`font-semibold tracking-tight text-[#111827] ${forceMobileLayout ? "text-[24px]" : "text-[26px] md:text-[38px]"}`}>精鋭狩りDB</h1>
             <div className="relative">
               <select
-                className={`appearance-none rounded-full border border-white/10 bg-[#272727] py-1.5 pl-3 pr-10 font-medium text-[#d9d9d9] ${forceMobileLayout ? "text-[15px]" : "text-[16px] md:pl-4 md:pr-12 md:text-[20px]"}`}
+                className={`appearance-none rounded-full border border-[#d8dde6] bg-[#f7f8fa] py-1.5 pl-3 pr-10 font-medium text-[#333333] ${forceMobileLayout ? "text-[15px]" : "text-[16px] md:pl-4 md:pr-12 md:text-[20px]"}`}
                 value={headerVersion}
                 onChange={(event) => onHeaderVersionChange(event.target.value)}
               >
@@ -67,7 +67,7 @@ export function Header({
                   </option>
                 ))}
               </select>
-              <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-white/60">
+              <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[#5f6678]">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
                   <path d="M6 9l6 6 6-6" />
                 </svg>
@@ -79,7 +79,7 @@ export function Header({
             <button
               type="button"
               onClick={onRequestSubmit}
-              className={`flex h-9 w-9 items-center justify-center rounded-full border border-white/12 bg-[#272727] text-white ${forceMobileLayout ? "" : "md:h-auto md:w-auto md:gap-2 md:px-5 md:py-2.5 md:text-[20px]"}`}
+              className={`flex h-9 w-9 items-center justify-center rounded-full border border-[#111827] bg-[#111827] text-white ${forceMobileLayout ? "" : "md:h-auto md:w-auto md:gap-2 md:px-5 md:py-2.5 md:text-[20px]"}`}
             >
               <span className="text-[20px] leading-none md:text-[22px]">＋</span>
               <span className={forceMobileLayout ? "hidden" : "hidden md:inline"}>記録提出</span>

--- a/src/features/recordDetail/sections/MainColumn.tsx
+++ b/src/features/recordDetail/sections/MainColumn.tsx
@@ -53,17 +53,17 @@ export function MainColumn({
 
       <div className="flex flex-col gap-[12px]">
         <div className="flex flex-col gap-[12px]">
-          <div className="text-[16px] font-bold leading-none text-white md:text-[18px]">{currentRun.title}</div>
+          <div className="text-[16px] font-bold leading-none text-[#111827] md:text-[18px]">{currentRun.title}</div>
           <div className={`flex gap-[12px] ${compareOpen ? "flex-col items-start" : "items-center justify-between"}`}>
             <div className="flex min-w-0 items-center gap-[12px]">
               <CircleAvatar label={currentRun.userName} size={40} />
-              <div className="truncate text-[16px] font-bold leading-none text-white md:text-[18px]">{currentRun.userName}</div>
+              <div className="truncate text-[16px] font-bold leading-none text-[#111827] md:text-[18px]">{currentRun.userName}</div>
             </div>
             <div className={`flex gap-[12px] md:gap-[12px] ${compareOpen ? "w-full shrink min-w-0 flex-wrap" : "shrink-0 flex-nowrap"}`}>
               <PillButton
                 active={liked}
                 onClick={onToggleLike}
-                className={`min-h-[36px] min-w-[92px] ${liked ? "border border-white/10 bg-[#272727] text-white/90 hover:bg-[#303030]" : ""}`}
+                className={`min-h-[36px] min-w-[92px] ${liked ? "border border-[#f0ccd3] bg-[#fff4f7] text-[#333333] hover:bg-[#ffeaf0]" : ""}`}
               >
                 <LikeIcon filled={liked} className={`h-4 w-4 ${liked ? DETAIL_LIKE_ACTIVE_ICON_CLASS : ""}`} />
                 <span>いいね</span>
@@ -78,7 +78,7 @@ export function MainColumn({
 
         <div className={`w-full ${DETAIL_MUTED_SURFACE_CLASS} p-[12px]`}>
           <div className={`flex gap-[16px] ${compareOpen ? "flex-col items-start whitespace-normal" : "items-center justify-between whitespace-nowrap"}`}>
-            <div className={`flex min-w-0 gap-x-[16px] text-[13px] text-white/74 md:gap-x-[18px] md:text-[14px] ${compareOpen ? "flex-wrap items-center gap-y-[6px]" : "items-center"}`}>
+            <div className={`flex min-w-0 gap-x-[16px] text-[13px] text-[#5f6678] md:gap-x-[18px] md:text-[14px] ${compareOpen ? "flex-wrap items-center gap-y-[6px]" : "items-center"}`}>
               <span>ver : {currentRun.versionLabel}</span>
               <span>{currentRun.postedLabel}</span>
               <PlatformLabel platform={currentRun.platform} />
@@ -87,7 +87,7 @@ export function MainColumn({
               <button
                 type="button"
                 onClick={onToggleDescription}
-                className={`shrink-0 text-right text-white/78 ${forceMobileLayout ? "text-[13px]" : "text-[13px] md:text-[14px]"}`}
+                className={`shrink-0 text-right text-[#5f6678] transition-colors hover:text-[#111827] ${forceMobileLayout ? "text-[13px]" : "text-[13px] md:text-[14px]"}`}
               >
                 ...もっと見る
               </button>
@@ -96,7 +96,7 @@ export function MainColumn({
 
           {shouldShowExpandedArea ? (
             <div className="mt-[12px] space-y-[12px]">
-              <p className={`whitespace-pre-line leading-[1.75] text-white/88 ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`} style={descriptionExpanded ? undefined : collapsedCopyStyle}>
+              <p className={`whitespace-pre-line leading-[1.75] text-[#333333] ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`} style={descriptionExpanded ? undefined : collapsedCopyStyle}>
                 {currentRun.summary}
               </p>
               <div className="flex flex-wrap gap-[10px] md:gap-[12px]">
@@ -114,12 +114,12 @@ export function MainColumn({
           <SectionTitle>{comments.length}件のコメント</SectionTitle>
           <form onSubmit={onCommentSubmit} className="flex w-full items-center gap-[8px]">
             <CircleAvatar label="You" size={36} />
-            <div className="flex flex-1 items-center justify-between border-b border-white/12 p-[8px] transition focus-within:border-white/30">
+            <div className="flex flex-1 items-center justify-between border-b border-[#d8dde6] p-[8px] transition focus-within:border-[#9aa7ba]">
               <input
                 value={commentDraft}
                 onChange={(event) => onCommentDraftChange(event.target.value)}
                 placeholder="コメントする..."
-                className={`min-w-0 flex-1 border-none bg-transparent text-white outline-none placeholder:text-white/36 ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}
+                className={`min-w-0 flex-1 border-none bg-transparent text-[#333333] outline-none placeholder:text-[#8d93a3] ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}
               />
               <PillButton className="ml-[8px] min-h-[30px] shrink-0 whitespace-nowrap px-[12px] py-[5px] text-[12px] md:text-[13px]">送信</PillButton>
             </div>
@@ -131,11 +131,11 @@ export function MainColumn({
             <article key={comment.id} className="flex items-start gap-[12px]">
               <CircleAvatar label={comment.userName} size={40} />
               <div className="flex min-w-0 flex-1 flex-col gap-[8px] justify-center">
-                <div className={`flex flex-wrap items-center gap-[8px] text-white/88 ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>
+                <div className={`flex flex-wrap items-center gap-[8px] text-[#333333] ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>
                   <span>{comment.userName}</span>
-                  <span className="text-white/42">{comment.postedLabel}</span>
+                  <span className="text-[#8d93a3]">{comment.postedLabel}</span>
                 </div>
-                <div className={`leading-[1.75] text-white/74 ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>{comment.body}</div>
+                <div className={`leading-[1.75] text-[#5f6678] ${forceMobileLayout ? "text-[14px]" : "text-[14px] md:text-[15px]"}`}>{comment.body}</div>
                 <div className={`flex gap-[12px] md:gap-[12px] ${compareOpen ? "w-full shrink min-w-0 flex-wrap" : "shrink-0 flex-nowrap"}`}>
                   <PillButton className="px-[8px] py-[4px] text-[11px] md:text-[12px]" onClick={() => onCommentLike(comment.id)}>
                     <LikeIcon filled={Boolean(commentLikeState[comment.id])} className={`h-3 w-3 ${commentLikeState[comment.id] ? DETAIL_LIKE_ACTIVE_ICON_CLASS : ""}`} />

--- a/src/features/recordDetail/sections/Sidebar.tsx
+++ b/src/features/recordDetail/sections/Sidebar.tsx
@@ -61,7 +61,7 @@ export function Sidebar({
               })}
             </div>
           ) : (
-            <div className="rounded-[16px] border border-dashed border-white/14 bg-[#272727] px-[14px] py-[16px] text-[13px] leading-[1.7] text-white/52">
+            <div className="rounded-[16px] border border-dashed border-[#d8dde6] bg-[#f7f8fa] px-[14px] py-[16px] text-[13px] leading-[1.7] text-[#8d93a3]">
               近い条件の記録はまだありません。
             </div>
           )}

--- a/src/features/recordDetail/sections/SimilarRunCard.tsx
+++ b/src/features/recordDetail/sections/SimilarRunCard.tsx
@@ -34,10 +34,10 @@ function SimilarActionMenu({
         </svg>
       </button>
       {isOpen ? (
-        <div className="absolute right-0 top-full z-20 mt-2 w-[180px] rounded-[16px] border border-white/10 bg-[#323132] p-2 shadow-[0_20px_40px_rgba(0,0,0,0.28)]">
+        <div className="absolute right-0 top-full z-20 mt-2 w-[180px] rounded-[16px] border border-[#e5e7eb] bg-white p-2 shadow-[0_20px_40px_rgba(31,41,55,0.14)]">
           <button
             type="button"
-            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-white/90 hover:bg-white/[0.08]"
+            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-[#333333] hover:bg-[#f1f3f6]"
             onClick={() => onAction("like")}
           >
             <LikeIcon filled={liked} className={`h-4 w-4 ${liked ? DETAIL_LIKE_ACTIVE_ICON_CLASS : ""}`} />
@@ -45,7 +45,7 @@ function SimilarActionMenu({
           </button>
           <button
             type="button"
-            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-white/90 hover:bg-white/[0.08]"
+            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-[#333333] hover:bg-[#f1f3f6]"
             onClick={() => onAction("share")}
           >
             <ShareIcon className="h-4 w-4" />
@@ -53,7 +53,7 @@ function SimilarActionMenu({
           </button>
           <button
             type="button"
-            className="hidden h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-white/90 hover:bg-white/[0.08] lg:flex"
+            className="hidden h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-[#333333] hover:bg-[#f1f3f6] lg:flex"
             onClick={() => onAction("compare")}
           >
             <CompareViewIcon className="h-4 w-4" />
@@ -87,16 +87,16 @@ export function SimilarRunCard({
   return (
     <article
       className={`rounded-[16px] border p-[14px] transition-colors ${
-        isCompareSelected ? "border-white/20 bg-[#3b3a3b]" : "border-white/10 bg-[#323132] hover:bg-[#353435]"
+        isCompareSelected ? "border-[#9aa7ba] bg-[#eef1f5]" : "border-[#e5e7eb] bg-white hover:bg-[#f7f8fa]"
       }`}
     >
       <div className="flex items-start gap-[10px]">
         <div className="min-w-0 flex-1">
           <div className="flex items-start justify-between gap-[12px]">
             <div className="min-w-0 flex-1">
-              <div className="truncate text-[15px] font-semibold leading-[1.4] text-white/92 md:text-[16px]">{match.run.title}</div>
-              <div className="mt-[6px] flex flex-wrap items-center gap-x-[8px] gap-y-[4px] text-[12px] text-white/52 md:text-[13px]">
-                <span className="max-w-full truncate font-medium text-white/78">{match.run.userName}</span>
+              <div className="truncate text-[15px] font-semibold leading-[1.4] text-[#111827] md:text-[16px]">{match.run.title}</div>
+              <div className="mt-[6px] flex flex-wrap items-center gap-x-[8px] gap-y-[4px] text-[12px] text-[#8d93a3] md:text-[13px]">
+                <span className="max-w-full truncate font-medium text-[#5f6678]">{match.run.userName}</span>
                 <span>{match.run.postedLabel}</span>
                 <PlatformLabel platform={match.run.platform} iconClassName="h-[13px] w-[13px]" />
               </div>
@@ -106,7 +106,7 @@ export function SimilarRunCard({
             </div>
           </div>
 
-          <div className="mt-[12px] rounded-[16px] border border-white/10 bg-[#272727] px-[10px] py-[9px]">
+          <div className="mt-[12px] rounded-[16px] border border-[#e5e7eb] bg-[#f7f8fa] px-[10px] py-[9px]">
             <div className="flex items-center justify-between gap-[8px]">
               {match.run.party.map((member) => {
                 const characterName = characterDb[member.characterId]?.name ?? member.characterId;

--- a/src/features/recordDetail/ui/index.tsx
+++ b/src/features/recordDetail/ui/index.tsx
@@ -54,7 +54,7 @@ export function PillButton({
       className={`inline-flex items-center justify-center gap-2 rounded-[42px] px-[14px] py-[7px] text-[14px] font-medium leading-none transition duration-150 hover:-translate-y-[1px] hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)] md:text-[15px] ${
         dark || active
           ? "border border-black/50 bg-black text-white"
-          : "border border-white/10 bg-[#272727] text-white/90 hover:bg-[#303030]"
+          : "border border-[#d8dde6] bg-[#f7f8fa] text-[#333333] hover:bg-[#eef1f5]"
       } ${className}`}
     >
       {children}
@@ -77,14 +77,14 @@ export function TinyBadge({ label, highlighted = false }: { label: string; highl
 }
 
 export function SectionTitle({ children }: { children: ReactNode }) {
-  return <div className="text-[16px] font-bold leading-none text-white/90 md:text-[18px]">{children}</div>;
+  return <div className="text-[16px] font-bold leading-none text-[#111827] md:text-[18px]">{children}</div>;
 }
 
 export function SidebarPanel({ children }: { children: ReactNode }) {
   return (
     <section className={`w-full ${DETAIL_PANEL_SHELL_CLASS}`}>
       <div className={`${DETAIL_PANEL_INNER_CLASS} p-[16px]`}>
-        <div className="pointer-events-none absolute -left-[30%] -top-[44%] h-[220px] w-[220px] rounded-full bg-white/18 blur-[72px]" />
+        <div className="pointer-events-none absolute -left-[30%] -top-[44%] h-[220px] w-[220px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.72),rgba(232,224,210,0.24)_48%,rgba(255,255,255,0)_72%)] blur-[72px]" />
         <div className="relative z-[1]">{children}</div>
       </div>
     </section>
@@ -95,19 +95,19 @@ export function SidebarSectionHeader({ title, meta }: { title: ReactNode; meta?:
   return (
     <div className="flex items-start justify-between gap-[12px]">
       <SectionTitle>{title}</SectionTitle>
-      {meta ? <div className="shrink-0 text-[12px] font-medium text-white/52 md:text-[13px]">{meta}</div> : null}
+      {meta ? <div className="shrink-0 text-[12px] font-medium text-[#8d93a3] md:text-[13px]">{meta}</div> : null}
     </div>
   );
 }
 
 export function PartyBuildItemCard({ entry }: { entry: PartyBuildItem }) {
   return (
-    <div className="rounded-[16px] border border-white/10 bg-[#272727] p-[12px] md:p-[14px]">
+    <div className="rounded-[16px] border border-[#e5e7eb] bg-[#f7f8fa] p-[12px] md:p-[14px]">
       <div className="flex items-start gap-[12px] md:gap-[14px]">
         <CharacterIcon characterId={entry.characterId} alt={entry.characterName} fallbackLabel={entry.characterName} size={56} />
         <div className="min-w-0 flex-1">
-          <div className="truncate text-[16px] font-semibold leading-[1.2] text-white/92 md:text-[17px]">{entry.characterName}</div>
-          <div className="mt-[5px] truncate text-[13px] leading-[1.45] text-white/56 md:text-[14px]">{entry.weaponName}</div>
+          <div className="truncate text-[16px] font-semibold leading-[1.2] text-[#111827] md:text-[17px]">{entry.characterName}</div>
+          <div className="mt-[5px] truncate text-[13px] leading-[1.45] text-[#5f6678] md:text-[14px]">{entry.weaponName}</div>
           <div className="mt-[10px] flex flex-wrap gap-[8px]">
             <TinyBadge label={`C${entry.cons}`} highlighted={entry.cons === 6} />
             <TinyBadge label={`R${entry.refine}`} highlighted={entry.refine === 5} />
@@ -120,7 +120,7 @@ export function PartyBuildItemCard({ entry }: { entry: PartyBuildItem }) {
 
 export function SimilarityReasonChip({ label }: { label: string }) {
   return (
-    <span className="inline-flex items-center rounded-full border border-white/10 bg-[#272727] px-[10px] py-[5px] text-[11px] font-medium leading-none text-white/68 md:text-[12px]">
+    <span className="inline-flex items-center rounded-full border border-[#d8dde6] bg-[#eef1f5] px-[10px] py-[5px] text-[11px] font-medium leading-none text-[#5f6678] md:text-[12px]">
       {label}
     </span>
   );
@@ -145,7 +145,7 @@ export function TagChip({ tag }: { tag: string }) {
   const platformParts = parsePlatformTag(tag);
 
   return (
-    <span className="inline-flex items-center gap-[6px] rounded-[42px] border border-white/10 bg-[#272727] px-[10px] py-[5px] text-[12px] text-white/85 md:px-[12px] md:py-[6px] md:text-[13px]">
+    <span className="inline-flex items-center gap-[6px] rounded-[42px] border border-[#d8dde6] bg-white px-[10px] py-[5px] text-[12px] text-[#333333] md:px-[12px] md:py-[6px] md:text-[13px]">
       {platformParts ? (
         <span className="inline-flex items-center gap-[4px]">
           {platformParts.map((platform, index) => (
@@ -174,7 +174,7 @@ export function VideoFrame({
   const embedUrl = getYouTubeEmbedUrl(videoUrl, { autoplay, mute, enableJsApi: true });
 
   return (
-    <div className="aspect-[669/380] w-full overflow-hidden rounded-[16px] border border-white/10 bg-[#272727] shadow-[0_20px_40px_rgba(0,0,0,0.28)]">
+    <div className="aspect-[669/380] w-full overflow-hidden rounded-[16px] border border-[#e5e7eb] bg-[#d9d9d9] shadow-[0_16px_34px_rgba(31,41,55,0.12)]">
       {embedUrl ? (
         <iframe
           ref={iframeRef}


### PR DESCRIPTION
## 概要
- #home と #detail を、現行のレイアウトや二重枠、影、hoverなどのUI構造は維持したままライト配色へ戻しました。
- #home/#detail 表示時の AppShell ヘッダーとドロワーもライトクロームへ切り替えました。
- ヒーロー下端、ページ背景、リーダーボード帯、詳細ページ、比較ビューの背景色を #f5f6f8 に統一しました。
- TOP/注目プレイヤー周辺は、ライト背景で継ぎ目が目立たないようにパネル外側の影と二重枠の見え方を調整しました。
- リーダーボード切替タブとヘッダーのバージョン選択は、旧ライト仕様の白地/黒文字系へ戻しました。

## 実装意図
- 旧コミットの単純復元ではなく、ダーク化後に追加されたカード密度、角丸、影、hover、二重枠などのUI改善は残しています。
- 背景の色ズレはページキャンバス側を #f5f6f8 に揃えて解消し、TOP/注目プレイヤー間の違和感は不要なフェード追加ではなく、横に広がる大パネル影を抑える形で対応しました。
- submit や placeholder 系ルートの黒基調は対象外として維持しています。

## 検証
- npm run lint（既存 warning 2件のみ）
- npm run test
- npm run typecheck
- npm run build