### PR TITLE
記録申請アラート修正とnoindexヘッダー追加

### DIFF
--- a/src/features/submit/Page.tsx
+++ b/src/features/submit/Page.tsx
@@ -122,7 +122,9 @@ export function SubmitPage({ onBack, embedded = false }: { onBack: () => void; e
               onSubmit={() =>
                 handleSubmit(draft, {
                   onSubmitSuccess: () => {
-                    window.alert("謠仙・縺励∪縺励◆");
+                    window.alert(
+                      "記録申請を受け付けました。\n\nこのサイトはUI/UX検証用プロトタイプのため、実際には送信・保存されません。入力内容はブラウザの下書きとして残ります。",
+                    );
                     onBack();
                   },
                   saveDraft,

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,17 @@
   "framework": "vite",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow, noarchive"
+        }
+      ]
+    }
+  ],
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## 変更内容
- 記録申請成功時の文字化けした `window.alert` を日本語文言に修正しました。
- アラート内で、このサイトはUI/UX検証用プロトタイプであり、実際には送信・保存されないことを明記しました。
- `vercel.json` に全ページ対象の `X-Robots-Tag: noindex, nofollow, noarchive` ヘッダーを追加しました。

## 実装意図
- UIレイアウトや送信処理の構造は変えず、完了時の説明だけを修正しています。
- Vercel公開済みデモが検索エンジンに拾われにくくなるよう、Vercelの `headers` 設定でレスポンスヘッダーを付与します。
- `framework` / `buildCommand` / `outputDirectory` / `rewrites` は維持しています。

## 検証
- `npm run typecheck`
- `npm run lint`（既存 warning 2件のみ）
- `npm run test`
- `npm run build`（既存の chunk size warning あり）
- README差分なしを確認
- 秘密情報パターンの混入なしを確認