### PR TITLE
詳細おすすめ導線とTOP操作の調整

### DIFF
--- a/src/RootApp.tsx
+++ b/src/RootApp.tsx
@@ -5,9 +5,9 @@ import { PlaceholderPage } from "./components/PlaceholderPage";
 import { RecordDetailPage } from "./components/RecordDetailPage";
 import { HomePage } from "./components/HomePage";
 import { SubmitPage } from "./components/SubmitPage";
-import { appRuns, defaultAppRunId, getAppRunById } from "./data/appRuns";
+import { defaultAppRunId, getAppRunById } from "./data/appRuns";
 import { LibraryPage } from "./features/library/Page";
-import { uniqueFormattedVersionLabels } from "./lib/versionLabels";
+import { HOME_SEASONS } from "./features/home/config";
 
 type AppRoute =
   | { name: "home" }
@@ -21,9 +21,6 @@ type AppRoute =
   | { name: "account" };
 
 type ShellDestination = Exclude<AppRoute["name"], "detail">;
-
-const DEFAULT_VERSION_OPTIONS = ["Luna3", "Luna2", "Luna1", "5.8", "5.7", "5.6", "5.5", "5.4", "5.3", "5.2", "5.1", "5.0"];
-const APP_VERSION_OPTIONS = uniqueFormattedVersionLabels([...DEFAULT_VERSION_OPTIONS, ...appRuns.map((run) => run.versionLabel)]);
 
 function safeDecodeRouteValue(value: string) {
   try {
@@ -237,7 +234,7 @@ function RoutePlaceholder({ routeName }: { routeName: Exclude<AppRoute["name"], 
 
 export default function RootApp() {
   const [route, setRoute] = useState<AppRoute>(() => getRouteFromLocation());
-  const [selectedVersion, setSelectedVersion] = useState(() => APP_VERSION_OPTIONS[0] ?? "Luna3");
+  const [selectedVersion, setSelectedVersion] = useState(() => HOME_SEASONS[0] ?? "Luna3");
   const [lastBrowseRoute, setLastBrowseRoute] = useState<AppRoute>(() => (route.name === "submit" ? { name: "home" } : route));
   const routeRef = useRef(route);
   const previousRouteRef = useRef<AppRoute | null>(null);
@@ -365,13 +362,10 @@ export default function RootApp() {
   return (
     <AppShell
       routeName={route.name}
-      version={selectedVersion}
-      versionOptions={APP_VERSION_OPTIONS}
       hasUnreadNotifications={route.name !== "notifications"}
       onNavigate={navigateFromShell}
       onTitleClick={navigateHomeFromTitle}
       onRequestSubmit={() => navigate({ name: "submit" })}
-      onVersionChange={setSelectedVersion}
     >
       <div style={{ display: route.name === "home" ? "block" : "none" }} aria-hidden={route.name !== "home"}>
         <HomePage
@@ -399,6 +393,7 @@ export default function RootApp() {
           runId={route.runId}
           onBack={() => navigate({ name: "home" })}
           onRequestSubmit={() => navigate({ name: "submit" })}
+          onSelectRun={(runId) => navigate({ name: "detail", runId })}
         />
       ) : null}
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -256,14 +256,6 @@ function MoreIcon({ className }: { className?: string }) {
   );
 }
 
-function ChevronDownIcon({ className }: { className?: string }) {
-  return (
-    <ShellIcon className={className}>
-      <path d="m6 9 6 6 6-6" />
-    </ShellIcon>
-  );
-}
-
 function PlusIcon({ className }: { className?: string }) {
   return (
     <ShellIcon className={className}>
@@ -419,24 +411,18 @@ function GlobalDrawer({
 
 function GlobalHeader({
   routeName,
-  version,
-  versionOptions,
   hasUnreadNotifications,
   onMenuClick,
   onTitleClick,
   onNavigate,
   onRequestSubmit,
-  onVersionChange,
 }: {
   routeName: ShellRouteName;
-  version: string;
-  versionOptions: string[];
   hasUnreadNotifications: boolean;
   onMenuClick: () => void;
   onTitleClick: () => void;
   onNavigate: (route: ShellDestination) => void;
   onRequestSubmit: () => void;
-  onVersionChange: (version: string) => void;
 }) {
   const lightChrome = false;
   const utilityButtonClass = lightChrome
@@ -469,25 +455,6 @@ function GlobalHeader({
             </button>
           </h1>
 
-          <div className="relative min-w-0">
-            <select
-              value={version}
-              onChange={(event) => onVersionChange(event.target.value)}
-              className={classNames(
-                "min-w-[104px] appearance-none rounded-full border py-2 pl-4 pr-10 text-[12px] font-normal outline-none transition-colors sm:text-[14px] md:text-[16px]",
-                lightChrome
-                  ? "border-black/30 bg-white text-black hover:border-black/45 focus:border-black/60"
-                  : "border-[#3a3a3a] bg-[#272727] text-[#d9d9d9] hover:border-[#505050] focus:border-[#6a6a6a]",
-              )}
-            >
-              {versionOptions.map((option) => (
-                <option key={option} value={option} className={lightChrome ? "bg-white text-black" : "bg-[#272727] text-[#d9d9d9]"}>
-                  {option}
-                </option>
-              ))}
-            </select>
-            <ChevronDownIcon className={classNames("pointer-events-none absolute top-1/2 right-3 size-5 -translate-y-1/2", lightChrome ? "text-black/70" : "text-[#8b95a7]")} />
-          </div>
         </div>
 
         <div className="flex shrink-0 items-center gap-4 sm:gap-6">
@@ -540,23 +507,17 @@ function GlobalHeader({
 
 export function AppShell({
   routeName,
-  version,
-  versionOptions,
   hasUnreadNotifications,
   onNavigate,
   onTitleClick,
   onRequestSubmit,
-  onVersionChange,
   children,
 }: {
   routeName: ShellRouteName;
-  version: string;
-  versionOptions: string[];
   hasUnreadNotifications: boolean;
   onNavigate: (route: ShellDestination) => void;
   onTitleClick: () => void;
   onRequestSubmit: () => void;
-  onVersionChange: (version: string) => void;
   children: ReactNode;
 }) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
@@ -607,14 +568,11 @@ export function AppShell({
         <div className="flex min-w-0 flex-1 flex-col bg-[#f8f9fb]">
           <GlobalHeader
             routeName={routeName}
-            version={version}
-            versionOptions={versionOptions}
             hasUnreadNotifications={hasUnreadNotifications}
             onMenuClick={() => setIsDrawerOpen(true)}
             onTitleClick={handleTitleClick}
             onNavigate={onNavigate}
             onRequestSubmit={onRequestSubmit}
-            onVersionChange={onVersionChange}
           />
 
           <main className={classNames("min-w-0 flex-1 text-[#333333]", routeName === "home" ? "bg-[#EDECEC]" : lightChrome ? "bg-[#f5f6f8]" : "bg-[#f0f2f5]")}>{children}</main>

--- a/src/features/home/Page.tsx
+++ b/src/features/home/Page.tsx
@@ -151,12 +151,12 @@ export function HomePage({
         {activeTab === "main" ? (
           <>
             <TopPanelsCarousel
+              viewportRef={topCarousel.viewportRef}
               rowRef={topCarousel.rowRef}
-              style={topCarousel.style}
               activeIndex={topCarousel.index}
               heroRuns={heroRuns}
               featuredCards={featuredCards}
-              onTransitionEnd={topCarousel.handleTransitionEnd}
+              onScroll={topCarousel.handleScroll}
               onJumpTo={topCarousel.jumpTo}
               onViewBracket={handleViewBracket}
               onSelectRun={onSelectRun}
@@ -165,8 +165,11 @@ export function HomePage({
               leaderboardRef={leaderboardRef}
               leaderboardView={leaderboardView}
               lastUpdatedDate={leaderboardLastUpdatedDate}
+              seasons={HOME_SEASONS}
+              activeSeason={activeSeason}
               filterBracket={filterBracket}
               leaderboardRuns={leaderboardRuns}
+              onSeasonChange={setActiveSeason}
               onFilterBracketChange={setFilterBracket}
               onLeaderboardViewChange={setLeaderboardView}
               onSelectRun={onSelectRun}

--- a/src/features/home/hooks/useTopCarousel.ts
+++ b/src/features/home/hooks/useTopCarousel.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 type UseTopCarouselOptions = {
   enabled: boolean;
@@ -8,6 +8,15 @@ type UseTopCarouselOptions = {
   scrollDurationMs: number;
 };
 
+type InternalCarouselIndex = 0 | 1 | 2;
+type VisibleCarouselIndex = 0 | 1;
+
+const SCROLL_SETTLE_MS = 140;
+
+function easeInOut(progress: number) {
+  return 0.5 - Math.cos(progress * Math.PI) / 2;
+}
+
 export function useTopCarousel({
   enabled,
   contentKey,
@@ -15,31 +24,158 @@ export function useTopCarousel({
   featuredPanelAutoscrollMs,
   scrollDurationMs,
 }: UseTopCarouselOptions) {
+  const viewportRef = useRef<HTMLDivElement | null>(null);
   const rowRef = useRef<HTMLDivElement | null>(null);
   const measureFrameRef = useRef<number | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
   const autoScrollTimerRef = useRef<number | null>(null);
+  const scrollSettleTimerRef = useRef<number | null>(null);
+  const programmaticScrollRef = useRef(false);
   const [offsets, setOffsets] = useState<number[]>([]);
-  const [index, setIndex] = useState(0);
-  const [transitionEnabled, setTransitionEnabled] = useState(false);
+  const [index, setIndex] = useState<InternalCarouselIndex>(0);
+  const [settleVersion, setSettleVersion] = useState(0);
 
-  const clearAutoScrollTimer = () => {
+  const clearAutoScrollTimer = useCallback(() => {
     if (autoScrollTimerRef.current !== null) {
       window.clearTimeout(autoScrollTimerRef.current);
       autoScrollTimerRef.current = null;
     }
-  };
+  }, []);
 
-  const getPanels = () => {
+  const clearScrollSettleTimer = useCallback(() => {
+    if (scrollSettleTimerRef.current !== null) {
+      window.clearTimeout(scrollSettleTimerRef.current);
+      scrollSettleTimerRef.current = null;
+    }
+  }, []);
+
+  const cancelScrollAnimation = useCallback(() => {
+    if (animationFrameRef.current !== null) {
+      window.cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+  }, []);
+
+  const getPanels = useCallback(() => {
     if (!rowRef.current) {
       return [] as HTMLElement[];
     }
 
     return Array.from(rowRef.current.querySelectorAll<HTMLElement>("[data-top-panel]"));
-  };
+  }, []);
 
-  const updateOffsets = () => {
-    setOffsets(getPanels().map((panel) => panel.offsetLeft));
-  };
+  const updateOffsets = useCallback(() => {
+    const panels = getPanels();
+    const firstOffset = panels[0]?.offsetLeft ?? 0;
+
+    setOffsets(panels.map((panel) => panel.offsetLeft - firstOffset));
+  }, [getPanels]);
+
+  const getNearestIndex = useCallback((): InternalCarouselIndex => {
+    const viewport = viewportRef.current;
+
+    if (!viewport || offsets.length === 0) {
+      return 0;
+    }
+
+    let nearestIndex = 0;
+    let nearestDistance = Number.POSITIVE_INFINITY;
+
+    offsets.forEach((offset, offsetIndex) => {
+      const distance = Math.abs(viewport.scrollLeft - offset);
+
+      if (distance < nearestDistance) {
+        nearestDistance = distance;
+        nearestIndex = offsetIndex;
+      }
+    });
+
+    return Math.min(nearestIndex, 2) as InternalCarouselIndex;
+  }, [offsets]);
+
+  const settleScrollPosition = useCallback(() => {
+    const viewport = viewportRef.current;
+    const nearestIndex = getNearestIndex();
+
+    if (nearestIndex === 2 && viewport && offsets[0] !== undefined) {
+      programmaticScrollRef.current = true;
+      viewport.scrollTo({ left: offsets[0], behavior: "auto" });
+      setIndex(0);
+
+      window.setTimeout(() => {
+        programmaticScrollRef.current = false;
+      }, 0);
+    } else {
+      programmaticScrollRef.current = false;
+      setIndex(nearestIndex === 1 ? 1 : 0);
+    }
+
+    setSettleVersion((version) => version + 1);
+  }, [getNearestIndex, offsets]);
+
+  const scheduleScrollSettle = useCallback(() => {
+    clearScrollSettleTimer();
+    scrollSettleTimerRef.current = window.setTimeout(() => {
+      scrollSettleTimerRef.current = null;
+      settleScrollPosition();
+    }, SCROLL_SETTLE_MS);
+  }, [clearScrollSettleTimer, settleScrollPosition]);
+
+  const animateScrollTo = useCallback(
+    (targetOffset: number) => {
+      const viewport = viewportRef.current;
+
+      if (!viewport) {
+        return;
+      }
+
+      cancelScrollAnimation();
+      clearScrollSettleTimer();
+      programmaticScrollRef.current = true;
+
+      const startOffset = viewport.scrollLeft;
+      const distance = targetOffset - startOffset;
+
+      if (Math.abs(distance) < 1) {
+        viewport.scrollTo({ left: targetOffset, behavior: "auto" });
+        scheduleScrollSettle();
+        return;
+      }
+
+      const startTime = window.performance.now();
+
+      const step = (time: number) => {
+        const progress = Math.min((time - startTime) / scrollDurationMs, 1);
+        viewport.scrollLeft = startOffset + distance * easeInOut(progress);
+
+        if (progress < 1) {
+          animationFrameRef.current = window.requestAnimationFrame(step);
+          return;
+        }
+
+        animationFrameRef.current = null;
+        scheduleScrollSettle();
+      };
+
+      animationFrameRef.current = window.requestAnimationFrame(step);
+    },
+    [cancelScrollAnimation, clearScrollSettleTimer, scheduleScrollSettle, scrollDurationMs],
+  );
+
+  const scrollToIndex = useCallback(
+    (nextIndex: InternalCarouselIndex) => {
+      const targetOffset = offsets[nextIndex];
+
+      if (targetOffset === undefined) {
+        return;
+      }
+
+      clearAutoScrollTimer();
+      setIndex(nextIndex);
+      animateScrollTo(targetOffset);
+    },
+    [animateScrollTo, clearAutoScrollTimer, offsets],
+  );
 
   useEffect(() => {
     if (!enabled || !rowRef.current) {
@@ -47,8 +183,11 @@ export function useTopCarousel({
     }
 
     clearAutoScrollTimer();
-    setTransitionEnabled(false);
+    clearScrollSettleTimer();
+    cancelScrollAnimation();
+    programmaticScrollRef.current = true;
     setIndex(0);
+    setSettleVersion((version) => version + 1);
 
     if (measureFrameRef.current !== null) {
       window.cancelAnimationFrame(measureFrameRef.current);
@@ -56,6 +195,8 @@ export function useTopCarousel({
 
     measureFrameRef.current = window.requestAnimationFrame(() => {
       updateOffsets();
+      viewportRef.current?.scrollTo({ left: 0, behavior: "auto" });
+      programmaticScrollRef.current = false;
     });
 
     const observer = new ResizeObserver(() => {
@@ -67,13 +208,39 @@ export function useTopCarousel({
 
     return () => {
       clearAutoScrollTimer();
+      clearScrollSettleTimer();
+      cancelScrollAnimation();
       observer.disconnect();
+
       if (measureFrameRef.current !== null) {
         window.cancelAnimationFrame(measureFrameRef.current);
         measureFrameRef.current = null;
       }
     };
-  }, [contentKey, enabled]);
+  }, [
+    cancelScrollAnimation,
+    clearAutoScrollTimer,
+    clearScrollSettleTimer,
+    contentKey,
+    enabled,
+    getPanels,
+    updateOffsets,
+  ]);
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+
+    if (!enabled || !viewport || offsets.length < 3 || programmaticScrollRef.current) {
+      return;
+    }
+
+    const targetIndex = index === 2 ? 0 : index;
+    const targetOffset = offsets[targetIndex];
+
+    if (targetOffset !== undefined && Math.abs(viewport.scrollLeft - targetOffset) > 1) {
+      viewport.scrollTo({ left: targetOffset, behavior: "auto" });
+    }
+  }, [enabled, index, offsets]);
 
   useEffect(() => {
     if (!enabled || offsets.length < 3 || index === 2) {
@@ -84,39 +251,43 @@ export function useTopCarousel({
 
     const waitMs = index === 0 ? topPanelAutoscrollMs : featuredPanelAutoscrollMs;
     autoScrollTimerRef.current = window.setTimeout(() => {
-      setTransitionEnabled(true);
-      setIndex(index === 0 ? 1 : 2);
+      scrollToIndex(index === 0 ? 1 : 2);
     }, waitMs);
 
     return clearAutoScrollTimer;
-  }, [enabled, featuredPanelAutoscrollMs, index, offsets, topPanelAutoscrollMs]);
+  }, [
+    clearAutoScrollTimer,
+    enabled,
+    featuredPanelAutoscrollMs,
+    index,
+    offsets.length,
+    scrollToIndex,
+    settleVersion,
+    topPanelAutoscrollMs,
+  ]);
 
-  const jumpTo = (nextIndex: 0 | 1) => {
-    clearAutoScrollTimer();
-    setTransitionEnabled(true);
-    setIndex(nextIndex);
-  };
-
-  const handleTransitionEnd = () => {
-    if (index !== 2) {
+  const handleScroll = useCallback(() => {
+    if (!enabled) {
       return;
     }
 
-    // 3 枚目は 1 枚目の複製。アニメーション後に 0 へ戻して無限ループ風に見せる。
-    setTransitionEnabled(false);
-    setIndex(0);
+    if (!programmaticScrollRef.current) {
+      clearAutoScrollTimer();
+      cancelScrollAnimation();
+    }
+
+    scheduleScrollSettle();
+  }, [cancelScrollAnimation, clearAutoScrollTimer, enabled, scheduleScrollSettle]);
+
+  const jumpTo = (nextIndex: VisibleCarouselIndex) => {
+    scrollToIndex(nextIndex);
   };
 
   return {
-    index,
+    index: index === 1 ? 1 : 0,
+    viewportRef,
     rowRef,
-    style: {
-      transform: `translateX(-${offsets[index] ?? 0}px)`,
-      transitionProperty: "transform",
-      transitionDuration: transitionEnabled ? `${scrollDurationMs}ms` : "0ms",
-      transitionTimingFunction: "ease-in-out",
-    },
-    handleTransitionEnd,
+    handleScroll,
     jumpTo,
   };
 }

--- a/src/features/home/sections/LeaderboardSection.tsx
+++ b/src/features/home/sections/LeaderboardSection.tsx
@@ -17,8 +17,11 @@ type LeaderboardSectionProps = {
   leaderboardRef: RefObject<HTMLDivElement | null>;
   leaderboardView: LeaderboardView;
   lastUpdatedDate: string;
+  seasons: readonly string[];
+  activeSeason: string;
   filterBracket: Bracket | null;
   leaderboardRuns: Array<HomeRun | HomeRunWithGroup>;
+  onSeasonChange: (season: string) => void;
   onFilterBracketChange: (bracket: Bracket | null) => void;
   onLeaderboardViewChange: (view: LeaderboardView) => void;
   onSelectRun: (runId: string) => void;
@@ -28,8 +31,11 @@ export function LeaderboardSection({
   leaderboardRef,
   leaderboardView,
   lastUpdatedDate,
+  seasons,
+  activeSeason,
   filterBracket,
   leaderboardRuns,
+  onSeasonChange,
   onFilterBracketChange,
   onLeaderboardViewChange,
   onSelectRun,
@@ -72,14 +78,22 @@ export function LeaderboardSection({
             </div>
           </div>
           <div className="mb-8 flex flex-wrap items-center gap-y-3">
-            <a
-              href="#library"
-              aria-label="記録図書館で記録を探す"
-              className="inline-flex h-11 items-center justify-center gap-2 rounded-full border border-[#d8dde6] bg-white px-5 text-[13px] font-semibold tracking-[0.01em] text-[#333333] transition-colors hover:bg-[#eef1f5] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/40"
-            >
-              <SearchIcon size={18} className="shrink-0" />
-              <span>記録を探す</span>
-            </a>
+            <span className="relative">
+              <select
+                value={activeSeason}
+                onChange={(event) => onSeasonChange(event.target.value)}
+                className="h-11 min-w-[112px] appearance-none rounded-full border border-[#d8dde6] bg-white py-2 pl-5 pr-10 text-[13px] font-black text-[#111827] outline-none transition-colors hover:bg-[#eef1f5] focus:border-[#111116] focus:bg-white focus:ring-2 focus:ring-[#111116]/20 md:text-[14px]"
+              >
+                {seasons.map((season) => (
+                  <option key={season} value={season}>
+                    {season}
+                  </option>
+                ))}
+              </select>
+              <svg className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#7b8493]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <path d="m6 9 6 6 6-6" />
+              </svg>
+            </span>
           </div>
           <div className="mb-8 flex items-center justify-between text-[13px] font-semibold md:text-[14px]">
             {HOME_BRACKET_FILTER_OPTIONS.map((item) => (

--- a/src/features/home/sections/TopPanelsCarousel.tsx
+++ b/src/features/home/sections/TopPanelsCarousel.tsx
@@ -1,28 +1,28 @@
-import type { CSSProperties, RefObject } from "react";
+import type { RefObject } from "react";
 import type { Bracket } from "../../../data/mockRuns";
 import type { HomeFeaturedCard, HomeRun } from "../types";
 import { FeaturedPlayersPanel } from "./FeaturedPlayersPanel";
 import { TopPlayersPanel } from "./TopPlayersPanel";
 
 type TopPanelsCarouselProps = {
+  viewportRef: RefObject<HTMLDivElement | null>;
   rowRef: RefObject<HTMLDivElement | null>;
-  style: CSSProperties;
   activeIndex: number;
   heroRuns: HomeRun[];
   featuredCards: HomeFeaturedCard[];
-  onTransitionEnd: () => void;
+  onScroll: () => void;
   onJumpTo: (nextIndex: 0 | 1) => void;
   onViewBracket: (bracket: Bracket) => void;
   onSelectRun: (runId: string) => void;
 };
 
 export function TopPanelsCarousel({
+  viewportRef,
   rowRef,
-  style,
   activeIndex,
   heroRuns,
   featuredCards,
-  onTransitionEnd,
+  onScroll,
   onJumpTo,
   onViewBracket,
   onSelectRun,
@@ -35,8 +35,13 @@ export function TopPanelsCarousel({
   return (
     <div className="relative left-1/2 right-1/2 z-10 -mt-40 mb-8 w-screen -translate-x-1/2 overflow-x-clip px-5 md:-mt-72 sm:px-6 lg:px-8">
       <div className="relative w-full">
-        <div className="overflow-hidden">
-          <div ref={rowRef} className="flex gap-5 will-change-transform" style={style} onTransitionEnd={onTransitionEnd}>
+        <div
+          ref={viewportRef}
+          className="top-panels-scroll no-scrollbar overflow-x-auto overscroll-x-contain"
+          style={{ scrollSnapType: "x mandatory" }}
+          onScroll={onScroll}
+        >
+          <div ref={rowRef} className="flex gap-5">
             <TopPlayersPanel panelKey="top-primary" heroRuns={heroRuns} onViewBracket={onViewBracket} onSelectRun={onSelectRun} />
             <FeaturedPlayersPanel panelKey="featured-primary" featuredCards={featuredCards} onViewBracket={onViewBracket} onSelectRun={onSelectRun} />
             <TopPlayersPanel panelKey="top-loop" heroRuns={heroRuns} onViewBracket={onViewBracket} onSelectRun={onSelectRun} />

--- a/src/features/recordDetail/Page.tsx
+++ b/src/features/recordDetail/Page.tsx
@@ -15,11 +15,13 @@ export function RecordDetailPage({
   runId,
   onBack,
   onRequestSubmit,
+  onSelectRun,
   embedded = false,
 }: {
   runId?: string;
   onBack?: () => void;
   onRequestSubmit?: () => void;
+  onSelectRun?: (runId: string) => void;
   embedded?: boolean;
 }) {
   const currentRun = getAppRunById(runId ?? defaultAppRunId) ?? getAppRunById(defaultAppRunId) ?? null;
@@ -212,6 +214,7 @@ export function RecordDetailPage({
             selectedCompareRunId={selectedCompareRunId}
             onToggleMenu={(runKey) => setOpenMenuRunId((previous) => (previous === runKey ? null : runKey))}
             onAction={handleSimilarAction}
+            onSelectRun={onSelectRun}
           />
         </div>
       </main>

--- a/src/features/recordDetail/sections/Sidebar.tsx
+++ b/src/features/recordDetail/sections/Sidebar.tsx
@@ -13,6 +13,7 @@ export function Sidebar({
   selectedCompareRunId,
   onToggleMenu,
   onAction,
+  onSelectRun,
 }: {
   compareOpen: boolean;
   partyBuildItems: PartyBuildItem[];
@@ -22,6 +23,7 @@ export function Sidebar({
   selectedCompareRunId: string | null;
   onToggleMenu: (runId: string) => void;
   onAction: (runId: string, action: "like" | "share" | "compare") => void;
+  onSelectRun?: (runId: string) => void;
 }) {
   return (
     <aside className={`flex w-full shrink-0 flex-col gap-[18px] ${compareOpen ? "lg:w-full xl:w-full" : "lg:w-[304px] xl:w-[316px]"}`}>
@@ -56,6 +58,7 @@ export function Sidebar({
                     isCompareSelected={isCompareSelected}
                     onToggleMenu={() => onToggleMenu(match.run.id)}
                     onAction={(action) => onAction(match.run.id, action)}
+                    onOpenDetail={onSelectRun ? () => onSelectRun(match.run.id) : undefined}
                   />
                 );
               })}

--- a/src/features/recordDetail/sections/SimilarRunCard.tsx
+++ b/src/features/recordDetail/sections/SimilarRunCard.tsx
@@ -1,4 +1,6 @@
 ﻿import type { SimilarRunMatch } from "../../../lib/getSimilarRuns";
+import type { KeyboardEvent } from "react";
+
 import { characterDb } from "../../../data/mockRuns";
 import { CharacterIcon } from "../../../components/CharacterIcon";
 import { CompareViewIcon, LikeIcon, ShareIcon } from "../../../components/UiIcons";
@@ -20,7 +22,11 @@ function SimilarActionMenu({
   onAction: (action: "like" | "share" | "compare") => void;
 }) {
   return (
-    <div className="relative shrink-0">
+    <div
+      className="relative shrink-0"
+      onClick={(event) => event.stopPropagation()}
+      onKeyDown={(event) => event.stopPropagation()}
+    >
       <button
         type="button"
         onClick={onToggle}
@@ -73,6 +79,7 @@ export function SimilarRunCard({
   isCompareSelected,
   onToggleMenu,
   onAction,
+  onOpenDetail,
 }: {
   match: SimilarRunMatch;
   liked: boolean;
@@ -81,14 +88,30 @@ export function SimilarRunCard({
   isCompareSelected: boolean;
   onToggleMenu: () => void;
   onAction: (action: "like" | "share" | "compare") => void;
+  onOpenDetail?: () => void;
 }) {
   const visibleReasons = match.reasons.slice(0, 2);
+  const canOpenDetail = Boolean(onOpenDetail);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (!canOpenDetail || (event.key !== "Enter" && event.key !== " ")) {
+      return;
+    }
+
+    event.preventDefault();
+    onOpenDetail?.();
+  };
 
   return (
     <article
-      className={`rounded-[16px] border p-[14px] transition-colors ${
+      role={canOpenDetail ? "button" : undefined}
+      tabIndex={canOpenDetail ? 0 : undefined}
+      aria-label={canOpenDetail ? `${match.run.title} の詳細を見る` : undefined}
+      onClick={onOpenDetail}
+      onKeyDown={handleKeyDown}
+      className={`rounded-[16px] border p-[14px] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/40 ${
         isCompareSelected ? "border-[#9aa7ba] bg-[#eef1f5]" : "border-[#e5e7eb] bg-white hover:bg-[#f7f8fa]"
-      }`}
+      } ${canOpenDetail ? "cursor-pointer" : ""}`}
     >
       <div className="flex items-start gap-[10px]">
         <div className="min-w-0 flex-1">

--- a/src/index.css
+++ b/src/index.css
@@ -105,6 +105,10 @@ textarea::placeholder {
   scrollbar-width: none;
 }
 
+.top-panels-scroll [data-top-panel] {
+  scroll-snap-align: start;
+}
+
 code {
   font-family: "Consolas", "SFMono-Regular", monospace;
 }


### PR DESCRIPTION
## 変更内容
- 詳細画面の類似編成カード全体から実データ詳細へ遷移できるようにしました。
- TOPプレイヤー/注目プレイヤーの外側カルーセルを自然な横スクロールに対応しました。
- ヘッダーのバージョン指定をリーダーボード上へ移動し、selector本体だけのUIにしました。

## 実装意図
- 既存の自動スクロール、矢印移動、カードクリック導線を維持しながら操作面だけを追加しています。
- 類似記録の三点メニュー操作は詳細遷移に伝播しないよう分離しています。
- バージョン指定はHOME本体側の状態を使い、TOPとリーダーボードの絞り込みが従来どおり連動するようにしています。

## 確認
- npm run typecheck
- npm run build
- npm run lint（既存の icons.tsx Fast Refresh 警告のみ）