### PR TITLE
ライブラリ導線とホーム上部カードのUI調整

### DIFF
--- a/src/features/home/ui/PlayerBlockPanel.tsx
+++ b/src/features/home/ui/PlayerBlockPanel.tsx
@@ -18,6 +18,19 @@ const BLOCK_GAP = scale(12);
 const SECTION_CARD_AREA_PADDING = { top: scale(10), right: scale(10), bottom: scale(12), left: scale(10) } as const;
 const RANK_BLOCK_WIDTH = CARD_SIZE.outerWidth * 4 + RAIL_GAP * 3 + RAIL_PADDING * 2;
 const SECTION_BLOCK_WIDTH = RANK_BLOCK_WIDTH * 4 + BLOCK_GAP * 3 + SECTION_CARD_AREA_PADDING.left + SECTION_CARD_AREA_PADDING.right;
+const MOBILE_MEDIA_QUERY = "(min-width: 640px)";
+const MOBILE_BLOCK_GAP = scale(8);
+const MOBILE_SECTION_CARD_AREA_PADDING = { top: scale(8), right: scale(8), bottom: scale(8), left: scale(8) } as const;
+const MOBILE_RUN_BLOCK_MIN_HEIGHT = scale(88);
+const MOBILE_RAIL_GAP = scale(1);
+const MOBILE_RAIL_PADDING = scale(0.75);
+const MOBILE_TEXT_AREA_PADDING = { top: scale(13), right: scale(7.5), bottom: scale(11), left: scale(8.4) } as const;
+const MOBILE_TEXT_FONT = {
+  label: scale(16.2),
+  userName: scale(21.6),
+  time: scale(14.8),
+  action: scale(6.9),
+} as const;
 
 const MAGAZINE_FACE_CROP = {
   trimLeftPercent: 10,
@@ -70,12 +83,29 @@ export function PlayerBlockPanel({
   loadingLabel,
   onSelectRun,
 }: PlayerBlockPanelProps) {
+  const [isDesktopLayout, setIsDesktopLayout] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia(MOBILE_MEDIA_QUERY).matches : true,
+  );
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(MOBILE_MEDIA_QUERY);
+    const updateLayout = () => setIsDesktopLayout(mediaQuery.matches);
+
+    updateLayout();
+    mediaQuery.addEventListener("change", updateLayout);
+    return () => mediaQuery.removeEventListener("change", updateLayout);
+  }, []);
+
   return (
     <section
       data-panel-key={panelKey}
       data-top-panel
       className="shrink-0 overflow-hidden"
-      style={{ width: SECTION_BLOCK_WIDTH, minWidth: SECTION_BLOCK_WIDTH }}
+      style={
+        isDesktopLayout
+          ? { width: SECTION_BLOCK_WIDTH, minWidth: SECTION_BLOCK_WIDTH }
+          : { width: "100%", minWidth: "100%" }
+      }
     >
       <header className="relative flex items-stretch bg-[#111116]" style={{ minHeight: scale(44) }}>
         <div className="flex flex-1 items-center" style={{ gap: scale(10), paddingLeft: scale(14), paddingRight: scale(14) }}>
@@ -117,15 +147,17 @@ export function PlayerBlockPanel({
       <div className="h-px bg-white/10" />
 
       <div
-        className="overflow-x-auto"
+        className={isDesktopLayout ? "overflow-x-auto" : "overflow-hidden"}
         style={{
           background: "#f4f3f1",
-          padding: `${SECTION_CARD_AREA_PADDING.top}px ${SECTION_CARD_AREA_PADDING.right}px ${SECTION_CARD_AREA_PADDING.bottom}px ${SECTION_CARD_AREA_PADDING.left}px`,
+          padding: isDesktopLayout
+            ? `${SECTION_CARD_AREA_PADDING.top}px ${SECTION_CARD_AREA_PADDING.right}px ${SECTION_CARD_AREA_PADDING.bottom}px ${SECTION_CARD_AREA_PADDING.left}px`
+            : `${MOBILE_SECTION_CARD_AREA_PADDING.top}px ${MOBILE_SECTION_CARD_AREA_PADDING.right}px ${MOBILE_SECTION_CARD_AREA_PADDING.bottom}px ${MOBILE_SECTION_CARD_AREA_PADDING.left}px`,
         }}
       >
-        <div className="flex items-start" style={{ gap: BLOCK_GAP }}>
+        <div className={isDesktopLayout ? "flex items-start" : "flex flex-col"} style={{ gap: isDesktopLayout ? BLOCK_GAP : MOBILE_BLOCK_GAP }}>
           {items.map((item) => (
-            <PlayerRunBlock key={item.key} item={item} loadingLabel={loadingLabel} onSelectRun={onSelectRun} />
+            <PlayerRunBlock key={item.key} item={item} loadingLabel={loadingLabel} onSelectRun={onSelectRun} isDesktopLayout={isDesktopLayout} />
           ))}
         </div>
       </div>
@@ -137,10 +169,12 @@ function PlayerRunBlock({
   item,
   loadingLabel,
   onSelectRun,
+  isDesktopLayout,
 }: {
   item: PlayerBlockItem;
   loadingLabel: string;
   onSelectRun: (runId: string) => void;
+  isDesktopLayout: boolean;
 }) {
   const cards = buildCharacterCards(item.run, item.accentColor);
   const canOpenDetail = Boolean(item.run);
@@ -153,8 +187,12 @@ function PlayerRunBlock({
 
   return (
     <article
-      className={`flex shrink-0 flex-col overflow-hidden border border-[#cfcfcf] bg-white ${canOpenDetail ? "cursor-pointer transition-transform hover:-translate-y-0.5" : ""}`}
-      style={{ width: RANK_BLOCK_WIDTH, minWidth: RANK_BLOCK_WIDTH }}
+      className={`${isDesktopLayout ? "flex shrink-0 flex-col" : "grid"} overflow-hidden border border-[#cfcfcf] bg-white ${canOpenDetail ? "cursor-pointer transition-transform hover:-translate-y-0.5" : ""}`}
+      style={
+        isDesktopLayout
+          ? { width: RANK_BLOCK_WIDTH, minWidth: RANK_BLOCK_WIDTH }
+          : { width: "100%", minWidth: 0, minHeight: MOBILE_RUN_BLOCK_MIN_HEIGHT, gridTemplateColumns: "4fr 5fr" }
+      }
       role={canOpenDetail ? "button" : undefined}
       tabIndex={canOpenDetail ? 0 : undefined}
       onClick={openDetail}
@@ -167,9 +205,11 @@ function PlayerRunBlock({
         openDetail();
       }}
     >
-      <section className="flex shrink-0" style={{ gap: RAIL_GAP, padding: RAIL_PADDING, background: "#cccccc" }}>
+      {isDesktopLayout ? (
+        <>
+          <section className="flex shrink-0" style={{ gap: RAIL_GAP, padding: RAIL_PADDING, background: "#cccccc" }}>
         {cards.map((card, index) => (
-          <PlayerCharacterCard key={`${item.key}-${card.characterId}-${index}`} card={card} />
+          <PlayerCharacterCard key={`${item.key}-${card.characterId}-${index}`} card={card} variant="desktop" />
         ))}
       </section>
       <section
@@ -212,6 +252,63 @@ function PlayerRunBlock({
           </button>
         </div>
       </section>
+        </>
+      ) : (
+        <>
+          <section
+            className="flex flex-1 items-start"
+            style={{
+              paddingLeft: MOBILE_TEXT_AREA_PADDING.left,
+              paddingRight: MOBILE_TEXT_AREA_PADDING.right,
+              paddingTop: MOBILE_TEXT_AREA_PADDING.top,
+              paddingBottom: MOBILE_TEXT_AREA_PADDING.bottom,
+              background: "#fffcf9",
+            }}
+          >
+            <div className="flex w-full flex-col items-start">
+              <div className="font-black leading-none" style={{ color: item.accentColor, fontSize: MOBILE_TEXT_FONT.label, fontFamily: FONT_FAMILY.headingDisplay }}>
+                {item.label}
+              </div>
+              <div
+                className="max-w-full break-words font-black leading-[0.92] text-black"
+                style={{ marginTop: scale(6.4), fontSize: MOBILE_TEXT_FONT.userName, fontFamily: FONT_FAMILY.headingDisplay }}
+              >
+                {item.run?.userName ?? loadingLabel}
+              </div>
+              <div className="font-extrabold leading-none text-black" style={{ marginTop: scale(7.2), fontSize: MOBILE_TEXT_FONT.time }}>
+                {item.run?.time ?? "--:--"}
+              </div>
+              <button
+                type="button"
+                className="text-left font-extrabold leading-none text-[#b8b8b8] transition-colors hover:text-[#666666] disabled:cursor-default disabled:text-[#d0d0d0]"
+                style={{ marginTop: scale(4.2), fontSize: MOBILE_TEXT_FONT.action }}
+                disabled={item.actionDisabled}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  if (!item.actionDisabled) {
+                    item.onAction();
+                  }
+                }}
+              >
+                {item.actionLabel} 竊・
+              </button>
+            </div>
+          </section>
+          <section
+            className="grid h-full min-w-0 self-stretch"
+            style={{
+              gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+              gap: MOBILE_RAIL_GAP,
+              padding: MOBILE_RAIL_PADDING,
+              background: "#cccccc",
+            }}
+          >
+            {cards.map((card, index) => (
+              <PlayerCharacterCard key={`${item.key}-${card.characterId}-${index}`} card={card} variant="mobile" />
+            ))}
+          </section>
+        </>
+      )}
     </article>
   );
 }
@@ -239,9 +336,16 @@ function buildCharacterCards(run: HomeRun | null, accentColor: string): Characte
   });
 }
 
-function PlayerCharacterCard({ card }: { card: CharacterCardData }) {
+function PlayerCharacterCard({ card, variant }: { card: CharacterCardData; variant: "desktop" | "mobile" }) {
   return (
-    <div className="relative overflow-hidden bg-[#8f8f91]" style={{ width: CARD_SIZE.outerWidth, height: CARD_SIZE.height, paddingLeft: scale(0.6), paddingRight: scale(0.6) }}>
+    <div
+      className="relative min-w-0 overflow-hidden bg-[#8f8f91]"
+      style={
+        variant === "desktop"
+          ? { width: CARD_SIZE.outerWidth, height: CARD_SIZE.height, paddingLeft: scale(0.6), paddingRight: scale(0.6) }
+          : { width: "100%", height: "100%", paddingLeft: scale(0.4), paddingRight: scale(0.4) }
+      }
+    >
       <div className="relative h-full w-full overflow-hidden" style={{ background: card.cardBackgroundColor }}>
         <CharacterImageLayer card={card} />
       </div>

--- a/src/features/library/sections/FilterEntrance.tsx
+++ b/src/features/library/sections/FilterEntrance.tsx
@@ -13,7 +13,7 @@ import {
   type WeaponTier,
 } from "../../../data/mockRuns";
 import { formatVersionLabel, versionRank } from "../../../lib/versionLabels";
-import { HOME_BRACKET_ACCENT_COLORS, HOME_ELEMENT_FILTER_OPTIONS, HOME_FILTER_TAG_GROUP_DEFINITIONS, HOME_FILTER_TARGET_OPTIONS } from "../../home/config";
+import { HOME_ELEMENT_FILTER_OPTIONS, HOME_FILTER_TAG_GROUP_DEFINITIONS, HOME_FILTER_TARGET_OPTIONS } from "../../home/config";
 import { cloneHomeFilterState, createEmptyHomeFilterState, updateSelectionGroup } from "../../home/logic";
 import type { CharacterFilterTabKey, HomeFilterState, SelectionTarget } from "../../home/types";
 import { FilterDrawer } from "../../home/ui/FilterDrawer";
@@ -25,8 +25,10 @@ import { cloneLibraryBuildFilterState, cloneLibraryCategoryFilterState, cloneLib
 import { LIBRARY_BUILD_RANGE_LIMITS as BUILD_RANGE_LIMITS, type LibraryBuildFilterState, type LibraryCategoryFilterState, type LibrarySearchFilters, type NumericRange } from "../types";
 
 type LibraryFilterKey = (typeof LIBRARY_FILTER_PANELS)[number]["key"];
+type LibraryFilterPanel = (typeof LIBRARY_FILTER_PANELS)[number];
 type SelectableFilterKey = Exclude<LibraryFilterKey, "search">;
-type IconType = (typeof LIBRARY_FILTER_PANELS)[number]["icon"];
+type SelectableFilterPanel = Extract<LibraryFilterPanel, { key: SelectableFilterKey }>;
+type SearchFilterPanel = Extract<LibraryFilterPanel, { key: "search" }>;
 type CharacterSummaryGroup = "partyCharacters" | "mainAttackers";
 type CharacterSummaryTarget = "include" | "exclude";
 type WeaponSummaryTarget = "include" | "exclude";
@@ -88,27 +90,33 @@ const UI = {
   cardBorder: "#CFCFCF",
 } as const;
 
-const DESKTOP_FILTER_DIM_CLASS = "bg-black/50 group-hover:bg-black/0 group-focus-visible:bg-black/0";
+const FILTER_CARD_DIM_CLASS = "bg-black/[0.58] group-hover:bg-black/[0.36] group-focus-visible:bg-black/[0.36]";
+const FILTER_CARD_DETAILS: Record<SelectableFilterKey, { number: string; subLabel: string }> = {
+  character: { number: "01", subLabel: "PARTY / MAIN" },
+  build: { number: "02", subLabel: "CONST / WEAPON" },
+  category: { number: "03", subLabel: "RULE / VERSION" },
+  tag: { number: "04", subLabel: "TAG CLUSTER" },
+};
 
 const DESKTOP_FILTER_CARD_META: Record<SelectableFilterKey, { imageUrl: string; backgroundColor: string; objectPosition: string }> = {
   character: {
     imageUrl: "https://enka.network/ui/UI_Gacha_AvatarImg_Chasca.png",
-    backgroundColor: HOME_BRACKET_ACCENT_COLORS[4],
+    backgroundColor: "#274060",
     objectPosition: "50% 18%",
   },
   build: {
     imageUrl: "https://enka.network/ui/UI_EquipIcon_Claymore_Wolfmound.png",
-    backgroundColor: HOME_BRACKET_ACCENT_COLORS[3],
+    backgroundColor: "#2c3e3d",
     objectPosition: "50% 44%",
   },
   category: {
     imageUrl: categoryPeriodImageUrl,
-    backgroundColor: HOME_BRACKET_ACCENT_COLORS[2],
+    backgroundColor: "#4a3528",
     objectPosition: "50% 34%",
   },
   tag: {
     imageUrl: "https://static.wikia.nocookie.net/gensin-impact/images/6/65/Item_An_Appellative_Stroke.png/revision/latest?cb=20221207135611",
-    backgroundColor: HOME_BRACKET_ACCENT_COLORS[1],
+    backgroundColor: "#3d2a4a",
     objectPosition: "50% 42%",
   },
 };
@@ -139,12 +147,12 @@ function isSelectableFilterKey(key: LibraryFilterKey): key is SelectableFilterKe
   return key !== "search";
 }
 
-function getNextSelectablePanel(activeKey: SelectableFilterKey | null) {
-  const selectablePanels = LIBRARY_FILTER_PANELS.filter((panel): panel is (typeof LIBRARY_FILTER_PANELS)[number] & { key: SelectableFilterKey } =>
-    isSelectableFilterKey(panel.key),
-  );
-  const activeIndex = activeKey ? selectablePanels.findIndex((panel) => panel.key === activeKey) : -1;
-  return selectablePanels[(activeIndex + 1) % selectablePanels.length] ?? selectablePanels[0];
+function isSelectableFilterPanel(panel: LibraryFilterPanel): panel is SelectableFilterPanel {
+  return isSelectableFilterKey(panel.key);
+}
+
+function isSearchFilterPanel(panel: LibraryFilterPanel): panel is SearchFilterPanel {
+  return panel.key === "search";
 }
 
 function isDefaultRange(value: NumericRange, limit: NumericRange) {
@@ -204,7 +212,6 @@ export function FilterEntrance({
   const [isCharacterModalOpen, setIsCharacterModalOpen] = useState(false);
   const [isWeaponModalOpen, setIsWeaponModalOpen] = useState(false);
   const activeLabel = useMemo(() => LIBRARY_FILTER_PANELS.find((panel) => panel.key === activeKey)?.label ?? "", [activeKey]);
-  const nextMobilePanel = getNextSelectablePanel(activeKey);
 
   const createCurrentSearchFilters = (): LibrarySearchFilters => ({
     characterFilters: cloneHomeFilterState(characterFilters),
@@ -290,9 +297,9 @@ export function FilterEntrance({
         </header>
         <div className="h-px bg-white/10" />
         <div className="p-3 sm:p-4" style={{ background: UI.sectionBody }}>
-          <DesktopFilterCards activeKey={activeKey} onPanelClick={handleDesktopPanelClick} onSearch={handleSearch} />
-          <MobileChipBar activeKey={activeKey} onPanelClick={handleMobilePanelClick} />
-          <div className="sm:hidden">
+          <FilterCardBar activeKey={activeKey} onPanelClick={handleDesktopPanelClick} variant="desktop" className="hidden sm:block" />
+          <FilterCardBar activeKey={activeKey} onPanelClick={handleMobilePanelClick} variant="mobile" className="sm:hidden" />
+          <div className="mt-3 sm:hidden">
             {activeKey === "character" ? (
               <CharacterFilterSummaryPanel filters={characterFilters} onOpenPicker={() => setIsCharacterModalOpen(true)} onRemoveFilter={handleRemoveCharacterFilter} />
             ) : null}
@@ -302,12 +309,6 @@ export function FilterEntrance({
             {activeKey === "category" ? <CategoryFilterPanel filters={categoryFilters} onChange={setCategoryFilters} /> : null}
             {activeKey === "tag" ? <TagFilterPanel selectedTags={selectedTags} onToggleTag={handleToggleTag} /> : null}
           </div>
-          <MobileFilterActions
-            showNext={activeKey !== null}
-            nextLabel={nextMobilePanel.label}
-            onNext={() => setActiveKey(nextMobilePanel.key)}
-            onSearch={handleSearch}
-          />
         </div>
       </div>
       <LibraryFilterModal
@@ -1536,88 +1537,52 @@ function getWeaponTierBadgeClass(tier: WeaponTier) {
   }
 }
 
-function DesktopFilterCards({
+function FilterCardBar({
   activeKey,
   onPanelClick,
-  onSearch,
+  variant,
+  className,
 }: {
   activeKey: SelectableFilterKey | null;
   onPanelClick: (key: LibraryFilterKey) => void;
-  onSearch: () => void;
+  variant: "desktop" | "mobile";
+  className?: string;
 }) {
-  const panels = LIBRARY_FILTER_PANELS.filter((panel): panel is (typeof LIBRARY_FILTER_PANELS)[number] & { key: SelectableFilterKey } =>
-    isSelectableFilterKey(panel.key),
-  );
+  const isMobile = variant === "mobile";
 
   return (
-    <div className="library-desktop-filter-entry hidden sm:block">
-      <div className="grid overflow-hidden border border-black/10 bg-transparent shadow-[0_14px_30px_rgba(15,23,42,0.18)] md:grid-cols-4">
-        {panels.map((panel) => {
-          const meta = DESKTOP_FILTER_CARD_META[panel.key];
-          const isActive = panel.key === activeKey;
+    <div className={[isMobile ? "" : "no-scrollbar overflow-x-auto", className].filter(Boolean).join(" ")} role="group" aria-label={LIBRARY_LABELS.searchTitle}>
+      <div
+        className={
+          isMobile
+            ? "grid grid-cols-1 gap-px overflow-hidden border border-black/25 bg-[#08080c] shadow-[0_14px_30px_rgba(15,23,42,0.18)]"
+            : "grid min-w-[932px] grid-cols-[repeat(4,210px)_92px] gap-px overflow-hidden border border-black/25 bg-[#08080c] shadow-[0_14px_30px_rgba(15,23,42,0.18)] sm:min-w-0 sm:grid-cols-[repeat(4,minmax(0,1fr))_minmax(92px,0.42fr)]"
+        }
+      >
+        {LIBRARY_FILTER_PANELS.map((panel) => {
+          const isSearch = panel.key === "search";
+          const isActive = !isSearch && panel.key === activeKey;
+          const backgroundColor = getFilterCardBackgroundColor(panel);
 
           return (
             <button
               key={panel.key}
               type="button"
-              aria-pressed={isActive}
+              aria-pressed={isSearch ? undefined : isActive}
               onClick={() => onPanelClick(panel.key)}
-              className="library-desktop-filter-card group relative min-h-[160px] overflow-hidden border-b border-white/10 text-[#d9d9d9] outline-none transition md:min-h-[190px] md:border-b-0 md:border-r last:border-b-0 md:last:border-r-0 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/75"
+              className={[
+                isMobile
+                  ? "group relative h-[58px] overflow-hidden text-[#d9d9d9] outline-none transition focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/75"
+                  : "group relative h-[138px] overflow-hidden text-[#d9d9d9] outline-none transition focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/75 sm:h-[168px] md:h-[190px]",
+                isActive ? "ring-2 ring-inset ring-white/70" : "",
+              ].join(" ")}
               style={
                 {
-                  backgroundColor: "#606060",
+                  backgroundColor,
                 } as CSSProperties
               }
             >
-              <img
-                src={meta.imageUrl}
-                alt=""
-                className="absolute inset-0 h-full w-full scale-[1.08] object-cover opacity-70 transition duration-300 group-hover:scale-[1.13] group-hover:opacity-100 group-focus-visible:scale-[1.13] group-focus-visible:opacity-100"
-                style={{ objectPosition: meta.objectPosition }}
-                loading="lazy"
-              />
-              <span className={`absolute inset-0 transition-colors duration-200 ${DESKTOP_FILTER_DIM_CLASS}`} />
-              <span className="relative z-10 flex h-full min-h-[160px] flex-col items-center justify-center gap-2 px-4 text-center md:min-h-[190px]">
-                <span className="grid h-10 w-10 place-items-center rounded-full bg-black/35 text-[#d9d9d9] shadow-[0_10px_24px_rgba(0,0,0,0.28)] backdrop-blur-sm transition duration-300 group-hover:bg-white/90 group-hover:text-[#111116] group-focus-visible:bg-white/90 group-focus-visible:text-[#111116] md:h-11 md:w-11">
-                  <FilterIcon type={panel.icon} className="h-5 w-5 md:h-5 md:w-5" />
-                </span>
-                <span className="text-[14px] font-black leading-tight tracking-[0.02em] drop-shadow-[0_2px_8px_rgba(0,0,0,0.55)] md:text-[16px]">{panel.label}</span>
-              </span>
-            </button>
-          );
-        })}
-      </div>
-      <button
-        type="button"
-        onClick={onSearch}
-        className="mt-3 flex h-13 w-full items-center justify-center gap-3 rounded-[10px] border border-[#111116] bg-[#111116] px-5 text-[15px] font-black tracking-[0.08em] text-[#d9d9d9] shadow-[0_12px_24px_rgba(17,17,22,0.22)] transition hover:bg-[#2a2a31] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50 focus-visible:ring-offset-2 focus-visible:ring-offset-[#f4f3f1]"
-      >
-        <SearchIcon size={18} className="text-[#d9d9d9]" />
-        <span>{LIBRARY_FILTER_PANELS.find((panel) => panel.key === "search")?.label ?? "検索"}</span>
-      </button>
-    </div>
-  );
-}
-
-function MobileChipBar({ activeKey, onPanelClick }: { activeKey: SelectableFilterKey | null; onPanelClick: (key: LibraryFilterKey) => void }) {
-  return (
-    <div className="sm:hidden">
-      <div className="no-scrollbar flex overflow-x-auto rounded-[8px] border border-[#d2d5dc] bg-white shadow-[0_8px_18px_rgba(21,27,38,0.08)]" aria-label={LIBRARY_LABELS.searchTitle}>
-        {LIBRARY_FILTER_PANELS.filter((panel) => panel.key !== "search").map((panel) => {
-          const isActive = panel.key === activeKey;
-          return (
-            <button
-              key={panel.key}
-              type="button"
-              aria-pressed={isActive}
-              onClick={() => onPanelClick(panel.key)}
-              className={[
-                "relative flex h-10 shrink-0 items-center justify-center gap-1.5 border-r border-[#e1e4ea] px-3 text-[12px] font-black transition-colors last:border-r-0 focus:outline-none focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#111116]/50",
-                isActive ? "min-w-[102px] bg-[#f4f5f7] text-[#111116] shadow-[inset_0_-2px_0_#111116]" : "min-w-[102px] bg-white text-[#333333] hover:bg-[#f7f7f7]",
-              ].join(" ")}
-            >
-              <FilterIcon type={panel.icon} className="size-3.5 text-[#333333]" />
-              <span className="whitespace-nowrap">{panel.label}</span>
+              {renderFilterCardContent(panel, variant)}
             </button>
           );
         })}
@@ -1626,148 +1591,93 @@ function MobileChipBar({ activeKey, onPanelClick }: { activeKey: SelectableFilte
   );
 }
 
-function MobileFilterActions({
-  showNext,
-  nextLabel,
-  onNext,
-  onSearch,
-}: {
-  showNext: boolean;
-  nextLabel: string;
-  onNext: () => void;
-  onSearch: () => void;
-}) {
+function getFilterCardBackgroundColor(panel: LibraryFilterPanel) {
+  return isSelectableFilterPanel(panel) ? DESKTOP_FILTER_CARD_META[panel.key].backgroundColor : "#111116";
+}
+
+function renderFilterCardContent(panel: LibraryFilterPanel, variant: "desktop" | "mobile") {
+  return isSearchFilterPanel(panel) ? <SearchFilterCardContent panel={panel} variant={variant} /> : <SelectableFilterCardContent panel={panel} variant={variant} />;
+}
+
+function SelectableFilterCardContent({ panel, variant }: { panel: SelectableFilterPanel; variant: "desktop" | "mobile" }) {
+  const meta = DESKTOP_FILTER_CARD_META[panel.key];
+  const details = FILTER_CARD_DETAILS[panel.key];
+
+  if (variant === "mobile") {
+    return (
+      <>
+        <img
+          src={meta.imageUrl}
+          alt=""
+          className="absolute inset-0 h-full w-full scale-[1.05] object-cover opacity-[0.62] transition duration-300 group-hover:scale-[1.09] group-hover:opacity-80 group-focus-visible:scale-[1.09] group-focus-visible:opacity-80"
+          style={{ objectPosition: meta.objectPosition }}
+          loading="lazy"
+        />
+        <span className={`absolute inset-0 transition-colors duration-200 ${FILTER_CARD_DIM_CLASS}`} />
+        <span className="relative z-10 flex h-full min-w-0 items-center gap-2.5 px-4 text-left">
+          <span className="shrink-0 text-[18px] font-black leading-none text-[#d9d9d9]/[0.9] drop-shadow-[0_2px_8px_rgba(0,0,0,0.55)]">{details.number}</span>
+          <span className="flex min-w-0 items-baseline gap-2">
+            <span className="shrink-0 whitespace-nowrap text-[16px] font-black leading-none tracking-[0.02em] text-white drop-shadow-[0_2px_10px_rgba(0,0,0,0.65)]">{panel.label}</span>
+            <span className="min-w-0 truncate text-[10px] font-black uppercase leading-none tracking-[0.08em] text-[#d9d9d9]/75">{details.subLabel}</span>
+          </span>
+        </span>
+      </>
+    );
+  }
+
   return (
-    <div className={`mt-3 grid gap-2 sm:hidden ${showNext ? "grid-cols-[minmax(0,1fr)_112px]" : "grid-cols-1"}`}>
-      {showNext ? (
-      <button
-        type="button"
-        onClick={onNext}
-        className="flex h-11 min-w-0 items-center justify-center gap-2 rounded-[8px] border border-[#d2d5dc] bg-white px-3 text-[13px] font-black text-[#333333] shadow-[0_6px_14px_rgba(21,27,38,0.06)] transition-colors hover:bg-[#f7f7f7] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50"
-      >
-        <span className="truncate">次: {nextLabel}</span>
-        <span className="text-[16px] leading-none">›</span>
-      </button>
-      ) : null}
-      <button
-        type="button"
-        onClick={onSearch}
-        className="flex h-11 items-center justify-center rounded-[8px] border border-[#111116] bg-[#111116] px-4 text-[13px] font-black text-white shadow-[0_8px_16px_rgba(17,17,22,0.18)] transition-colors hover:bg-[#2a2a31] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50"
-      >
-        検索
-      </button>
-    </div>
+    <>
+      <img
+        src={meta.imageUrl}
+        alt=""
+        className="absolute inset-0 h-full w-full scale-[1.08] object-cover opacity-[0.72] transition duration-300 group-hover:scale-[1.13] group-hover:opacity-90 group-focus-visible:scale-[1.13] group-focus-visible:opacity-90"
+        style={{ objectPosition: meta.objectPosition }}
+        loading="lazy"
+      />
+      <span className={`absolute inset-0 transition-colors duration-200 ${FILTER_CARD_DIM_CLASS}`} />
+      <span className="absolute left-4 top-4 z-10 text-[22px] font-black leading-none text-[#d9d9d9]/[0.88] drop-shadow-[0_2px_8px_rgba(0,0,0,0.55)] sm:left-5 sm:top-5 sm:text-[24px]">
+        {details.number}
+      </span>
+      <span className="relative z-10 flex h-full translate-y-0.5 items-end px-4 pb-5 pt-16 text-left sm:px-5 sm:pb-6">
+        <span className="min-w-0">
+          <span className="block whitespace-nowrap text-[19px] font-black leading-tight tracking-[0.02em] text-white drop-shadow-[0_2px_10px_rgba(0,0,0,0.65)]">{panel.label}</span>
+          <span className="mt-1 block text-[11px] font-black uppercase leading-none tracking-[0.08em] text-[#d9d9d9]/75">{details.subLabel}</span>
+        </span>
+      </span>
+    </>
   );
 }
 
-function FilterIcon({ type, className }: { type: IconType; className?: string }) {
-  const commonProps = { className, fill: "none", stroke: "currentColor", strokeWidth: 2.8, strokeLinecap: "round" as const, strokeLinejoin: "round" as const, "aria-hidden": true };
-  if (type === "character") {
+function SearchFilterCardContent({ panel, variant }: { panel: SearchFilterPanel; variant: "desktop" | "mobile" }) {
+  if (variant === "mobile") {
     return (
-      <svg viewBox="0 0 24 24" {...commonProps}>
-        <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-        <circle cx="9" cy="7" r="4" />
-        <path d="M22 21v-2a4 4 0 0 0-3-3.87" />
-        <path d="M16 3.13a4 4 0 0 1 0 7.75" />
-      </svg>
+      <>
+        <span className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.10),rgba(255,255,255,0)_48%)] opacity-75 transition duration-300 group-hover:opacity-100 group-focus-visible:opacity-100" />
+        <span className="relative z-10 flex h-full items-center justify-center gap-2.5 px-4 text-center">
+          <SearchIcon size={22} className="text-[#d9d9d9] drop-shadow-[0_8px_20px_rgba(0,0,0,0.4)] transition duration-300 group-hover:text-white group-focus-visible:text-white" />
+          <span className="text-[16px] font-black leading-none tracking-[0.02em] text-white">{panel.label}</span>
+        </span>
+      </>
     );
   }
-  if (type === "weapon") {
-    return (
-      <svg viewBox="0 0 24 24" {...commonProps}>
-        <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z" />
-        <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z" />
-      </svg>
-    );
-  }
-  if (type === "calendar") {
-    return (
-      <svg viewBox="0 0 24 24" {...commonProps}>
-        <line x1="10" x2="14" y1="2" y2="2" />
-        <line x1="12" x2="15" y1="14" y2="11" />
-        <circle cx="12" cy="14" r="8" />
-      </svg>
-    );
-  }
-  if (type === "search") {
-    return (
-      <svg viewBox="0 0 48 48" {...commonProps}>
-        <circle cx="22" cy="22" r="13" />
-        <path d="m32 32 8 8" />
-      </svg>
-    );
-  }
+
   return (
-    <svg viewBox="0 0 24 24" {...commonProps}>
-      <path d="M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l6.58-6.58a2.426 2.426 0 0 0 0-3.42z" />
-      <circle cx="7.5" cy="7.5" r=".5" fill="currentColor" stroke="none" />
-    </svg>
+    <>
+      <span className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.10),rgba(255,255,255,0)_48%)] opacity-75 transition duration-300 group-hover:opacity-100 group-focus-visible:opacity-100" />
+      <span className="relative z-10 flex h-full flex-col items-center justify-center gap-3 px-4 text-center">
+        <SearchIcon size={38} className="text-[#d9d9d9] drop-shadow-[0_8px_20px_rgba(0,0,0,0.4)] transition duration-300 group-hover:text-white group-focus-visible:text-white" />
+        <span className="text-[22px] font-black leading-none tracking-[0.02em] text-white sm:text-[23px]">{panel.label}</span>
+      </span>
+    </>
   );
 }
 
 function ResponsiveStyle() {
   return (
     <style>{`
-      .library-filter-search-bar { container-type: inline-size; }
-      .library-filter-panel-content {
-        --icon-size: clamp(16px, 2.05cqw, 23px);
-        --arrow-size: clamp(18px, 2.4cqw, 28px);
-        --title-size: clamp(14px, 1.75cqw, 20px);
-        display: grid;
-        grid-template-columns: var(--icon-size) max-content var(--arrow-size);
-        align-items: center;
-        justify-content: center;
-        gap: clamp(9px, 1.05cqw, 14px);
-        height: 100%;
-        width: 100%;
-        box-sizing: border-box;
-        padding-inline: clamp(14px, 1.8cqw, 24px) clamp(18px, 2.4cqw, 30px);
-      }
-      .library-filter-panel-icon { width: var(--icon-size); height: var(--icon-size); display: grid; place-items: center; }
-      .library-filter-panel-title {
-        min-width: 0;
-        display: flex;
-        flex-wrap: nowrap;
-        align-items: center;
-        justify-content: center;
-        font-size: var(--title-size);
-        line-height: 1.05;
-        font-weight: 900;
-        letter-spacing: 0;
-        white-space: nowrap;
-        word-break: keep-all;
-        overflow-wrap: normal;
-      }
-      .library-filter-panel-title-part { display: inline-block; flex: 0 0 auto; }
-      .library-filter-panel-arrow { display: grid; place-items: center; font-size: var(--arrow-size); line-height: 1; font-weight: 300; }
-      .library-filter-submit-label { font-size: clamp(15px, 1.9cqw, 22px); }
       .library-range-input { pointer-events: none; }
       .library-range-input::-webkit-slider-thumb { pointer-events: auto; }
       .library-range-input::-moz-range-thumb { pointer-events: auto; }
-      @container (max-width: 820px) {
-        .library-filter-panel-content {
-          --icon-size: clamp(14px, 1.85cqw, 19px);
-          --arrow-size: clamp(16px, 1.9cqw, 21px);
-          --title-size: clamp(12px, 1.65cqw, 16px);
-          gap: 5px;
-          padding-inline: 10px 14px;
-        }
-      }
-      @container (max-width: 700px) {
-        .library-filter-panel-content {
-          grid-template-columns: var(--icon-size) minmax(0, 1fr) var(--arrow-size);
-        }
-        .library-filter-panel-title { flex-wrap: wrap; text-align: center; white-space: normal; }
-      }
-      @container (max-width: 640px) {
-        .library-filter-panel-content {
-          grid-template-columns: minmax(0, 1fr) 16px;
-          --title-size: clamp(11px, 2.55cqw, 15px);
-          padding-inline: 8px 10px;
-        }
-        .library-filter-panel-icon { display: none; }
-        .library-filter-panel-arrow { font-size: 20px; }
-      }
     `}</style>
   );
 }

--- a/src/features/library/sections/SearchResults.tsx
+++ b/src/features/library/sections/SearchResults.tsx
@@ -6,6 +6,7 @@ import { appRuns, getAppRunById } from "../../../data/appRuns";
 import { characterDb, type RunRecord } from "../../../data/mockRuns";
 import { getYouTubeVideoId } from "../../../lib/youtube";
 import { formatVersionLabel } from "../../../lib/versionLabels";
+import { HOME_BRACKET_ACCENT_COLORS } from "../../home/config";
 import { getBracketLabel } from "../../home/logic";
 import { SearchIcon } from "../../home/ui/icons";
 import { getPartyBuildItems, postYouTubeCommand } from "../../recordDetail/logic";
@@ -148,9 +149,8 @@ function LibraryRecordCard({
   onToggleWatchLater: (runId: string) => void;
   onSelectRun: (runId: string) => void;
 }) {
-  const versionLabel = formatVersionLabel(run.versionLabel || run.season);
-  const visibleTags = run.tags.slice(0, 5);
   const bracketLabel = formatCompactBracketLabel(getBracketLabel(run.bracket));
+  const visibleTags = Array.from(new Set(run.tags)).slice(0, 4);
   const openDetail = () => onSelectRun(run.id);
   const compareDisabled = !isCandidate && candidateLimitReached;
 
@@ -184,62 +184,49 @@ function LibraryRecordCard({
       tabIndex={0}
       onClick={openDetail}
       onKeyDown={handleKeyDown}
-      className="group cursor-pointer overflow-hidden rounded-[8px] border border-[#dfe3ea] bg-white text-left shadow-[0_12px_28px_rgba(21,27,38,0.07)] transition hover:-translate-y-0.5 hover:shadow-[0_18px_38px_rgba(21,27,38,0.12)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50"
+      className="group flex cursor-pointer flex-col overflow-hidden rounded-[8px] border border-[#dfe3ea] bg-white text-left shadow-[0_10px_24px_rgba(21,27,38,0.06)] transition hover:-translate-y-0.5 hover:border-[#cfd6e2] hover:shadow-[0_18px_34px_rgba(21,27,38,0.11)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50"
       aria-label={`${run.title} の詳細を見る`}
     >
       <Thumbnail run={run} />
-      <div className="p-4">
-        <h3 className="line-clamp-1 text-[16px] font-black tracking-[-0.03em] text-[#111827]">{run.title}</h3>
-
-        <div className="mt-4 flex items-center gap-2">
-          {run.party.map((member) => {
-            const characterName = characterDb[member.characterId]?.name ?? member.characterId;
-            return (
-              <div key={`${run.id}-${member.characterId}`} className="relative">
-                <CharacterIcon characterId={member.characterId} alt={characterName} fallbackLabel={characterName} size={42} className="border border-white bg-[#f4f4f4] shadow-[0_0_0_1px_rgba(17,24,39,0.08)]" />
-                <span className="absolute -bottom-1 -right-1 rounded-full bg-[#eef1f5] px-1.5 py-0.5 text-[9px] font-black leading-none text-[#6b7280] shadow-[0_0_0_1px_rgba(255,255,255,0.9)]">C{member.cons}</span>
-              </div>
-            );
-          })}
-        </div>
-
-        <div className="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1 text-[12px] font-bold text-[#5f6678]">
-          <span className="inline-flex max-w-full items-center gap-1.5 truncate">
-            <span className="grid size-5 shrink-0 place-items-center rounded-full bg-[#eef1f5] text-[10px] text-[#6b7280]">{Array.from(run.userName)[0] ?? "?"}</span>
-            <span className="truncate">{run.userName}</span>
+      <div className="flex flex-1 flex-col gap-2.5 px-[11px] pb-[10px] pt-[11px]">
+        <div className="flex min-w-0 items-center gap-2">
+          <LibraryCardCharacterStack run={run} />
+          <span className="h-3 w-px shrink-0 bg-[#d1d5db]" />
+          <span className="min-w-0 flex-1 truncate text-[13px] font-extrabold text-[#111827]">{run.userName}</span>
+          <span className="flex shrink-0 items-center gap-1">
+            <InfoBadge>{run.platform}</InfoBadge>
+            <InfoBadge>{run.ruleset}</InfoBadge>
           </span>
-          <span className="h-3 w-px bg-[#d1d5db]" />
-          <PlatformLabel platform={run.platform} iconClassName="h-[13px] w-[13px]" />
-          <span className="h-3 w-px bg-[#d1d5db]" />
-          <span>{versionLabel}</span>
         </div>
 
-        <div className="mt-4 flex min-w-0 flex-wrap items-center justify-between gap-x-3 gap-y-1 rounded-[4px] border border-[#e5e7eb] bg-[#f7f8fa] px-3 py-2 text-[11px] font-black text-[#5f6678]">
-          <CostMetric label="Char" value={run.charCost} />
-          <CostMetric label="Weapon" value={run.weaponCost} />
-          <CostMetric label="Bracket" value={bracketLabel} />
+        <h3 className="line-clamp-2 text-[12px] font-semibold leading-[1.45] text-[#374151]">{run.title}</h3>
+
+        <div className="grid min-w-0 grid-cols-3 gap-x-2 rounded-[10px] bg-[#f0f2f5] px-2.5 py-1.5">
+          <CostMetric label="CHAR" value={run.charCost} />
+          <CostMetric label="WEAPON" value={run.weaponCost} />
+          <CostMetric label="BRACKET" value={bracketLabel} />
         </div>
 
-        <div className="mt-3 flex flex-wrap gap-1.5">
+        <div className="flex flex-wrap gap-1">
           {visibleTags.map((tag) => (
-            <span key={`${run.id}-${tag}`} className="max-w-full truncate rounded-full bg-[#f0f2f5] px-2.5 py-1 text-[11px] font-black text-[#5b6472]">
+            <span key={`${run.id}-${tag}`} className="max-w-full truncate rounded-full bg-[#f0f2f5] px-2 py-0.5 text-[10px] font-bold text-[#6b7280]">
               #{tag}
             </span>
           ))}
         </div>
 
-        <div className="mt-4 flex items-center justify-end gap-4 border-t border-[#edf0f4] pt-3 text-[12px] font-black text-[#374151]">
+        <div className="mt-auto flex items-center justify-between border-t border-[#edf0f4] pt-2 text-[11px] font-extrabold text-[#5f6678]">
           <button
             type="button"
             onClick={handleAddCandidate}
             aria-disabled={compareDisabled || isCandidate}
-            className={`flex items-center gap-1.5 transition ${compareDisabled ? "cursor-not-allowed text-[#a2a8b3]" : "hover:text-[#ff3b1f]"} ${isCandidate ? "text-[#5f6678]" : ""}`}
+            className={`flex items-center gap-1 transition ${compareDisabled ? "cursor-not-allowed text-[#b8bec8]" : "hover:text-[#111827]"} ${isCandidate ? "text-[#111827]" : ""}`}
           >
-            {isCandidate ? <CheckIcon className="h-4 w-4" /> : <PlusIcon className="h-4 w-4" />}
+            {isCandidate ? <CheckIcon className="h-[11px] w-[11px]" /> : <PlusIcon className="h-[11px] w-[11px]" />}
             {isCandidate ? "追加済み" : compareDisabled ? "2件まで" : "比較に追加"}
           </button>
-          <button type="button" onClick={handleToggleWatchLater} aria-pressed={isWatchLater} className="flex items-center gap-1.5 transition hover:text-[#ff3b1f]">
-            <BookmarkIcon className={isWatchLater ? "h-4 w-4 fill-current" : "h-4 w-4"} />
+          <button type="button" onClick={handleToggleWatchLater} aria-pressed={isWatchLater} className={`flex items-center gap-1 transition hover:text-[#111827] ${isWatchLater ? "text-[#111827]" : ""}`}>
+            <BookmarkIcon className={isWatchLater ? "h-[11px] w-[11px] fill-current" : "h-[11px] w-[11px]"} />
             {isWatchLater ? "保存済み" : "あとで見る"}
           </button>
         </div>
@@ -660,26 +647,71 @@ function CompareEmptyState() {
 
 function Thumbnail({ run }: { run: RunRecord }) {
   const thumbnailUrl = getYouTubeThumbnailUrl(run.videoUrl);
+  const versionLabel = formatVersionLabel(run.versionLabel || run.season);
+  const bracketLabel = formatCompactBracketLabel(getBracketLabel(run.bracket));
+  const bracketAccentColor = HOME_BRACKET_ACCENT_COLORS[run.bracket];
 
   return (
     <div className="relative aspect-video overflow-hidden bg-[#111827]">
       {thumbnailUrl ? <img src={thumbnailUrl} alt="" className="absolute inset-0 h-full w-full object-cover transition duration-500 group-hover:scale-105" loading="lazy" decoding="async" referrerPolicy="no-referrer" /> : null}
-      <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.08)_0%,rgba(0,0,0,0.08)_46%,rgba(0,0,0,0.66)_100%)]" />
-      <div className="absolute bottom-3 left-3 right-3 min-w-0 text-white">
-        <p className="truncate text-[12px] font-black text-white/72">
-          {run.ruleset} / {formatVersionLabel(run.versionLabel || run.season)}
+      <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.08)_0%,rgba(0,0,0,0.12)_48%,rgba(0,0,0,0.58)_100%)]" />
+      <div className="absolute left-2.5 top-2.5">
+        <BracketBadge color={bracketAccentColor}>{bracketLabel}</BracketBadge>
+      </div>
+      <div className="absolute bottom-2.5 right-2.5 border border-white/15 bg-black/60 px-2 py-1 text-[9px] font-black uppercase leading-none tracking-[0.08em] text-white/72">
+        {run.time}
+      </div>
+      <div className="absolute bottom-2.5 left-2.5 right-16 min-w-0">
+        <p className="truncate text-[10px] font-black uppercase tracking-[0.12em] text-white/62">
+          {versionLabel}
         </p>
-        <p className="mt-0.5 truncate text-[16px] font-black tracking-[-0.03em]">{run.title}</p>
       </div>
     </div>
+  );
+}
+
+function LibraryCardCharacterStack({ run }: { run: RunRecord }) {
+  return (
+    <div className="flex shrink-0">
+      {run.party.map((member, index) => {
+        const characterName = characterDb[member.characterId]?.name ?? member.characterId;
+        return (
+          <div key={`${run.id}-${member.characterId}`} className={index === 0 ? "relative" : "relative -ml-2"} style={{ zIndex: run.party.length - index }}>
+            <CharacterIcon
+              characterId={member.characterId}
+              alt={characterName}
+              fallbackLabel={characterName}
+              size={30}
+              className="border border-white bg-[#eef1f5] shadow-[0_0_0_1px_rgba(17,24,39,0.08)]"
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function InfoBadge({ children }: { children: string }) {
+  return (
+    <span className="max-w-[76px] truncate border border-[#d8dde6] px-1.5 py-0.5 text-[9px] font-black uppercase leading-none tracking-[0.1em] text-[#7b8493]">
+      {children}
+    </span>
+  );
+}
+
+function BracketBadge({ children, color }: { children: string; color: string }) {
+  return (
+    <span className="max-w-[68px] truncate px-1.5 py-0.5 text-[9px] font-black uppercase leading-none tracking-[0.1em] text-white" style={{ backgroundColor: color }}>
+      {children}
+    </span>
   );
 }
 
 function CostMetric({ label, value }: { label: string; value: string | number }) {
   return (
     <span className="inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap">
-      <span className="text-[10px] uppercase tracking-[0.08em] text-[#8d93a3]">{label}</span>
-      <span className="truncate text-[12px] text-[#8d93a3]">{value}</span>
+      <span className="text-[10px] font-bold uppercase tracking-[0.06em] text-[#6b7280]">{label}</span>
+      <span className="truncate text-[12px] font-black text-[#6b7280]">{value}</span>
     </span>
   );
 }


### PR DESCRIPTION
## 概要
- ライブラリのフィルターエントランスを参考デザイン寄せで再調整
- ライブラリの検索結果カードを白基調の情報密度高めな構成へ再編
- ホームのTOPプレイヤー / 注目プレイヤーパネルをスマホで縦積みカードに変更

## 変更内容
- フィルターエントランス
  - 5ボタンの黒基調バーを維持しつつ、背景色・数字・ラベル配置を再調整
  - スマホ幅では横スクロールをやめ、低めの縦積みボタン列に変更
  - 検索ボタン幅、検索アイコン、ラベル密度を調整
- 検索結果カード
  - サムネイル上の装飾を整理し、左上に階級バッジ、右下にタイム、左下にバージョンを配置
  - 情報欄を、重なりキャラアイコン / ユーザー名 / 小バッジ / メトリクス / タグ / アクションの順に再構成
  - アクセント色は階級バッジのみに限定し、全体は白基調でまとめた
- ホーム上部カード
  - スマホ幅では各パネル内の4カードを縦積みに変更
  - 各カードは文字左・画像右の 4:5 レイアウトに切り替え、scale ベースの寸法管理は維持

## 実装意図
- フィルターエントランスはPCとスマホで必要な情報密度が違うため、共通コンポーネントに variant を入れて分けた
- 検索結果カードは、既存の挙動を崩さずに見た目だけを寄せるため、データ構造やクリック条件は触らず表示構造だけを整理した
- ホーム上部カードはカルーセルの計測ロジックを壊さないことを優先し、パネル単位のスライドはそのまま、内部レイアウトだけスマホ用に切り替えた

## 確認
- npm run typecheck
- npm run lint
- npm run build

## 補足
- 既存の lint warning 2件は今回の変更起因ではありません