### PR TITLE
Design System v0.1 の初期統一

### DIFF
--- a/docs/design-system-v0.1-audit.md
+++ b/docs/design-system-v0.1-audit.md
@@ -1,0 +1,50 @@
+# UI統一・Design System v0.1 Audit
+
+## Purpose
+
+Elite Run DB is a prototype for viewing, searching, comparing, and submitting Genshin elite-hunting RTA records. The current phase is UI / flow integration, so the design-system work should reduce visible drift without turning the repository into a broad architecture rewrite.
+
+The product should have two page modes:
+
+- View mode: Home, Library, Record Detail, and Compare. These pages focus on records as things to inspect, search, trust, and compare.
+- Create mode: Submit. This page focuses on creating an application draft and should keep a workbench / form atmosphere while sharing base UI rules.
+
+## Current Drift
+
+| UI | Main Locations | Current Issue | Direction |
+| --- | --- | --- | --- |
+| Header | `src/components/AppShell.tsx`, `src/features/home/sections/Header.tsx`, `src/features/recordDetail/sections/Header.tsx`, `src/features/submit/sections/Header.tsx` | Multiple header systems exist. Embedded pages usually rely on `AppShell`, but page-local headers still define their own controls. | Keep dark Global Header. Standardize page subheaders and Create Header. |
+| Submit entry | `AppShell`, Home header, Detail header | Copy and button treatment differ. | Use `記録申請` consistently. |
+| Back button | Detail header, Submit header, Submit stepper | Icon shape, surface, and copy differ. | Use shared `BackButton` with icon-only and text variants. |
+| Buttons | Many feature files | Primary, secondary, ghost, and icon-only treatments are hand-written. | Introduce `Button` and `IconButton`. |
+| Version select | Home leaderboard, Detail header, Library category filter | Season / Version copy and control styling differ. | Use `Version` in visible copy and a shared compact select. |
+| Floating CTA | Home, Library | Nearly identical implementation duplicated. | Use shared `FloatingCta`. |
+| Record cards | Home ranking, Library, Similar, Compare candidates | Cards need different information density, but hover, tags, actions, and shell rules drift. | Treat as a RecordCard family, not a single card. |
+| Chips / badges | Detail, Library, Submit, Filter drawers | Role and appearance are mixed. | Shared `Chip` / `Badge` variants with view/create modes. |
+| Form fields | Submit, Library filters, Home filter drawer | Field shells, focus rings, helper/error text differ. | Shared `FormField` and `SelectControl`; Create mode can use larger sizing. |
+| Modal / drawer | Filter drawers, Compare drawer, Submit modals | Overlay, close button, radius, and shadow differ. | Shared `ModalFrame` / `DrawerFrame` shell. |
+| Legacy CSS | `src/index.css` | `.hoyo-card` is unused in `src`; it remains from the legacy HTML mock. | Remove from production CSS in cleanup. |
+
+## Token Defaults
+
+- Ink: `#111827`
+- Text: `#333333`
+- Dark chrome: `#111116`
+- Surface: `#ffffff`
+- Muted surface: `#f7f8fa`
+- App surface: `#f5f6f8`
+- Create surface: `#f6f6f6`
+- Border: `#d8dde6`
+- Muted border: `#e5e7eb`
+- Muted text: `#5f6678`
+- Subtle text: `#8d93a3`
+- Create muted text: `#9999b1`
+- Danger: `#d24b5a`
+- Like: `#ff8ea1`
+
+## Migration Notes
+
+- Radius changes that alter existing UI should be kept in an independent commit.
+- Submit's global scale wrapper is prototype-only and should be removed early.
+- Home / Library display headlines using Bebas Neue are intentional View mode brand elements and should remain.
+- `docs/mocks/submit-page-ui-prototype.html` may keep `.hoyo-card`; production CSS should not.

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -465,15 +465,11 @@ function GlobalHeader({
           <Button
             type="button"
             onClick={onRequestSubmit}
-            variant="tonal"
+            variant={lightChrome ? "primary" : "dark"}
             size="md"
             className={classNames(
               "px-3 py-2 sm:px-4",
-              routeName === "submit"
-                ? "bg-white text-[#111111]"
-                : lightChrome
-                  ? "bg-[#111827] text-white hover:bg-[#263142]"
-                  : "bg-[#272727] text-[#d9d9d9] hover:bg-[#313131]",
+              routeName === "submit" && (lightChrome ? "ring-2 ring-[#9aa7ba]" : "border-white/25 bg-[#272727] text-[#d9d9d9]"),
             )}
           >
             <PlusIcon className="size-5" />

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,5 +1,7 @@
 ﻿import { type ReactNode, useEffect, useState } from "react";
 
+import { Button, IconButton } from "./ui";
+
 type ShellRouteName =
   | "home"
   | "detail"
@@ -433,14 +435,16 @@ function GlobalHeader({
     <header className={classNames("sticky top-0 z-30 h-[80px] shrink-0 border-b", lightChrome ? "border-[#e5e7eb] bg-white shadow-[0_1px_0_rgba(17,24,39,0.03)]" : "border-[#343434] bg-[#000000]")}>
       <div className="header-font flex h-full items-center justify-between gap-4 px-4 py-4 md:px-6">
         <div className="flex min-w-0 items-center gap-4 sm:gap-6">
-          <button
+          <IconButton
             type="button"
-            className={classNames("transition-colors", lightChrome ? "text-[#333333] hover:text-[#111827]" : "text-[#d9d9d9] hover:text-[#d9d9d9]")}
+            variant={lightChrome ? "ghost" : "dark"}
+            size="lg"
+            className={classNames("border-transparent bg-transparent", lightChrome ? "text-[#333333] hover:text-[#111827]" : "text-[#d9d9d9] hover:bg-[#272727] hover:text-[#d9d9d9]")}
             onClick={onMenuClick}
             aria-label="\u30e1\u30cb\u30e5\u30fc\u3092\u958b\u304f"
           >
             <MenuIcon className="size-7" />
-          </button>
+          </IconButton>
 
           <h1 className="shrink-0">
             <button
@@ -458,11 +462,13 @@ function GlobalHeader({
         </div>
 
         <div className="flex shrink-0 items-center gap-4 sm:gap-6">
-          <button
+          <Button
             type="button"
             onClick={onRequestSubmit}
+            variant="tonal"
+            size="md"
             className={classNames(
-              "flex items-center gap-2 rounded-full px-3 py-2 transition-colors sm:px-4",
+              "px-3 py-2 sm:px-4",
               routeName === "submit"
                 ? "bg-white text-[#111111]"
                 : lightChrome
@@ -472,12 +478,14 @@ function GlobalHeader({
           >
             <PlusIcon className="size-5" />
             <span className="hidden whitespace-nowrap text-[12px] font-normal sm:block md:text-[16px]">{"\u8a18\u9332\u7533\u8acb"}</span>
-          </button>
+          </Button>
 
-          <button
+          <IconButton
             type="button"
             onClick={() => onNavigate("notifications")}
             aria-label="\u901a\u77e5"
+            variant={lightChrome ? "ghost" : "dark"}
+            size="lg"
             className={classNames(
               utilityButtonClass,
               routeName === "notifications" &&
@@ -486,7 +494,7 @@ function GlobalHeader({
           >
             <BellIcon className="size-6 sm:size-7" />
             {hasUnreadNotifications ? <span className={classNames("absolute top-1 right-1 block size-2.5 rounded-full border-2 bg-red-500", lightChrome ? "border-white" : "border-[#000000]")} /> : null}
-          </button>
+          </IconButton>
 
           <button
             type="button"

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -1,0 +1,460 @@
+import type {
+  AnchorHTMLAttributes,
+  ButtonHTMLAttributes,
+  HTMLAttributes,
+  LabelHTMLAttributes,
+  ReactNode,
+  SelectHTMLAttributes,
+} from "react";
+
+export function cn(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}
+
+type ButtonVariant = "primary" | "secondary" | "ghost" | "tonal" | "danger" | "link";
+type ButtonSize = "sm" | "md" | "lg" | "create";
+
+const buttonVariantClass: Record<ButtonVariant, string> = {
+  primary: "border border-[#111827] bg-[#111827] text-white hover:bg-[#263142]",
+  secondary: "border border-[#d8dde6] bg-white text-[#333333] hover:bg-[#f7f8fa]",
+  ghost: "border border-transparent bg-transparent text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#111827]",
+  tonal: "border border-[#d8dde6] bg-[#f7f8fa] text-[#333333] hover:bg-[#eef1f5]",
+  danger: "border border-[#f0ccd3] bg-[#fff4f7] text-[#d24b5a] hover:bg-[#ffeaf0]",
+  link: "border border-transparent bg-transparent text-[#4d49fc] hover:text-[#111827]",
+};
+
+const buttonSizeClass: Record<ButtonSize, string> = {
+  sm: "min-h-8 px-3 py-1.5 text-[12px]",
+  md: "min-h-9 px-4 py-2 text-[13px] md:text-[14px]",
+  lg: "min-h-11 px-5 py-2.5 text-[15px] md:text-[16px]",
+  create: "min-h-[56px] px-6 py-4 text-[18px] md:text-[24px]",
+};
+
+export function Button({
+  children,
+  className,
+  size = "md",
+  variant = "primary",
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: ReactNode;
+  size?: ButtonSize;
+  variant?: ButtonVariant;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-full font-semibold leading-none transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/40 disabled:cursor-not-allowed disabled:opacity-55",
+        buttonVariantClass[variant],
+        buttonSizeClass[size],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+type IconButtonVariant = "surface" | "ghost" | "dark" | "overlay";
+type IconButtonSize = "sm" | "md" | "lg";
+
+const iconButtonVariantClass: Record<IconButtonVariant, string> = {
+  surface: "border border-[#d8dde6] bg-[#f7f8fa] text-[#333333] hover:bg-[#eef1f5]",
+  ghost: "border border-transparent bg-transparent text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#111827]",
+  dark: "border border-[#343434] bg-[#272727] text-[#d9d9d9] hover:bg-[#313131]",
+  overlay: "border border-white/20 bg-black/70 text-white hover:bg-black",
+};
+
+const iconButtonSizeClass: Record<IconButtonSize, string> = {
+  sm: "h-8 w-8",
+  md: "h-9 w-9",
+  lg: "h-10 w-10",
+};
+
+export function IconButton({
+  children,
+  className,
+  size = "md",
+  variant = "surface",
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: ReactNode;
+  size?: IconButtonSize;
+  variant?: IconButtonVariant;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "grid shrink-0 place-items-center rounded-full transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/40 disabled:cursor-not-allowed disabled:opacity-55",
+        iconButtonVariantClass[variant],
+        iconButtonSizeClass[size],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function BackButton({
+  label,
+  showLabel = false,
+  className,
+  icon = "chevron",
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  label: string;
+  showLabel?: boolean;
+  icon?: "chevron" | "arrow";
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      className={cn(
+        "inline-flex min-h-9 items-center gap-2 rounded-full text-[#5f6678] transition-colors hover:text-[#111827] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/40",
+        showLabel ? "px-2 py-2 text-[14px] font-medium" : "h-9 w-9 justify-center border border-[#d8dde6] bg-[#f7f8fa] hover:bg-[#eef1f5]",
+        className,
+      )}
+      {...props}
+    >
+      <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        {icon === "arrow" ? (
+          <>
+            <path d="M19 12H5" />
+            <path d="M11 6 5 12l6 6" />
+          </>
+        ) : (
+          <path d="M15 5 8 12l7 7" />
+        )}
+      </svg>
+      {showLabel ? <span>{label}</span> : null}
+    </button>
+  );
+}
+
+export function SelectControl({
+  className,
+  children,
+  variant = "compact",
+  ...props
+}: SelectHTMLAttributes<HTMLSelectElement> & {
+  children: ReactNode;
+  variant?: "compact" | "create";
+}) {
+  return (
+    <span className="relative inline-flex min-w-0">
+      <select
+        className={cn(
+          "w-full appearance-none border text-[#111827] outline-none transition-colors focus:bg-white focus:ring-2 focus:ring-[#111116]/20",
+          variant === "create"
+            ? "rounded-[8px] border-transparent bg-transparent py-1 pr-9 text-[20px] md:text-[24px]"
+            : "h-11 min-w-[112px] rounded-full border-[#d8dde6] bg-white py-2 pl-5 pr-10 text-[13px] font-black hover:bg-[#eef1f5] focus:border-[#111116] md:text-[14px]",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+      <svg className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#7b8493]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+        <path d="m6 9 6 6 6-6" />
+      </svg>
+    </span>
+  );
+}
+
+export function FormField({
+  children,
+  className,
+  error,
+  helper,
+  label,
+  labelClassName,
+  ...props
+}: LabelHTMLAttributes<HTMLLabelElement> & {
+  children: ReactNode;
+  error?: ReactNode;
+  helper?: ReactNode;
+  label?: ReactNode;
+  labelClassName?: string;
+}) {
+  return (
+    <label className={cn("block", className)} {...props}>
+      {label ? <div className={cn("text-[14px] font-bold text-[#5f6678]", labelClassName)}>{label}</div> : null}
+      {children}
+      {helper && !error ? <p className="mt-2 text-[13px] leading-[1.6] text-[#8d93a3]">{helper}</p> : null}
+      {error ? <p className="mt-2 text-[13px] leading-[1.5] text-[#d24b5a]">{error}</p> : null}
+    </label>
+  );
+}
+
+export function FieldShell({
+  children,
+  className,
+  variant = "view",
+}: {
+  children: ReactNode;
+  className?: string;
+  variant?: "view" | "create";
+}) {
+  return (
+    <div
+      className={cn(
+        "transition-colors focus-within:ring-2 focus-within:ring-[#111116]/15",
+        variant === "create" ? "rounded-[8px] bg-[#f6f6f6] px-4 py-4 md:px-5" : "rounded-[14px] border border-[#d8dde6] bg-[#f7f8fa] px-4 py-3 focus-within:bg-white",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type ChipVariant = "neutral" | "active" | "include" | "exclude" | "create";
+
+const chipVariantClass: Record<ChipVariant, string> = {
+  neutral: "border-[#d8dde6] bg-white text-[#5f6678]",
+  active: "border-transparent bg-[#111827] text-white",
+  include: "border-[#8fc7d8] bg-[#eef9fc] text-[#357f91]",
+  exclude: "border-[#efc9b0] bg-[#fff7f2] text-[#b6611e]",
+  create: "border-transparent bg-[#f2f2f2] text-[#9999b1]",
+};
+
+export function Chip({
+  children,
+  className,
+  variant = "neutral",
+  ...props
+}: HTMLAttributes<HTMLSpanElement> & {
+  children: ReactNode;
+  variant?: ChipVariant;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex min-h-8 max-w-full items-center rounded-full border px-3 py-1.5 text-[12px] font-medium leading-none",
+        chipVariantClass[variant],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}
+
+type BadgeVariant = "neutral" | "dark" | "count" | "warning" | "success";
+
+const badgeVariantClass: Record<BadgeVariant, string> = {
+  neutral: "border-[#d8dde6] bg-white text-[#5f6678]",
+  dark: "border-white/40 bg-transparent text-[#d9d9d9]",
+  count: "border-[#d8dde6] bg-white text-[#5f6678]",
+  warning: "border-[#efc9b0] bg-[#fff7f2] text-[#b6611e]",
+  success: "border-[#8fc7d8] bg-[#eef9fc] text-[#357f91]",
+};
+
+export function Badge({
+  children,
+  className,
+  variant = "neutral",
+  ...props
+}: HTMLAttributes<HTMLSpanElement> & {
+  children: ReactNode;
+  variant?: BadgeVariant;
+}) {
+  return (
+    <span
+      className={cn(
+        "inline-flex h-8 max-w-full items-center rounded-full border px-3 text-[12px] font-black leading-none",
+        badgeVariantClass[variant],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}
+
+export function CardShell({
+  children,
+  className,
+  interactive = false,
+  selected = false,
+  ...props
+}: HTMLAttributes<HTMLElement> & {
+  children: ReactNode;
+  interactive?: boolean;
+  selected?: boolean;
+}) {
+  return (
+    <article
+      className={cn(
+        "border bg-white text-left shadow-[0_10px_24px_rgba(21,27,38,0.06)]",
+        selected ? "border-[#9aa7ba] bg-[#eef1f5]" : "border-[#dfe3ea]",
+        interactive && "cursor-pointer transition hover:-translate-y-0.5 hover:border-[#cfd6e2] hover:shadow-[0_18px_34px_rgba(21,27,38,0.11)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </article>
+  );
+}
+
+export function Panel({
+  children,
+  className,
+  variant = "surface",
+  ...props
+}: HTMLAttributes<HTMLElement> & {
+  children: ReactNode;
+  variant?: "surface" | "muted" | "create";
+}) {
+  return (
+    <section
+      className={cn(
+        "border",
+        variant === "surface" && "border-[#e5e7eb] bg-white shadow-[0_12px_26px_rgba(21,27,38,0.06)]",
+        variant === "muted" && "border-[#e5e7eb] bg-[#f7f8fa]",
+        variant === "create" && "border-transparent bg-[#f6f6f6]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </section>
+  );
+}
+
+export function ModalFrame({
+  children,
+  className,
+  onClose,
+  title,
+  description,
+}: {
+  children: ReactNode;
+  className?: string;
+  onClose: () => void;
+  title?: ReactNode;
+  description?: ReactNode;
+}) {
+  return (
+    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/35 px-4 py-6" onClick={onClose}>
+      <div
+        className={cn("flex max-h-[calc(100vh-48px)] w-full max-w-[760px] flex-col overflow-hidden rounded-[24px] border border-[#ebebeb] bg-white p-5 text-[#333333] shadow-[0_24px_60px_rgba(0,0,0,0.18)] md:p-6", className)}
+        onClick={(event) => event.stopPropagation()}
+      >
+        {title ? (
+          <div className="flex shrink-0 items-start justify-between gap-4 border-b border-[#ebebeb] pb-5">
+            <div>
+              <h3 className="text-[24px] font-bold leading-tight text-[#111827] md:text-[30px]">{title}</h3>
+              {description ? <p className="mt-2 text-[14px] leading-[1.7] text-[#7b7b8d] md:text-[15px]">{description}</p> : null}
+            </div>
+            <IconButton type="button" onClick={onClose} aria-label="閉じる">
+              <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+                <path d="M6 6 18 18" />
+                <path d="M18 6 6 18" />
+              </svg>
+            </IconButton>
+          </div>
+        ) : null}
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function DrawerFrame({
+  children,
+  className,
+  side = "right",
+  ...props
+}: HTMLAttributes<HTMLElement> & {
+  children: ReactNode;
+  side?: "left" | "right";
+}) {
+  return (
+    <aside
+      className={cn(
+        "fixed inset-y-0 z-50 flex flex-col overflow-y-auto border bg-white text-[#333333]",
+        side === "left" ? "left-0 border-r shadow-[18px_0_44px_rgba(31,41,55,0.12)]" : "right-0 border-l shadow-[-24px_0_60px_rgba(31,41,55,0.16)]",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </aside>
+  );
+}
+
+export function EmptyState({
+  children,
+  className,
+  icon,
+  title,
+}: {
+  children?: ReactNode;
+  className?: string;
+  icon?: ReactNode;
+  title: ReactNode;
+}) {
+  return (
+    <div className={cn("rounded-[16px] border border-dashed border-[#d8dde6] bg-[#f7f8fa] px-4 py-8 text-center text-[13px] text-[#8d93a3]", className)}>
+      {icon ? <div className="mb-3 flex justify-center text-[#dcdfe6]">{icon}</div> : null}
+      <div className="font-black text-[#606266]">{title}</div>
+      {children ? <div className="mt-2 font-bold leading-5 text-[#909399]">{children}</div> : null}
+    </div>
+  );
+}
+
+export function FloatingCta({
+  badge,
+  children,
+  className,
+  icon,
+  ...props
+}: AnchorHTMLAttributes<HTMLAnchorElement> &
+  ButtonHTMLAttributes<HTMLButtonElement> & {
+  badge?: ReactNode;
+  children: ReactNode;
+  icon?: ReactNode;
+}) {
+  const content = (
+    <>
+      {badge ? (
+        <span className="flex items-center gap-1.5 border border-white/35 px-2 py-1 text-[9px] font-bold uppercase leading-none text-white/60">
+          {badge}
+        </span>
+      ) : null}
+      <span className="cta-shine-text whitespace-nowrap text-[14px] font-black leading-none sm:text-[15px]">{children}</span>
+      {icon}
+    </>
+  );
+
+  if ("href" in props && props.href) {
+    return (
+      <a
+        className={cn("fixed bottom-6 right-6 z-30 flex items-center gap-3 border border-white/25 bg-[#111116] px-3.5 py-3 text-left text-[#d9d9d9] shadow-[0_12px_28px_rgba(0,0,0,0.24)] transition duration-200 hover:-translate-y-0.5 hover:border-white/40 hover:bg-[#17171d] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-[#111116]", className)}
+        {...(props as HTMLAttributes<HTMLAnchorElement>)}
+      >
+        {content}
+      </a>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={cn("fixed bottom-6 right-6 z-30 flex items-center gap-3 border border-white/25 bg-[#111116] px-3.5 py-3 text-left text-[#d9d9d9] shadow-[0_12px_28px_rgba(0,0,0,0.24)] transition duration-200 hover:-translate-y-0.5 hover:border-white/40 hover:bg-[#17171d] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-[#111116]", className)}
+      {...(props as ButtonHTMLAttributes<HTMLButtonElement>)}
+    >
+      {content}
+    </button>
+  );
+}

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -11,7 +11,7 @@ export function cn(...values: Array<string | false | null | undefined>) {
   return values.filter(Boolean).join(" ");
 }
 
-type ButtonVariant = "primary" | "secondary" | "ghost" | "tonal" | "danger" | "link";
+type ButtonVariant = "primary" | "secondary" | "ghost" | "tonal" | "dark" | "danger" | "link";
 type ButtonSize = "sm" | "md" | "lg" | "create";
 
 const buttonVariantClass: Record<ButtonVariant, string> = {
@@ -19,6 +19,7 @@ const buttonVariantClass: Record<ButtonVariant, string> = {
   secondary: "border border-[#d8dde6] bg-white text-[#333333] hover:bg-[#f7f8fa]",
   ghost: "border border-transparent bg-transparent text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#111827]",
   tonal: "border border-[#d8dde6] bg-[#f7f8fa] text-[#333333] hover:bg-[#eef1f5]",
+  dark: "border border-[#343434] bg-[#272727] text-[#d9d9d9] hover:bg-[#313131]",
   danger: "border border-[#f0ccd3] bg-[#fff4f7] text-[#d24b5a] hover:bg-[#ffeaf0]",
   link: "border border-transparent bg-transparent text-[#4d49fc] hover:text-[#111827]",
 };
@@ -54,6 +55,55 @@ export function Button({
     >
       {children}
     </button>
+  );
+}
+
+type InlineActionVariant = "neutral" | "primary" | "danger" | "success";
+
+const inlineActionVariantClass: Record<InlineActionVariant, string> = {
+  neutral: "text-[#5f6678] hover:text-[#111827]",
+  primary: "text-[#111827] hover:text-[#263142]",
+  danger: "text-[#d24b5a] hover:text-[#111827]",
+  success: "text-[#357f91] hover:text-[#111827]",
+};
+
+export function InlineActionButton({
+  active = false,
+  children,
+  className,
+  variant = "neutral",
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  active?: boolean;
+  children: ReactNode;
+  variant?: InlineActionVariant;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "inline-flex min-h-0 items-center justify-center gap-1 rounded-full border border-transparent p-0 text-[11px] font-extrabold leading-none transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/40 disabled:cursor-not-allowed disabled:text-[#b8bec8] disabled:opacity-70",
+        active ? "text-[#111827]" : inlineActionVariantClass[variant],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function InlineCtaButton({
+  children,
+  className,
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: ReactNode;
+}) {
+  return (
+    <Button variant="primary" size="md" className={cn("w-full px-6 py-2.5 text-[13px]", className)} {...props}>
+      {children}
+    </Button>
   );
 }
 
@@ -214,11 +264,13 @@ export function FieldShell({
   );
 }
 
-type ChipVariant = "neutral" | "active" | "include" | "exclude" | "create";
+type ChipVariant = "neutral" | "active" | "tag" | "reason" | "include" | "exclude" | "create";
 
 const chipVariantClass: Record<ChipVariant, string> = {
   neutral: "border-[#d8dde6] bg-white text-[#5f6678]",
   active: "border-transparent bg-[#111827] text-white",
+  tag: "border-[#d8dde6] bg-white text-[#333333]",
+  reason: "border-[#d8dde6] bg-[#eef1f5] text-[#5f6678]",
   include: "border-[#8fc7d8] bg-[#eef9fc] text-[#357f91]",
   exclude: "border-[#efc9b0] bg-[#fff7f2] text-[#b6611e]",
   create: "border-transparent bg-[#f2f2f2] text-[#9999b1]",
@@ -247,12 +299,14 @@ export function Chip({
   );
 }
 
-type BadgeVariant = "neutral" | "dark" | "count" | "warning" | "success";
+type BadgeVariant = "neutral" | "dark" | "count" | "stat" | "overlay" | "warning" | "success";
 
 const badgeVariantClass: Record<BadgeVariant, string> = {
   neutral: "border-[#d8dde6] bg-white text-[#5f6678]",
   dark: "border-white/40 bg-transparent text-[#d9d9d9]",
   count: "border-[#d8dde6] bg-white text-[#5f6678]",
+  stat: "border-transparent bg-[#f0f2f5] text-[#6b7280]",
+  overlay: "border-white/15 bg-black/60 text-white/75",
   warning: "border-[#efc9b0] bg-[#fff7f2] text-[#b6611e]",
   success: "border-[#8fc7d8] bg-[#eef9fc] text-[#357f91]",
 };
@@ -278,6 +332,61 @@ export function Badge({
       {children}
     </span>
   );
+}
+
+export function CountBadge({
+  children,
+  className,
+  count,
+  suffix = "件",
+}: {
+  children?: ReactNode;
+  className?: string;
+  count?: number | string;
+  suffix?: string;
+}) {
+  return (
+    <Badge variant="count" className={className}>
+      {children ?? `${count}${suffix}`}
+    </Badge>
+  );
+}
+
+export function StatusBadge({
+  children,
+  className,
+  tone = "neutral",
+  ...props
+}: HTMLAttributes<HTMLSpanElement> & {
+  children: ReactNode;
+  tone?: "neutral" | "dark" | "warning" | "success" | "overlay";
+}) {
+  return (
+    <Badge variant={tone === "neutral" ? "neutral" : tone} className={className} {...props}>
+      {children}
+    </Badge>
+  );
+}
+
+export function StatBadge({
+  className,
+  label,
+  value,
+}: {
+  className?: string;
+  label: ReactNode;
+  value: ReactNode;
+}) {
+  return (
+    <span className={cn("inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap rounded-full bg-[#f0f2f5] px-2.5 py-1 leading-none", className)}>
+      <span className="text-[10px] font-bold uppercase tracking-[0.06em] text-[#6b7280]">{label}</span>
+      <span className="truncate text-[12px] font-black text-[#6b7280]">{value}</span>
+    </span>
+  );
+}
+
+export function CostBadge(props: { className?: string; label: ReactNode; value: ReactNode }) {
+  return <StatBadge {...props} />;
 }
 
 export function CardShell({

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -418,12 +418,14 @@ export function FloatingCta({
   children,
   className,
   icon,
+  leadingIcon,
   ...props
 }: AnchorHTMLAttributes<HTMLAnchorElement> &
   ButtonHTMLAttributes<HTMLButtonElement> & {
   badge?: ReactNode;
   children: ReactNode;
   icon?: ReactNode;
+  leadingIcon?: ReactNode;
 }) {
   const content = (
     <>
@@ -432,6 +434,7 @@ export function FloatingCta({
           {badge}
         </span>
       ) : null}
+      {leadingIcon}
       <span className="cta-shine-text whitespace-nowrap text-[14px] font-black leading-none sm:text-[15px]">{children}</span>
       {icon}
     </>

--- a/src/components/ui/tokens.ts
+++ b/src/components/ui/tokens.ts
@@ -1,0 +1,39 @@
+export const dsTokens = {
+  color: {
+    ink: "#111827",
+    inkSoft: "#333333",
+    chromeDark: "#111116",
+    chromeDarkHover: "#17171d",
+    surface: "#ffffff",
+    surfaceMuted: "#f7f8fa",
+    surfaceApp: "#f5f6f8",
+    surfaceCreate: "#f6f6f6",
+    surfaceRaised: "#fbfcfd",
+    border: "#d8dde6",
+    borderMuted: "#e5e7eb",
+    textMuted: "#5f6678",
+    textSubtle: "#8d93a3",
+    textCreateMuted: "#9999b1",
+    danger: "#d24b5a",
+    like: "#ff8ea1",
+  },
+  radius: {
+    xs: "4px",
+    sm: "8px",
+    md: "12px",
+    lg: "16px",
+    xl: "20px",
+    modal: "24px",
+    pill: "999px",
+  },
+  shadow: {
+    hairline: "0 1px 0 rgba(17,24,39,0.04)",
+    card: "0 10px 24px rgba(21,27,38,0.06)",
+    raised: "0 18px 34px rgba(21,27,38,0.11)",
+    modal: "0 24px 60px rgba(0,0,0,0.18)",
+    drawerLeft: "18px 0 44px rgba(31,41,55,0.12)",
+    drawerRight: "-24px 0 60px rgba(31,41,55,0.16)",
+  },
+} as const;
+
+export type DsTokenPath = typeof dsTokens;

--- a/src/features/home/Page.tsx
+++ b/src/features/home/Page.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 
 import { ChevronRightIcon } from "../../components/UiIcons";
+import { FloatingCta } from "../../components/ui";
 import { appRuns } from "../../data/appRuns";
 import { type Bracket } from "../../data/mockRuns";
 import { SearchIcon } from "./ui/icons";
@@ -188,18 +189,19 @@ export function HomePage({
 
 function RecordLibraryFloatingCta() {
   return (
-    <a
+    <FloatingCta
       href="#library"
       aria-label="記録図書館で記録を探す"
-      className="fixed bottom-6 right-6 z-30 flex items-center gap-3 border border-white/25 bg-[#111116] px-3.5 py-3 text-left text-[#d9d9d9] shadow-[0_12px_28px_rgba(0,0,0,0.24)] transition duration-200 hover:-translate-y-0.5 hover:border-white/40 hover:bg-[#17171d] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-[#111116]"
+      badge={
+        <>
+          <SearchIcon size={11} className="shrink-0" />
+          Library
+        </>
+      }
+      icon={<ChevronRightIcon className="h-4 w-4 shrink-0 text-white/70" />}
     >
-      <span className="flex items-center gap-1.5 border border-white/35 px-2 py-1 text-[9px] font-bold uppercase leading-none text-white/60">
-        <SearchIcon size={11} className="shrink-0" />
-        Library
-      </span>
-      <span className="cta-shine-text whitespace-nowrap text-[14px] font-black leading-none sm:text-[15px]">記録を探す</span>
-      <ChevronRightIcon className="h-4 w-4 shrink-0 text-white/70" />
-    </a>
+      記録を探す
+    </FloatingCta>
   );
 }
 

--- a/src/features/home/config.ts
+++ b/src/features/home/config.ts
@@ -10,7 +10,7 @@ export const OTHER_RULESET_LABELS = ["Npui-Alt", "Weapon-Alt", "Multi-PUI", "Mul
 
 export const HOME_LABELS = {
   appTitle: "精鋭狩りDB",
-  submitLabel: "記録提出",
+  submitLabel: "記録申請",
   filterTitle: "絞り込み",
   filterResetLabel: "リセット",
   filterApplyLabel: "適用する",

--- a/src/features/home/sections/FestivalBanner.tsx
+++ b/src/features/home/sections/FestivalBanner.tsx
@@ -5,7 +5,7 @@ export function FestivalBanner() {
     <div className="bg-gradient-to-r from-[#ff7e5f] to-[#feb47b] rounded-2xl p-8 mb-8 text-center relative overflow-hidden shadow-lg">
       <div className="relative z-10">
         <div className="inline-flex items-center gap-2 bg-white/20 px-3 py-1 rounded-full text-white text-xs font-bold mb-3 border border-white/40 backdrop-blur-sm">
-          <CalendarIcon size={12} /> SEASON EVENT
+          <CalendarIcon size={12} /> VERSION EVENT
         </div>
         <h2 className="text-4xl md:text-5xl font-black text-white mb-2 drop-shadow-md tracking-tight">Festival Event</h2>
         <p className="text-white/90 text-lg font-bold">ルール別のイベント記録をここに並べる構成です。</p>

--- a/src/features/home/sections/Header.tsx
+++ b/src/features/home/sections/Header.tsx
@@ -1,3 +1,5 @@
+import { Button, SelectControl } from "../../../components/ui";
+
 type HeaderProps = {
   embedded: boolean;
   appTitle: string;
@@ -26,39 +28,37 @@ export function Header({
       <div className="max-w-[1280px] mx-auto px-4 md:px-6 py-2 md:py-3 flex items-center justify-between header-font">
         <div className="flex items-center gap-4 md:gap-6">
           <h1 className="text-[26px] md:text-[38px] font-semibold tracking-tight text-black">{appTitle}</h1>
-          <div className="relative">
-            <select
-              className="appearance-none bg-white border border-black/30 rounded-full pl-3 md:pl-4 pr-12 md:pr-14 py-1.5 text-[16px] md:text-[20px] font-medium text-black"
+          <div className="flex items-center gap-2">
+            <span className="text-[11px] font-black uppercase tracking-[0.12em] text-black/55">Version</span>
+            <SelectControl
+              className="border-black/30 text-black md:text-[20px]"
               value={activeSeason}
               onChange={(event) => onSeasonChange(event.target.value)}
+              aria-label="Version"
             >
               {seasons.map((season) => (
                 <option key={season} value={season}>
                   {season}
                 </option>
               ))}
-            </select>
-            <span className="pointer-events-none absolute right-4 md:right-5 top-1/2 -translate-y-1/2 text-black/70">
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="M6 9l6 6 6-6" />
-              </svg>
-            </span>
+            </SelectControl>
           </div>
         </div>
 
         <div className="flex items-center gap-3 md:gap-4">
-          <button
+          <Button
             type="button"
             onClick={() => {
               window.scrollTo({ top: 0, behavior: "smooth" });
               onRequestSubmit();
             }}
-            className="bg-black text-white rounded-full text-[16px] md:text-[20px] font-medium flex items-center justify-center md:justify-start gap-0 md:gap-2 w-9 h-9 md:w-auto md:h-auto px-0 md:px-5 py-0 md:py-2.5"
+            size="lg"
+            className="h-9 w-9 gap-0 px-0 py-0 md:h-auto md:w-auto md:gap-2 md:px-5 md:py-2.5 md:text-[20px]"
           >
             <span className="md:hidden flex items-center justify-center w-full h-full text-[20px] leading-none">+</span>
             <span className="hidden md:inline text-[22px] leading-none">+</span>
             <span className="hidden md:inline">{submitLabel}</span>
-          </button>
+          </Button>
           <div className="w-9 h-9 rounded-full border border-black/30 bg-white" aria-label="User avatar" />
         </div>
       </div>

--- a/src/features/home/sections/LeaderboardSection.tsx
+++ b/src/features/home/sections/LeaderboardSection.tsx
@@ -1,5 +1,6 @@
 import type { RefObject } from "react";
 
+import { SelectControl } from "../../../components/ui";
 import type { Bracket } from "../../../data/mockRuns";
 import {
   HOME_BRACKET_ACCENT_COLORS,
@@ -78,22 +79,16 @@ export function LeaderboardSection({
             </div>
           </div>
           <div className="mb-8 flex flex-wrap items-center gap-y-3">
-            <span className="relative">
-              <select
-                value={activeSeason}
-                onChange={(event) => onSeasonChange(event.target.value)}
-                className="h-11 min-w-[112px] appearance-none rounded-full border border-[#d8dde6] bg-white py-2 pl-5 pr-10 text-[13px] font-black text-[#111827] outline-none transition-colors hover:bg-[#eef1f5] focus:border-[#111116] focus:bg-white focus:ring-2 focus:ring-[#111116]/20 md:text-[14px]"
-              >
+            <div className="flex items-center gap-2">
+              <span className="text-[11px] font-black uppercase tracking-[0.12em] text-[#8d93a3]">Version</span>
+              <SelectControl value={activeSeason} onChange={(event) => onSeasonChange(event.target.value)} aria-label="Version">
                 {seasons.map((season) => (
                   <option key={season} value={season}>
                     {season}
                   </option>
                 ))}
-              </select>
-              <svg className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[#7b8493]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="m6 9 6 6 6-6" />
-              </svg>
-            </span>
+              </SelectControl>
+            </div>
           </div>
           <div className="mb-8 flex items-center justify-between text-[13px] font-semibold md:text-[14px]">
             {HOME_BRACKET_FILTER_OPTIONS.map((item) => (

--- a/src/features/home/ui/LeaderboardRow.tsx
+++ b/src/features/home/ui/LeaderboardRow.tsx
@@ -12,7 +12,7 @@ function classNames(...values: Array<string | false | null | undefined>) {
 function getLeaderboardStats(run: HomeRun | HomeRunWithGroup) {
   return [
     { label: "DEVICE", value: run.platform },
-    { label: "SEASON", value: formatVersionLabel(run.versionLabel || run.season) },
+    { label: "VERSION", value: formatVersionLabel(run.versionLabel || run.season) },
     { label: "BRACKET", value: getBracketLabel(run.bracket as Bracket) },
   ];
 }

--- a/src/features/library/Page.tsx
+++ b/src/features/library/Page.tsx
@@ -1,4 +1,5 @@
 import { ChevronRightIcon, CrownIcon } from "../../components/UiIcons";
+import { FloatingCta } from "../../components/ui";
 import { useEffect, useState } from "react";
 import { LIBRARY_COLORS, LIBRARY_HERO_IMAGE_URL, LIBRARY_LABELS } from "./config";
 import {
@@ -158,15 +159,14 @@ export function LibraryPage({ onOpenRankings, onSelectRun }: LibraryPageProps) {
 
 function RankingsFloatingCta({ onOpen }: { onOpen: () => void }) {
   return (
-    <button
+    <FloatingCta
       type="button"
       aria-label="全ランキングを見る"
       onClick={onOpen}
-      className="fixed bottom-6 right-6 z-30 flex items-center gap-3 border border-white/25 bg-[#111116] px-3.5 py-3 text-left text-[#d9d9d9] shadow-[0_12px_28px_rgba(0,0,0,0.24)] transition duration-200 hover:-translate-y-0.5 hover:border-white/40 hover:bg-[#17171d] focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-[#111116]"
+      leadingIcon={<CrownIcon className="h-[17px] w-[17px] shrink-0 text-white/70" />}
+      icon={<ChevronRightIcon className="h-4 w-4 shrink-0 text-white/70" />}
     >
-      <CrownIcon className="h-[17px] w-[17px] shrink-0 text-white/70" />
-      <span className="cta-shine-text whitespace-nowrap text-[14px] font-black leading-none sm:text-[15px]">全ランキングを見る</span>
-      <ChevronRightIcon className="h-4 w-4 shrink-0 text-white/70" />
-    </button>
+      全ランキングを見る
+    </FloatingCta>
   );
 }

--- a/src/features/library/sections/FilterEntrance.tsx
+++ b/src/features/library/sections/FilterEntrance.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useId, useMemo, useState, type CSSProperties, type Dispatch, type ReactNode, type SetStateAction } from "react";
 
 import { CharacterIcon } from "../../../components/CharacterIcon";
+import { Chip, CountBadge, IconButton, InlineActionButton, InlineCtaButton, StatusBadge, cn } from "../../../components/ui";
 import { WeaponIcon } from "../../../components/WeaponIcon";
 import { appRuns } from "../../../data/appRuns";
 import {
@@ -530,6 +531,29 @@ function LibrarySelectControl({
   );
 }
 
+function SelectableChipButton({
+  active,
+  children,
+  className,
+  onClick,
+}: {
+  active: boolean;
+  children: ReactNode;
+  className?: string;
+  onClick: () => void;
+}) {
+  return (
+    <button type="button" onClick={onClick} className="rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/40">
+      <Chip
+        variant={active ? "active" : "neutral"}
+        className={cn("min-h-8 cursor-pointer px-3 py-1.5 text-[12px] transition-colors", !active && "hover:bg-[#eef1f5] hover:text-[#333333]", className)}
+      >
+        {children}
+      </Chip>
+    </button>
+  );
+}
+
 function ChoiceFilterGroup({
   title,
   options,
@@ -548,17 +572,9 @@ function ChoiceFilterGroup({
         {options.map((option) => {
           const active = value === option;
           return (
-            <button
-              key={option}
-              type="button"
-              onClick={() => onChange(active ? null : option)}
-              className={[
-                "min-h-9 rounded-full border px-3 py-1.5 text-[12px] font-black transition-colors",
-                active ? "border-[#111116] bg-[#111116] text-white" : "border-[#dcdcdc] bg-white text-[#333333] hover:bg-[#eeeeee]",
-              ].join(" ")}
-            >
+            <SelectableChipButton key={option} active={active} onClick={() => onChange(active ? null : option)} className="min-h-9 font-black">
               {option}
-            </button>
+            </SelectableChipButton>
           );
         })}
       </div>
@@ -577,17 +593,9 @@ function TagFilterPanel({ selectedTags, onToggleTag }: { selectedTags: string[];
               {group.tags.map((tag) => {
                 const active = selectedTags.includes(tag);
                 return (
-                  <button
-                    key={`${group.key}-${tag}`}
-                    type="button"
-                    onClick={() => onToggleTag(tag)}
-                    className={[
-                      "inline-flex min-h-9 items-center rounded-full border px-3 py-2 text-[12px] font-medium transition-colors",
-                      active ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]",
-                    ].join(" ")}
-                  >
+                  <SelectableChipButton key={`${group.key}-${tag}`} active={active} onClick={() => onToggleTag(tag)} className="min-h-9 py-2">
                     #{tag}
-                  </button>
+                  </SelectableChipButton>
                 );
               })}
             </div>
@@ -702,9 +710,9 @@ function MaxValueSelector({ title, prefix, value, min = 0, max, onChange }: { ti
         {options.map((option) => {
           const active = value === option;
           return (
-            <button key={option} type="button" onClick={() => onChange(active ? null : option)} className={["h-9 min-w-11 rounded-full border px-3 text-[12px] font-black transition-colors", active ? "border-[#111116] bg-[#111116] text-white" : "border-[#dcdcdc] bg-white text-[#333333] hover:bg-[#eeeeee]"].join(" ")}>
+            <SelectableChipButton key={option} active={active} onClick={() => onChange(active ? null : option)} className="h-9 min-w-11 justify-center font-black">
               {prefix}{option}
-            </button>
+            </SelectableChipButton>
           );
         })}
       </div>
@@ -838,12 +846,12 @@ function LibraryWeaponFilterDrawer({
         <div className="shrink-0 border-b border-[#e5e7eb]">
           <div className="flex items-start justify-between gap-4 px-5 pb-5 pt-8 md:px-6">
             <div className="text-[24px] font-semibold text-[#111827]">武器条件を選択</div>
-            <button type="button" className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[#d8dde6] bg-[#f7f8fa] text-[#5f6678] transition-colors hover:bg-[#eef1f5] hover:text-[#111827]" onClick={onClose} aria-label="閉じる">
+            <IconButton type="button" variant="surface" onClick={onClose} aria-label="閉じる">
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M6 6L18 18" />
                 <path d="M18 6L6 18" />
               </svg>
-            </button>
+            </IconButton>
           </div>
         </div>
         <div className="flex-1 overflow-y-auto overscroll-contain px-5 py-6 md:px-6">
@@ -867,16 +875,16 @@ function LibraryWeaponFilterDrawer({
             </section>
             <div className="flex flex-wrap gap-2">
               {WEAPON_CLASS_FILTER_OPTIONS.map((option) => (
-                <button key={option.key} type="button" onClick={() => setClassFilter(option.key)} className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${classFilter === option.key ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"}`}>
+                <SelectableChipButton key={option.key} active={classFilter === option.key} onClick={() => setClassFilter(option.key)}>
                   {option.label}
-                </button>
+                </SelectableChipButton>
               ))}
             </div>
             <div className="flex flex-wrap gap-2">
               {WEAPON_TIER_FILTER_OPTIONS.map((option) => (
-                <button key={option.key} type="button" onClick={() => setTierFilter(option.key)} className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${tierFilter === option.key ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"}`}>
+                <SelectableChipButton key={option.key} active={tierFilter === option.key} onClick={() => setTierFilter(option.key)}>
                   {option.label}
-                </button>
+                </SelectableChipButton>
               ))}
             </div>
             <div className="rounded-[16px] bg-[#f6f7f9] p-3">
@@ -894,7 +902,7 @@ function LibraryWeaponFilterDrawer({
                           <WeaponIcon imageUrl={weapon.imageUrl} alt={weapon.name} fallbackLabel={weapon.shortLabel} size={64} className="rounded-[14px] p-1.5" />
                           <div className="min-w-0 flex-1">
                             <div className="flex flex-wrap items-center gap-2">
-                              <div className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${getWeaponTierBadgeClass(weapon.tier)}`}>{formatWeaponTierLabel(weapon.tier)}</div>
+                              <StatusBadge className={`h-auto px-2.5 py-1 text-[11px] font-semibold ${getWeaponTierBadgeClass(weapon.tier)}`}>{formatWeaponTierLabel(weapon.tier)}</StatusBadge>
                               <div className="text-[12px] text-[#7b7b8d]">{formatWeaponClassLabel(weapon.weaponClass)}</div>
                             </div>
                             <div className="mt-2 text-[15px] font-semibold text-black">{weapon.name}</div>
@@ -902,9 +910,9 @@ function LibraryWeaponFilterDrawer({
                           </div>
                         </div>
                         {isInclude || isExclude ? (
-                          <span className={["absolute right-2 top-2 flex h-6 items-center rounded-full px-2 text-[11px] font-bold text-white", isExclude ? "bg-[#c27642]" : "bg-[#6bbbd0]"].join(" ")}>
+                          <StatusBadge tone={isExclude ? "warning" : "success"} className="absolute right-2 top-2 h-6 px-2 text-[11px] font-bold">
                             {isExclude ? "除外" : "含む"}
-                          </span>
+                          </StatusBadge>
                         ) : null}
                       </button>
                     );
@@ -915,12 +923,12 @@ function LibraryWeaponFilterDrawer({
           </div>
         </div>
         <div className="grid shrink-0 grid-cols-[1fr_minmax(220px,360px)_1fr] items-center gap-3 border-t border-[#e5e7eb] px-5 py-4 md:px-6">
-          <button type="button" className="justify-self-start text-[13px] font-medium text-[#5f6678] underline decoration-[#c8ced8] underline-offset-4 hover:text-[#333333]" onClick={() => setDraft({ include: [], exclude: [] })}>
+          <InlineActionButton type="button" className="justify-self-start text-[13px] font-medium underline decoration-[#c8ced8] underline-offset-4" onClick={() => setDraft({ include: [], exclude: [] })}>
             リセット
-          </button>
-          <button type="button" className="w-full rounded-full border border-[#111827] bg-[#111827] px-6 py-2.5 text-[13px] font-semibold text-white transition-colors hover:bg-[#263142]" onClick={() => onApply(draft)}>
+          </InlineActionButton>
+          <InlineCtaButton type="button" onClick={() => onApply(draft)}>
             適用する
-          </button>
+          </InlineCtaButton>
           <div aria-hidden="true" />
         </div>
       </div>
@@ -1009,29 +1017,24 @@ function LibraryModalFrame({
       >
         <header className="flex shrink-0 items-start justify-between gap-4 border-b border-[#ebebeb] px-5 pb-5 pt-6 md:px-6">
           <div className="min-w-0">
-            <div className="inline-flex h-[22px] items-center border border-[#d8dde6] px-3 text-[11px] font-black uppercase tracking-[0.14em] text-[#8d93a3]">FILTER</div>
+            <StatusBadge className="h-[22px] rounded-none px-3 text-[11px] uppercase tracking-[0.14em] text-[#8d93a3]">FILTER</StatusBadge>
             <h3 className="mt-3 text-[24px] font-bold leading-tight text-[#111827] md:text-[30px]">{title}</h3>
           </div>
-          <button
-            type="button"
-            className="grid h-10 w-10 shrink-0 place-items-center rounded-full bg-[#f2f2f2] text-black transition hover:bg-[#e6e8ec]"
-            onClick={onClose}
-            aria-label="閉じる"
-          >
+          <IconButton type="button" variant="surface" size="lg" onClick={onClose} aria-label="閉じる">
             <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
               <path d="M6 6L18 18" />
               <path d="M18 6L6 18" />
             </svg>
-          </button>
+          </IconButton>
         </header>
         <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5 md:px-6">{children}</div>
         <footer className="grid shrink-0 grid-cols-[1fr_minmax(190px,340px)_1fr] items-center gap-3 border-t border-[#e5e7eb] px-5 py-4 md:px-6">
-          <button type="button" className="justify-self-start text-[13px] font-medium text-[#5f6678] underline decoration-[#c8ced8] underline-offset-4 hover:text-[#333333]" onClick={onReset}>
+          <InlineActionButton type="button" className="justify-self-start text-[13px] font-medium underline decoration-[#c8ced8] underline-offset-4" onClick={onReset}>
             リセット
-          </button>
-          <button type="button" className="w-full rounded-full border border-[#111827] bg-[#111827] px-6 py-2.5 text-[13px] font-semibold text-white transition-colors hover:bg-[#263142]" onClick={onApply}>
+          </InlineActionButton>
+          <InlineCtaButton type="button" onClick={onApply}>
             適用する
-          </button>
+          </InlineCtaButton>
           <div aria-hidden="true" />
         </footer>
       </div>
@@ -1183,14 +1186,9 @@ function LibraryCharacterFilterModal({
             </label>
             <div className="flex flex-wrap gap-2">
               {HOME_ELEMENT_FILTER_OPTIONS.map((option) => (
-                <button
-                  key={option.key}
-                  type="button"
-                  onClick={() => setElementFilter((current) => (current === option.key ? null : option.key))}
-                  className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${elementFilter === option.key ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"}`}
-                >
+                <SelectableChipButton key={option.key} active={elementFilter === option.key} onClick={() => setElementFilter((current) => (current === option.key ? null : option.key))}>
                   {option.label}
-                </button>
+                </SelectableChipButton>
               ))}
             </div>
             <div className="rounded-[16px] bg-[#f6f7f9] p-3">
@@ -1358,16 +1356,16 @@ function LibraryBuildFilterModal({
                 </label>
                 <div className="flex flex-wrap gap-2">
                   {WEAPON_CLASS_FILTER_OPTIONS.map((option) => (
-                    <button key={option.key} type="button" onClick={() => setClassFilter(option.key)} className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${classFilter === option.key ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"}`}>
+                    <SelectableChipButton key={option.key} active={classFilter === option.key} onClick={() => setClassFilter(option.key)}>
                       {option.label}
-                    </button>
+                    </SelectableChipButton>
                   ))}
                 </div>
                 <div className="flex flex-wrap gap-2">
                   {WEAPON_TIER_FILTER_OPTIONS.map((option) => (
-                    <button key={option.key} type="button" onClick={() => setTierFilter(option.key)} className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${tierFilter === option.key ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"}`}>
+                    <SelectableChipButton key={option.key} active={tierFilter === option.key} onClick={() => setTierFilter(option.key)}>
                       {option.label}
-                    </button>
+                    </SelectableChipButton>
                   ))}
                 </div>
                 <div className="max-h-[430px] overflow-y-auto rounded-[16px] bg-white p-3">
@@ -1385,7 +1383,7 @@ function LibraryBuildFilterModal({
                               <WeaponIcon imageUrl={weapon.imageUrl} alt={weapon.name} fallbackLabel={weapon.shortLabel} size={58} className="rounded-[14px] p-1.5" />
                               <div className="min-w-0 flex-1">
                                 <div className="flex flex-wrap items-center gap-2">
-                                  <div className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${getWeaponTierBadgeClass(weapon.tier)}`}>{formatWeaponTierLabel(weapon.tier)}</div>
+                                  <StatusBadge className={`h-auto px-2.5 py-1 text-[11px] font-semibold ${getWeaponTierBadgeClass(weapon.tier)}`}>{formatWeaponTierLabel(weapon.tier)}</StatusBadge>
                                   <div className="text-[12px] text-[#7b7b8d]">{formatWeaponClassLabel(weapon.weaponClass)}</div>
                                 </div>
                                 <div className="mt-2 text-[14px] font-semibold text-black">{weapon.name}</div>
@@ -1393,9 +1391,9 @@ function LibraryBuildFilterModal({
                               </div>
                             </div>
                             {isInclude || isExclude ? (
-                              <span className={["absolute right-2 top-2 flex h-6 items-center rounded-full px-2 text-[11px] font-bold text-white", isExclude ? "bg-[#c27642]" : "bg-[#6bbbd0]"].join(" ")}>
+                              <StatusBadge tone={isExclude ? "warning" : "success"} className="absolute right-2 top-2 h-6 px-2 text-[11px] font-bold">
                                 {isExclude ? "除外" : "含む"}
-                              </span>
+                              </StatusBadge>
                             ) : null}
                           </button>
                         );
@@ -1471,7 +1469,11 @@ function LibraryTagFilterModal({
 
   return (
     <LibraryModalFrame title={title} onClose={onClose} onReset={() => setDraftTags([])} onApply={() => onApply([...draftTags])}>
-      <div className="mb-4 flex items-center justify-end text-[12px] font-black text-[#777777]">{draftTags.length}件選択中</div>
+      <div className="mb-4 flex items-center justify-end">
+        <CountBadge className="h-7 px-2.5 text-[11px]" count={draftTags.length}>
+          {draftTags.length}件選択中
+        </CountBadge>
+      </div>
       <div className="grid gap-3 lg:grid-cols-2">
         {HOME_FILTER_TAG_GROUP_DEFINITIONS.map((group) => (
           <section key={group.key} className="rounded-[12px] border bg-[#f7f7f7] p-3" style={{ borderColor: UI.panelBorder }}>
@@ -1480,17 +1482,9 @@ function LibraryTagFilterModal({
               {group.tags.map((tag) => {
                 const active = draftTags.includes(tag);
                 return (
-                  <button
-                    key={`${group.key}-${tag}`}
-                    type="button"
-                    onClick={() => toggleTag(tag)}
-                    className={[
-                      "inline-flex min-h-9 items-center rounded-full border px-3 py-2 text-[12px] font-medium transition-colors",
-                      active ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]",
-                    ].join(" ")}
-                  >
+                  <SelectableChipButton key={`${group.key}-${tag}`} active={active} onClick={() => toggleTag(tag)} className="min-h-9 py-2">
                     #{tag}
-                  </button>
+                  </SelectableChipButton>
                 );
               })}
             </div>

--- a/src/features/library/sections/SearchResults.tsx
+++ b/src/features/library/sections/SearchResults.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type MouseEve
 
 import { CharacterIcon } from "../../../components/CharacterIcon";
 import { CompareViewIcon, PauseIcon, PlayIcon } from "../../../components/UiIcons";
+import { Button, CardShell, EmptyState, IconButton } from "../../../components/ui";
 import { appRuns, getAppRunById } from "../../../data/appRuns";
 import { characterDb, type RunRecord } from "../../../data/mockRuns";
 import { getYouTubeVideoId } from "../../../lib/youtube";
@@ -179,12 +180,13 @@ function LibraryRecordCard({
   };
 
   return (
-    <article
+    <CardShell
       role="button"
       tabIndex={0}
       onClick={openDetail}
       onKeyDown={handleKeyDown}
-      className="group flex cursor-pointer flex-col overflow-hidden rounded-[8px] border border-[#dfe3ea] bg-white text-left shadow-[0_10px_24px_rgba(21,27,38,0.06)] transition hover:-translate-y-0.5 hover:border-[#cfd6e2] hover:shadow-[0_18px_34px_rgba(21,27,38,0.11)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50"
+      interactive
+      className="group flex cursor-pointer flex-col overflow-hidden rounded-[8px]"
       aria-label={`${run.title} の詳細を見る`}
     >
       <Thumbnail run={run} />
@@ -231,7 +233,7 @@ function LibraryRecordCard({
           </button>
         </div>
       </div>
-    </article>
+    </CardShell>
   );
 }
 
@@ -291,16 +293,18 @@ function CompareCandidatePanel({
 
 function CompareCandidateCard({ run, onSelectRun, onRemove }: { run: RunRecord; onSelectRun: (runId: string) => void; onRemove: (runId: string) => void }) {
   return (
-    <article className="relative overflow-hidden rounded-[8px] border border-[#e2e6ee] bg-[#fbfcfd]">
-      <button
+    <CardShell className="relative overflow-hidden rounded-[8px] bg-[#fbfcfd] shadow-none">
+      <IconButton
         type="button"
         onClick={() => onRemove(run.id)}
         aria-label={`${run.title} を比較候補から削除`}
         title="削除"
-        className="absolute right-2 top-2 z-10 grid h-7 w-7 place-items-center rounded-full bg-black/70 text-white shadow transition hover:bg-black focus:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+        variant="overlay"
+        size="sm"
+        className="absolute right-2 top-2 z-10 h-7 w-7 shadow"
       >
         <XIcon className="h-4 w-4" />
-      </button>
+      </IconButton>
       <button type="button" onClick={() => onSelectRun(run.id)} className="block w-full text-left transition hover:bg-[#f7f8fa] focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[#111116]/40">
         <div className="relative h-[88px] bg-[#111827]">
           <img src={getYouTubeThumbnailUrl(run.videoUrl) ?? ""} alt="" className="absolute inset-0 h-full w-full object-cover" loading="lazy" decoding="async" referrerPolicy="no-referrer" />
@@ -324,7 +328,7 @@ function CompareCandidateCard({ run, onSelectRun, onRemove }: { run: RunRecord; 
           </div>
         </div>
       </button>
-    </article>
+    </CardShell>
   );
 }
 
@@ -479,7 +483,7 @@ function ActionRunList({
 }
 
 function ActionEmptyState({ label }: { label: string }) {
-  return <div className="rounded-[8px] border border-dashed border-[#dfe3ea] bg-[#fbfcfd] px-3 py-5 text-center text-[12px] font-bold text-[#8d93a3]">{label}</div>;
+  return <EmptyState title={label} className="rounded-[8px] bg-[#fbfcfd] px-3 py-5 text-[12px]" />;
 }
 
 function formatHistoryDate(value: string) {
@@ -557,13 +561,13 @@ function LibraryCompareDrawer({
             <div className="text-[18px] font-semibold text-[#111827]">比較ビュー</div>
           </div>
           <div className="flex items-center gap-2">
-            <button type="button" onClick={toggleSync} className="inline-flex h-9 items-center justify-center gap-2 rounded-[42px] border border-[#d8dde6] bg-[#f7f8fa] px-4 text-[13px] font-medium text-[#333333] transition hover:bg-[#eef1f5]">
+            <Button type="button" onClick={toggleSync} variant="tonal" size="md" className="h-9 rounded-[42px] px-4 text-[13px]">
               {syncPlaying ? <PauseIcon className="h-4 w-4" /> : <PlayIcon className="h-4 w-4" />}
               <span>{syncPlaying ? "同期停止" : "同時再生"}</span>
-            </button>
-            <button type="button" aria-label="比較ビューを閉じる" onClick={onClose} className="grid h-9 w-9 place-items-center rounded-full border border-[#d8dde6] bg-[#f7f8fa] text-[#333333] transition hover:bg-[#eef1f5] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50">
+            </Button>
+            <IconButton type="button" aria-label="比較ビューを閉じる" onClick={onClose} variant="surface">
               <XIcon className="h-4 w-4" />
-            </button>
+            </IconButton>
           </div>
         </div>
         <div className="grid min-h-0 flex-1 grid-cols-2 divide-x divide-[#e5e7eb]">
@@ -635,13 +639,9 @@ function LibraryCompareRunPane({
 
 function CompareEmptyState() {
   return (
-    <div className="px-4 py-8 text-center">
-      <div className="mx-auto grid h-11 w-11 place-items-center rounded-full bg-[#f0f2f5] text-[#7b8493]">
-        <CompareViewIcon className="h-5 w-5" />
-      </div>
-      <p className="mt-3 text-[13px] font-black text-[#111827]">候補なし</p>
-      <p className="mt-1 text-[11px] font-bold leading-5 text-[#8d93a3]">結果カードの下部から追加できます。</p>
-    </div>
+    <EmptyState title="候補なし" icon={<CompareViewIcon className="h-5 w-5" />} className="border-0 bg-transparent px-4 py-8 text-[13px]">
+      結果カードの下部から追加できます。
+    </EmptyState>
   );
 }
 
@@ -722,11 +722,9 @@ function formatCompactBracketLabel(label: string) {
 
 function LibraryEmptyResults() {
   return (
-    <div className="rounded-[16px] border border-dashed border-[#dcdfe6] bg-white py-16 text-center">
-      <SearchIcon size={46} className="mx-auto mb-4 text-[#dcdfe6]" />
-      <h3 className="text-[18px] font-black text-[#606266]">該当する記録がありません</h3>
-      <p className="mt-2 text-[13px] font-bold text-[#909399]">条件を減らすか、検索ワードを変えてください。</p>
-    </div>
+    <EmptyState title="該当する記録がありません" icon={<SearchIcon size={46} />} className="rounded-[16px] bg-white py-16 text-[18px]">
+      条件を減らすか、検索ワードを変えてください。
+    </EmptyState>
   );
 }
 

--- a/src/features/library/sections/SearchResults.tsx
+++ b/src/features/library/sections/SearchResults.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type MouseEve
 
 import { CharacterIcon } from "../../../components/CharacterIcon";
 import { CompareViewIcon, PauseIcon, PlayIcon } from "../../../components/UiIcons";
-import { Button, CardShell, EmptyState, IconButton } from "../../../components/ui";
+import { Button, CardShell, CostBadge, CountBadge, EmptyState, IconButton, InlineActionButton, StatusBadge } from "../../../components/ui";
 import { appRuns, getAppRunById } from "../../../data/appRuns";
 import { characterDb, type RunRecord } from "../../../data/mockRuns";
 import { getYouTubeVideoId } from "../../../lib/youtube";
@@ -11,7 +11,7 @@ import { HOME_BRACKET_ACCENT_COLORS } from "../../home/config";
 import { getBracketLabel } from "../../home/logic";
 import { SearchIcon } from "../../home/ui/icons";
 import { getPartyBuildItems, postYouTubeCommand } from "../../recordDetail/logic";
-import { CircleAvatar, DETAIL_MUTED_SURFACE_CLASS, PartyBuildItemCard, PlatformLabel, SidebarPanel, SidebarSectionHeader, TagChip, VideoFrame } from "../../recordDetail/ui";
+import { CircleAvatar, DETAIL_MUTED_SURFACE_CLASS, PartyBuildItemCard, PlatformBadge, PlatformLabel, SidebarPanel, SidebarSectionHeader, TagChip, VideoFrame } from "../../recordDetail/ui";
 import { LIBRARY_COMPARE_CANDIDATE_LIMIT, type LibraryActionAccordionKey, type LibrarySearchHistoryEntry } from "../logic/actionStorage";
 import { filterLibraryRuns, hasActiveLibrarySearchFilters } from "../logic/searchResults";
 import type { LibrarySearchFilters } from "../types";
@@ -73,7 +73,7 @@ export function LibrarySearchResults({
         </h2>
         <div className="mt-4 flex flex-wrap items-center gap-3">
           <span className="text-[20px] font-black tracking-[-0.03em] text-[#111827] md:text-[24px]">{heading}</span>
-          <span className="inline-flex h-8 items-center rounded-full border border-[#d8dde6] bg-white px-3 text-[12px] font-black text-[#5f6678]">{visibleRuns.length}件</span>
+          <CountBadge count={visibleRuns.length} />
         </div>
         <p className="mt-2 max-w-[560px] text-[12px] font-bold leading-5 text-[#7b8493] md:text-[13px]">{lead}</p>
       </div>
@@ -211,26 +211,25 @@ function LibraryRecordCard({
 
         <div className="flex flex-wrap gap-1">
           {visibleTags.map((tag) => (
-            <span key={`${run.id}-${tag}`} className="max-w-full truncate rounded-full bg-[#f0f2f5] px-2 py-0.5 text-[10px] font-bold text-[#6b7280]">
-              #{tag}
-            </span>
+            <TagChip key={`${run.id}-${tag}`} tag={`#${tag}`} compact />
           ))}
         </div>
 
         <div className="mt-auto flex items-center justify-between border-t border-[#edf0f4] pt-2 text-[11px] font-extrabold text-[#5f6678]">
-          <button
+          <InlineActionButton
             type="button"
             onClick={handleAddCandidate}
             aria-disabled={compareDisabled || isCandidate}
-            className={`flex items-center gap-1 transition ${compareDisabled ? "cursor-not-allowed text-[#b8bec8]" : "hover:text-[#111827]"} ${isCandidate ? "text-[#111827]" : ""}`}
+            active={isCandidate}
+            className={compareDisabled ? "cursor-not-allowed text-[#b8bec8]" : ""}
           >
             {isCandidate ? <CheckIcon className="h-[11px] w-[11px]" /> : <PlusIcon className="h-[11px] w-[11px]" />}
             {isCandidate ? "追加済み" : compareDisabled ? "2件まで" : "比較に追加"}
-          </button>
-          <button type="button" onClick={handleToggleWatchLater} aria-pressed={isWatchLater} className={`flex items-center gap-1 transition hover:text-[#111827] ${isWatchLater ? "text-[#111827]" : ""}`}>
+          </InlineActionButton>
+          <InlineActionButton type="button" onClick={handleToggleWatchLater} aria-pressed={isWatchLater} active={isWatchLater}>
             <BookmarkIcon className={isWatchLater ? "h-[11px] w-[11px] fill-current" : "h-[11px] w-[11px]"} />
             {isWatchLater ? "保存済み" : "あとで見る"}
-          </button>
+          </InlineActionButton>
         </div>
       </div>
     </CardShell>
@@ -257,7 +256,7 @@ function CompareCandidatePanel({
       <header className="border-b border-[#eef1f5] p-4">
         <div className="flex items-center justify-between gap-3">
           <h3 className="text-[15px] font-black text-[#111827]">比較候補の記録</h3>
-          <span className="shrink-0 text-[11px] font-black text-[#5b6472]">{candidates.length}/{LIBRARY_COMPARE_CANDIDATE_LIMIT}件</span>
+          <CountBadge className="h-7 px-2.5 text-[11px]" count={`${candidates.length}/${LIBRARY_COMPARE_CANDIDATE_LIMIT}`} />
         </div>
         <p className="mt-2 text-[11px] font-bold leading-5 text-[#7b8493]">比較したい記録だけをここに一時保存します。</p>
       </header>
@@ -271,18 +270,20 @@ function CompareCandidatePanel({
         <CompareEmptyState />
       )}
       <div className="grid grid-cols-2 border-t border-[#eef1f5]">
-        <button type="button" onClick={onClear} disabled={candidates.length === 0} className="h-11 border-r border-[#eef1f5] text-[12px] font-black text-[#7b8493] transition hover:bg-[#fafbfc] hover:text-[#ff3b1f] disabled:cursor-not-allowed disabled:text-[#c1c7d0] disabled:hover:bg-transparent">
+        <Button type="button" variant="ghost" size="sm" onClick={onClear} disabled={candidates.length === 0} className="h-11 rounded-none border-r border-[#eef1f5] text-[12px] font-black text-[#7b8493] hover:bg-[#fafbfc] hover:text-[#d24b5a] disabled:text-[#c1c7d0] disabled:hover:bg-transparent">
           候補をクリア
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
+          variant="ghost"
+          size="sm"
           onClick={onOpenCompare}
           disabled={!canOpenCompare}
-          className="hidden h-11 items-center justify-center gap-1.5 text-[12px] font-black text-[#111827] transition hover:bg-[#fafbfc] hover:text-[#ff3b1f] disabled:cursor-not-allowed disabled:text-[#c1c7d0] disabled:hover:bg-transparent lg:flex"
+          className="hidden h-11 rounded-none text-[12px] font-black text-[#111827] hover:bg-[#fafbfc] hover:text-[#d24b5a] disabled:text-[#c1c7d0] disabled:hover:bg-transparent lg:flex"
         >
           比較画面を開く
           <ChevronIcon className="h-4 w-4" />
-        </button>
+        </Button>
         <button type="button" disabled className="h-11 text-[12px] font-black text-[#c1c7d0] lg:hidden">
           PC専用
         </button>
@@ -309,7 +310,7 @@ function CompareCandidateCard({ run, onSelectRun, onRemove }: { run: RunRecord; 
         <div className="relative h-[88px] bg-[#111827]">
           <img src={getYouTubeThumbnailUrl(run.videoUrl) ?? ""} alt="" className="absolute inset-0 h-full w-full object-cover" loading="lazy" decoding="async" referrerPolicy="no-referrer" />
           <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.05),rgba(0,0,0,0.68))]" />
-          <span className="absolute bottom-2 right-2 rounded-full bg-white px-2 py-1 text-[11px] font-black text-black shadow">{run.time}</span>
+          <StatusBadge tone="neutral" className="absolute bottom-2 right-2 h-auto px-2 py-1 text-[11px] text-black shadow">{run.time}</StatusBadge>
         </div>
         <div className="p-3">
           <p className="line-clamp-1 text-[12px] font-black text-[#111827]">{run.title}</p>
@@ -427,15 +428,16 @@ function SearchHistoryList({
               {entry.summary} / {formatHistoryDate(entry.createdAt)}
             </p>
           </button>
-          <button
+          <IconButton
             type="button"
             onClick={() => onRemove(entry.signature)}
             aria-label={`${entry.label} を検索履歴から削除`}
             title="削除"
-            className="grid h-8 w-8 shrink-0 place-items-center rounded-full text-[#7b8493] transition hover:bg-[#eef1f5] hover:text-[#111827] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/40"
+            variant="ghost"
+            size="sm"
           >
             <XIcon className="h-4 w-4" />
-          </button>
+          </IconButton>
         </div>
       ))}
     </div>
@@ -467,15 +469,16 @@ function ActionRunList({
               {run.userName} / {run.time}
             </p>
           </button>
-          <button
+          <IconButton
             type="button"
             onClick={() => onRemove(run.id)}
             aria-label={`${run.title} をリストから削除`}
             title="削除"
-            className="grid h-8 w-8 shrink-0 place-items-center rounded-full text-[#7b8493] transition hover:bg-[#eef1f5] hover:text-[#111827] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/40"
+            variant="ghost"
+            size="sm"
           >
             <XIcon className="h-4 w-4" />
-          </button>
+          </IconButton>
         </div>
       ))}
     </div>
@@ -594,7 +597,7 @@ function LibraryCompareRunPane({
 
   return (
     <div className="min-h-0 overflow-y-auto bg-[#f5f6f8] px-3 py-3">
-      <div className="mb-3 inline-flex rounded-full border border-[#d8dde6] bg-white px-3 py-1 text-[12px] font-black text-[#5f6678]">{label}</div>
+      <StatusBadge className="mb-3 h-auto px-3 py-1 text-[12px]">{label}</StatusBadge>
       <VideoFrame title={run.title} videoUrl={run.videoUrl} iframeRef={iframeRef} mute={muted} />
       <div className="mt-4 flex flex-col gap-[12px]">
         <div className="text-[18px] font-bold leading-tight text-[#111827]">{run.title}</div>
@@ -603,9 +606,7 @@ function LibraryCompareRunPane({
             <CircleAvatar label={run.userName} size={40} />
             <div className="truncate text-[18px] font-bold leading-none text-[#111827]">{run.userName}</div>
           </div>
-          <div className="inline-flex shrink-0 items-center gap-[6px] rounded-[42px] border border-[#d8dde6] bg-white px-[10px] py-[5px] text-[13px] text-[#333333]">
-            <PlatformLabel platform={run.platform} iconClassName="h-[13px] w-[13px]" />
-          </div>
+          <PlatformBadge platform={run.platform} />
         </div>
         <div className={`w-full ${DETAIL_MUTED_SURFACE_CLASS} p-[12px]`}>
           <div className="flex items-center gap-x-[18px] overflow-x-auto whitespace-nowrap text-[14px] text-[#5f6678]">
@@ -693,27 +694,22 @@ function LibraryCardCharacterStack({ run }: { run: RunRecord }) {
 
 function InfoBadge({ children }: { children: string }) {
   return (
-    <span className="max-w-[76px] truncate border border-[#d8dde6] px-1.5 py-0.5 text-[9px] font-black uppercase leading-none tracking-[0.1em] text-[#7b8493]">
+    <StatusBadge className="h-auto max-w-[76px] rounded-none px-1.5 py-0.5 text-[9px] uppercase tracking-[0.1em] text-[#7b8493]">
       {children}
-    </span>
+    </StatusBadge>
   );
 }
 
 function BracketBadge({ children, color }: { children: string; color: string }) {
   return (
-    <span className="max-w-[68px] truncate px-1.5 py-0.5 text-[9px] font-black uppercase leading-none tracking-[0.1em] text-white" style={{ backgroundColor: color }}>
+    <StatusBadge tone="overlay" className="h-auto max-w-[68px] rounded-none border-0 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.1em] text-white" style={{ backgroundColor: color }}>
       {children}
-    </span>
+    </StatusBadge>
   );
 }
 
 function CostMetric({ label, value }: { label: string; value: string | number }) {
-  return (
-    <span className="inline-flex min-w-0 items-center gap-1.5 whitespace-nowrap">
-      <span className="text-[10px] font-bold uppercase tracking-[0.06em] text-[#6b7280]">{label}</span>
-      <span className="truncate text-[12px] font-black text-[#6b7280]">{value}</span>
-    </span>
-  );
+  return <CostBadge className="bg-transparent px-0 py-0" label={label} value={value} />;
 }
 
 function formatCompactBracketLabel(label: string) {

--- a/src/features/recordDetail/config.ts
+++ b/src/features/recordDetail/config.ts
@@ -11,6 +11,4 @@ export const DETAIL_PANEL_SHELL_CLASS =
   "relative overflow-hidden rounded-[20px] bg-[linear-gradient(135deg,#ffffff_0%,#f1eadf_34%,#dfe8f2_68%,#f8f6f1_100%)] shadow-[0_18px_34px_rgba(37,44,58,0.10)]";
 export const DETAIL_PANEL_INNER_CLASS = "relative z-[1] m-[2px] rounded-[18px] bg-white text-[#333333]";
 export const DETAIL_MUTED_SURFACE_CLASS = "rounded-[16px] border border-[#e5e7eb] bg-[#f7f8fa]";
-export const DETAIL_ICON_BUTTON_CLASS =
-  "grid h-9 w-9 place-items-center rounded-full border border-[#d8dde6] bg-white text-[#333333] transition hover:bg-[#eef1f5]";
 export const DETAIL_LIKE_ACTIVE_ICON_CLASS = "text-[#ff8ea1]";

--- a/src/features/recordDetail/sections/CompareDrawer.tsx
+++ b/src/features/recordDetail/sections/CompareDrawer.tsx
@@ -2,9 +2,10 @@
 
 import type { RunRecord } from "../../../data/mockRuns";
 import { PlatformIcon, PauseIcon, PlayIcon } from "../../../components/UiIcons";
+import { Button, IconButton } from "../../../components/ui";
 import { formatVersionLabel } from "../../../lib/versionLabels";
 
-import { DETAIL_ICON_BUTTON_CLASS, DETAIL_MUTED_SURFACE_CLASS } from "../config";
+import { DETAIL_MUTED_SURFACE_CLASS } from "../config";
 import { getPartyBuildItems, postYouTubeCommand } from "../logic";
 import {
   CircleAvatar,
@@ -129,25 +130,26 @@ export function CompareDrawer({
             <div className="text-[16px] font-semibold text-[#111827] md:text-[18px]">比較ビュー</div>
           </div>
           <div className="flex items-center gap-2">
-            <button
-              type="button"
+            <Button
               onClick={onToggleSync}
-              className="inline-flex h-9 items-center justify-center gap-2 rounded-[42px] border border-[#d8dde6] bg-[#f7f8fa] px-4 text-[13px] font-medium text-[#333333] transition hover:bg-[#eef1f5]"
+              variant="tonal"
+              size="md"
+              className="h-9 rounded-[42px] px-4 text-[13px]"
             >
               {syncPlaying ? <PauseIcon className="h-4 w-4" /> : <PlayIcon className="h-4 w-4" />}
               <span>{syncPlaying ? "同期停止" : "同時再生"}</span>
-            </button>
-            <button
+            </Button>
+            <IconButton
               type="button"
               aria-label="比較ビューを閉じる"
               onClick={onClose}
-              className={DETAIL_ICON_BUTTON_CLASS}
+              variant="surface"
             >
               <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
                 <path d="M6 6l12 12" />
                 <path d="M18 6l-12 12" />
               </svg>
-            </button>
+            </IconButton>
           </div>
         </div>
 

--- a/src/features/recordDetail/sections/Header.tsx
+++ b/src/features/recordDetail/sections/Header.tsx
@@ -1,4 +1,4 @@
-﻿import { DETAIL_ICON_BUTTON_CLASS } from "../config";
+﻿import { BackButton, Button, SelectControl } from "../../../components/ui";
 import { CircleAvatar } from "../ui";
 
 export function Header({
@@ -23,18 +23,7 @@ export function Header({
       {embedded ? (
         <div className="border-b border-[#e5e7eb] bg-white">
           <div className={`header-font mx-auto flex min-h-[52px] max-w-[1600px] items-center gap-3 px-4 py-2 ${forceMobileLayout ? "" : "md:px-6"}`}>
-            {onBack ? (
-              <button
-                type="button"
-                onClick={onBack}
-                aria-label="一覧へ戻る"
-                className={`${DETAIL_ICON_BUTTON_CLASS} shrink-0`}
-              >
-                <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M15 5L8 12L15 19" />
-                </svg>
-              </button>
-            ) : null}
+            {onBack ? <BackButton label="一覧へ戻る" onClick={onBack} className="shrink-0" /> : null}
             <div className="min-w-0 text-[16px] font-semibold tracking-tight text-[#111827] md:text-[18px]">記録詳細</div>
           </div>
         </div>
@@ -42,48 +31,34 @@ export function Header({
       <nav className={embedded ? "hidden" : "sticky top-0 z-40 border-b border-[#e5e7eb] bg-white shadow-[0_1px_0_rgba(17,24,39,0.03)]"}>
         <div className={`header-font mx-auto flex max-w-[1600px] items-center justify-between px-4 py-2 ${forceMobileLayout ? "min-h-[52px]" : "md:px-6 md:py-3"}`}>
           <div className={`flex items-center ${forceMobileLayout ? "gap-3" : "gap-4 md:gap-6"}`}>
-            {onBack ? (
-              <button
-                type="button"
-                onClick={onBack}
-                aria-label="一覧へ戻る"
-                className={`${DETAIL_ICON_BUTTON_CLASS} shrink-0`}
-              >
-                <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M15 5L8 12L15 19" />
-                </svg>
-              </button>
-            ) : null}
+            {onBack ? <BackButton label="一覧へ戻る" onClick={onBack} className="shrink-0" /> : null}
             <h1 className={`font-semibold tracking-tight text-[#111827] ${forceMobileLayout ? "text-[24px]" : "text-[26px] md:text-[38px]"}`}>精鋭狩りDB</h1>
-            <div className="relative">
-              <select
-                className={`appearance-none rounded-full border border-[#d8dde6] bg-[#f7f8fa] py-1.5 pl-3 pr-10 font-medium text-[#333333] ${forceMobileLayout ? "text-[15px]" : "text-[16px] md:pl-4 md:pr-12 md:text-[20px]"}`}
+            <label className="flex items-center gap-2 text-[10px] font-black uppercase tracking-[0.18em] text-[#7b8493]">
+              <span className={forceMobileLayout ? "sr-only" : "hidden md:inline"}>Version</span>
+              <SelectControl
+                className={forceMobileLayout ? "h-9 min-w-[96px] py-1.5 pl-3 pr-9 text-[15px]" : "h-10 min-w-[112px] bg-[#f7f8fa] py-1.5 pl-4 pr-10 text-[16px] md:h-11 md:min-w-[128px] md:text-[20px]"}
                 value={headerVersion}
                 onChange={(event) => onHeaderVersionChange(event.target.value)}
+                aria-label="Version"
               >
                 {versionOptions.map((version) => (
                   <option key={version} value={version}>
                     {version}
                   </option>
                 ))}
-              </select>
-              <span className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[#5f6678]">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                  <path d="M6 9l6 6 6-6" />
-                </svg>
-              </span>
-            </div>
+              </SelectControl>
+            </label>
           </div>
 
           <div className={`flex items-center ${forceMobileLayout ? "gap-2" : "gap-3 md:gap-4"}`}>
-            <button
-              type="button"
+            <Button
               onClick={onRequestSubmit}
-              className={`flex h-9 w-9 items-center justify-center rounded-full border border-[#111827] bg-[#111827] text-white ${forceMobileLayout ? "" : "md:h-auto md:w-auto md:gap-2 md:px-5 md:py-2.5 md:text-[20px]"}`}
+              size={forceMobileLayout ? "sm" : "lg"}
+              className={forceMobileLayout ? "h-9 w-9 px-0" : "md:text-[20px]"}
             >
               <span className="text-[20px] leading-none md:text-[22px]">＋</span>
-              <span className={forceMobileLayout ? "hidden" : "hidden md:inline"}>記録提出</span>
-            </button>
+              <span className={forceMobileLayout ? "hidden" : "hidden md:inline"}>記録申請</span>
+            </Button>
             <CircleAvatar label="luna3" size={36} bordered />
           </div>
         </div>

--- a/src/features/recordDetail/sections/MainColumn.tsx
+++ b/src/features/recordDetail/sections/MainColumn.tsx
@@ -5,7 +5,7 @@ import { LikeIcon, ShareIcon } from "../../../components/UiIcons";
 import { formatVersionLabel } from "../../../lib/versionLabels";
 
 import { collapsedCopyStyle, DETAIL_LIKE_ACTIVE_ICON_CLASS } from "../config";
-import { CircleAvatar, DETAIL_MUTED_SURFACE_CLASS, PillButton, PlatformLabel, SectionTitle, TagChip, VideoFrame } from "../ui";
+import { CircleAvatar, DETAIL_MUTED_SURFACE_CLASS, PillButton, PlatformBadge, SectionTitle, TagChip, VideoFrame } from "../ui";
 
 export function MainColumn({
   currentRun,
@@ -82,7 +82,7 @@ export function MainColumn({
             <div className={`flex min-w-0 gap-x-[16px] text-[13px] text-[#5f6678] md:gap-x-[18px] md:text-[14px] ${compareOpen ? "flex-wrap items-center gap-y-[6px]" : "items-center"}`}>
               <span>ver : {formatVersionLabel(currentRun.versionLabel)}</span>
               <span>{currentRun.postedLabel}</span>
-              <PlatformLabel platform={currentRun.platform} />
+              <PlatformBadge platform={currentRun.platform} />
             </div>
             {canExpandDescription && !descriptionExpanded ? (
               <button

--- a/src/features/recordDetail/sections/SimilarRunCard.tsx
+++ b/src/features/recordDetail/sections/SimilarRunCard.tsx
@@ -4,8 +4,9 @@ import type { KeyboardEvent } from "react";
 import { characterDb } from "../../../data/mockRuns";
 import { CharacterIcon } from "../../../components/CharacterIcon";
 import { CompareViewIcon, LikeIcon, ShareIcon } from "../../../components/UiIcons";
+import { CardShell, IconButton } from "../../../components/ui";
 
-import { DETAIL_ICON_BUTTON_CLASS, DETAIL_LIKE_ACTIVE_ICON_CLASS } from "../config";
+import { DETAIL_LIKE_ACTIVE_ICON_CLASS } from "../config";
 import { PlatformLabel, SimilarityReasonChip } from "../ui";
 
 function SimilarActionMenu({
@@ -27,18 +28,18 @@ function SimilarActionMenu({
       onClick={(event) => event.stopPropagation()}
       onKeyDown={(event) => event.stopPropagation()}
     >
-      <button
+      <IconButton
         type="button"
         onClick={onToggle}
         aria-label="類似記録の操作"
-        className={DETAIL_ICON_BUTTON_CLASS}
+        variant="surface"
       >
         <svg viewBox="0 0 24 24" className="h-4 w-4" fill="currentColor" aria-hidden="true">
           <circle cx="12" cy="5" r="1.8" />
           <circle cx="12" cy="12" r="1.8" />
           <circle cx="12" cy="19" r="1.8" />
         </svg>
-      </button>
+      </IconButton>
       {isOpen ? (
         <div className="absolute right-0 top-full z-20 mt-2 w-[180px] rounded-[16px] border border-[#e5e7eb] bg-white p-2 shadow-[0_20px_40px_rgba(31,41,55,0.14)]">
           <button
@@ -103,15 +104,15 @@ export function SimilarRunCard({
   };
 
   return (
-    <article
+    <CardShell
       role={canOpenDetail ? "button" : undefined}
       tabIndex={canOpenDetail ? 0 : undefined}
       aria-label={canOpenDetail ? `${match.run.title} の詳細を見る` : undefined}
       onClick={onOpenDetail}
       onKeyDown={handleKeyDown}
-      className={`rounded-[16px] border p-[14px] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/40 ${
-        isCompareSelected ? "border-[#9aa7ba] bg-[#eef1f5]" : "border-[#e5e7eb] bg-white hover:bg-[#f7f8fa]"
-      } ${canOpenDetail ? "cursor-pointer" : ""}`}
+      interactive={canOpenDetail}
+      selected={isCompareSelected}
+      className={`rounded-[16px] p-[14px] shadow-none ${!isCompareSelected ? "hover:bg-[#f7f8fa]" : ""}`}
     >
       <div className="flex items-start gap-[10px]">
         <div className="min-w-0 flex-1">
@@ -147,6 +148,6 @@ export function SimilarRunCard({
           </div>
         </div>
       </div>
-    </article>
+    </CardShell>
   );
 }

--- a/src/features/recordDetail/sections/SimilarRunCard.tsx
+++ b/src/features/recordDetail/sections/SimilarRunCard.tsx
@@ -4,7 +4,7 @@ import type { KeyboardEvent } from "react";
 import { characterDb } from "../../../data/mockRuns";
 import { CharacterIcon } from "../../../components/CharacterIcon";
 import { CompareViewIcon, LikeIcon, ShareIcon } from "../../../components/UiIcons";
-import { CardShell, IconButton } from "../../../components/ui";
+import { Button, CardShell, IconButton } from "../../../components/ui";
 
 import { DETAIL_LIKE_ACTIVE_ICON_CLASS } from "../config";
 import { PlatformLabel, SimilarityReasonChip } from "../ui";
@@ -42,30 +42,18 @@ function SimilarActionMenu({
       </IconButton>
       {isOpen ? (
         <div className="absolute right-0 top-full z-20 mt-2 w-[180px] rounded-[16px] border border-[#e5e7eb] bg-white p-2 shadow-[0_20px_40px_rgba(31,41,55,0.14)]">
-          <button
-            type="button"
-            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-[#333333] hover:bg-[#f1f3f6]"
-            onClick={() => onAction("like")}
-          >
+          <Button type="button" variant="ghost" size="sm" className="h-10 w-full justify-start rounded-[12px] px-3 text-[13px] font-medium text-[#333333]" onClick={() => onAction("like")}>
             <LikeIcon filled={liked} className={`h-4 w-4 ${liked ? DETAIL_LIKE_ACTIVE_ICON_CLASS : ""}`} />
             <span>{liked ? "いいね解除" : "いいね"}</span>
-          </button>
-          <button
-            type="button"
-            className="flex h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-[#333333] hover:bg-[#f1f3f6]"
-            onClick={() => onAction("share")}
-          >
+          </Button>
+          <Button type="button" variant="ghost" size="sm" className="h-10 w-full justify-start rounded-[12px] px-3 text-[13px] font-medium text-[#333333]" onClick={() => onAction("share")}>
             <ShareIcon className="h-4 w-4" />
             <span>{shared ? "共有解除" : "共有"}</span>
-          </button>
-          <button
-            type="button"
-            className="hidden h-10 w-full items-center gap-3 rounded-[12px] px-3 text-left text-[13px] font-medium text-[#333333] hover:bg-[#f1f3f6] lg:flex"
-            onClick={() => onAction("compare")}
-          >
+          </Button>
+          <Button type="button" variant="ghost" size="sm" className="hidden h-10 w-full justify-start rounded-[12px] px-3 text-[13px] font-medium text-[#333333] lg:flex" onClick={() => onAction("compare")}>
             <CompareViewIcon className="h-4 w-4" />
             比較ビュー
-          </button>
+          </Button>
         </div>
       ) : null}
     </div>

--- a/src/features/recordDetail/ui/index.tsx
+++ b/src/features/recordDetail/ui/index.tsx
@@ -3,6 +3,7 @@
 import type { RunRecord } from "../../../data/mockRuns";
 import { CharacterIcon } from "../../../components/CharacterIcon";
 import { PlatformIcon } from "../../../components/UiIcons";
+import { Badge, Button, Chip } from "../../../components/ui";
 import { getYouTubeEmbedUrl } from "../../../lib/youtube";
 
 import { DETAIL_MUTED_SURFACE_CLASS, DETAIL_PANEL_INNER_CLASS, DETAIL_PANEL_SHELL_CLASS } from "../config";
@@ -48,31 +49,30 @@ export function PillButton({
   className?: string;
 }) {
   return (
-    <button
+    <Button
       type="button"
       onClick={onClick}
-      className={`inline-flex items-center justify-center gap-2 rounded-[42px] px-[14px] py-[7px] text-[14px] font-medium leading-none transition duration-150 hover:-translate-y-[1px] hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)] md:text-[15px] ${
-        dark || active
-          ? "border border-black/50 bg-black text-white"
-          : "border border-[#d8dde6] bg-[#f7f8fa] text-[#333333] hover:bg-[#eef1f5]"
+      variant={dark || active ? "primary" : "tonal"}
+      size="sm"
+      className={`rounded-[42px] px-[14px] py-[7px] text-[14px] font-medium transition duration-150 hover:-translate-y-[1px] hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)] md:text-[15px] ${
+        dark || active ? "border-black/50 bg-black text-white" : ""
       } ${className}`}
     >
       {children}
-    </button>
+    </Button>
   );
 }
 
 export function TinyBadge({ label, highlighted = false }: { label: string; highlighted?: boolean }) {
   return (
-    <span
-      className={`inline-flex min-w-[38px] items-center justify-center rounded-full px-[9px] py-[5px] text-[11px] font-semibold leading-none md:text-[12px] ${
-        highlighted
-          ? "border border-[#efc9b0] bg-[#fbf1ea] text-[#c27642]"
-          : "border border-[#dde2ea] bg-[#f2f4f7] text-[#5f6678]"
+    <Badge
+      variant={highlighted ? "warning" : "stat"}
+      className={`h-auto min-h-[24px] min-w-[38px] justify-center px-[9px] py-[5px] text-[11px] font-semibold md:text-[12px] ${
+        highlighted ? "bg-[#fbf1ea] text-[#c27642]" : "border border-[#dde2ea] bg-[#f2f4f7]"
       }`}
     >
       {label}
-    </span>
+    </Badge>
   );
 }
 
@@ -120,9 +120,9 @@ export function PartyBuildItemCard({ entry }: { entry: PartyBuildItem }) {
 
 export function SimilarityReasonChip({ label }: { label: string }) {
   return (
-    <span className="inline-flex items-center rounded-full border border-[#d8dde6] bg-[#eef1f5] px-[10px] py-[5px] text-[11px] font-medium leading-none text-[#5f6678] md:text-[12px]">
+    <Chip variant="reason" className="min-h-0 px-[10px] py-[5px] text-[11px] md:text-[12px]">
       {label}
-    </span>
+    </Chip>
   );
 }
 
@@ -141,11 +141,33 @@ export function PlatformLabel({
   );
 }
 
-export function TagChip({ tag }: { tag: string }) {
+export function PlatformBadge({
+  platform,
+  iconClassName = "h-[13px] w-[13px]",
+}: {
+  platform: RunRecord["platform"];
+  iconClassName?: string;
+}) {
+  return (
+    <Badge variant="neutral" className="h-auto gap-[6px] px-[10px] py-[5px] text-[12px] font-medium text-[#333333] md:text-[13px]">
+      <PlatformIcon platform={platform} className={iconClassName} />
+      <span>{platform}</span>
+    </Badge>
+  );
+}
+
+export function TagChip({ compact = false, tag }: { compact?: boolean; tag: string }) {
   const platformParts = parsePlatformTag(tag);
 
   return (
-    <span className="inline-flex items-center gap-[6px] rounded-[42px] border border-[#d8dde6] bg-white px-[10px] py-[5px] text-[12px] text-[#333333] md:px-[12px] md:py-[6px] md:text-[13px]">
+    <Chip
+      variant="tag"
+      className={
+        compact
+          ? "min-h-0 gap-[5px] px-2 py-0.5 text-[10px] font-bold text-[#6b7280]"
+          : "min-h-0 gap-[6px] rounded-[42px] px-[10px] py-[5px] text-[12px] font-normal md:px-[12px] md:py-[6px] md:text-[13px]"
+      }
+    >
       {platformParts ? (
         <span className="inline-flex items-center gap-[4px]">
           {platformParts.map((platform, index) => (
@@ -154,7 +176,7 @@ export function TagChip({ tag }: { tag: string }) {
         </span>
       ) : null}
       <span>{tag}</span>
-    </span>
+    </Chip>
   );
 }
 

--- a/src/features/submit/Page.tsx
+++ b/src/features/submit/Page.tsx
@@ -8,7 +8,7 @@ import { Header } from "./sections/Header";
 import { StepBasic } from "./sections/StepBasic";
 import { StepDetails } from "./sections/StepDetails";
 import { StepParty } from "./sections/StepParty";
-import { StepIndicator, SubmitSurfaceScale } from "./ui";
+import { StepIndicator } from "./ui";
 
 export function SubmitPage({ onBack, embedded = false }: { onBack: () => void; embedded?: boolean }) {
   const [showCharacterPicker, setShowCharacterPicker] = useState(false);
@@ -66,9 +66,8 @@ export function SubmitPage({ onBack, embedded = false }: { onBack: () => void; e
       <main className="min-h-screen bg-white text-[#333333]">
         <Header embedded={embedded} onBack={onBack} />
 
-        <SubmitSurfaceScale>
-          <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-6 px-4 py-6 md:px-6">
-            <StepIndicator currentStep={draft.currentStep} onBack={handleStepBack} />
+        <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-6 px-4 py-6 md:px-6">
+          <StepIndicator currentStep={draft.currentStep} onBack={handleStepBack} />
 
             {draft.currentStep === 1 ? (
               <StepBasic
@@ -115,25 +114,24 @@ export function SubmitPage({ onBack, embedded = false }: { onBack: () => void; e
               />
             ) : null}
 
-            <FooterActions
-              currentStep={draft.currentStep}
-              onSave={saveDraft}
-              onAdvance={() => handleStepAdvance(draft, setCurrentStep)}
-              onSubmit={() =>
-                handleSubmit(draft, {
-                  onSubmitSuccess: () => {
-                    window.alert(
-                      "記録申請を受け付けました。\n\nこのサイトはUI/UX検証用プロトタイプのため、実際には送信・保存されません。入力内容はブラウザの下書きとして残ります。",
-                    );
-                    onBack();
-                  },
-                  saveDraft,
-                  setCurrentStep,
-                })
-              }
-            />
-          </div>
-        </SubmitSurfaceScale>
+          <FooterActions
+            currentStep={draft.currentStep}
+            onSave={saveDraft}
+            onAdvance={() => handleStepAdvance(draft, setCurrentStep)}
+            onSubmit={() =>
+              handleSubmit(draft, {
+                onSubmitSuccess: () => {
+                  window.alert(
+                    "記録申請を受け付けました。\n\nこのサイトはUI/UX検証用プロトタイプのため、実際には送信・保存されません。入力内容はブラウザの下書きとして残ります。",
+                  );
+                  onBack();
+                },
+                saveDraft,
+                setCurrentStep,
+              })
+            }
+          />
+        </div>
       </main>
 
       <CharacterPickerModal

--- a/src/features/submit/config.ts
+++ b/src/features/submit/config.ts
@@ -9,7 +9,6 @@ import type { SubmitDraft, SubmitPartySlot } from "./types";
 
 export const SUBMIT_DRAFT_KEY = "elite-run-db.submitDraft.v1";
 export const AUTO_SAVE_DELAY_MS = 500;
-export const SUBMIT_SURFACE_SCALE = 0.6;
 export const CHARACTER_OPTIONS = selectableCharacters;
 export const WEAPON_OPTIONS = selectableWeapons;
 export const RULESET_OPTIONS = ["NPUI", "PUI", "PUA", "Npui飯", "淵下宮", "マルチNpui", "マルチPui", "マルチPUA"];

--- a/src/features/submit/modals/CharacterPickerModal.tsx
+++ b/src/features/submit/modals/CharacterPickerModal.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { CharacterIcon } from "../../../components/CharacterIcon";
+import { ModalFrame } from "../../../components/ui";
 
 import { CHARACTER_OPTIONS, ELEMENT_FILTER_OPTIONS } from "../config";
-import { SectionTitle } from "../ui";
 
 export function CharacterPickerModal({
   isOpen,
@@ -46,28 +46,12 @@ export function CharacterPickerModal({
   }
 
   return (
-    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/35 px-4 py-6" onClick={onClose}>
-      <div
-        className="flex h-[720px] max-h-[calc(100vh-48px)] w-full max-w-[760px] flex-col rounded-[24px] border border-[#ebebeb] bg-white p-5 shadow-[0_24px_48px_rgba(0,0,0,0.16)] md:p-6"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <SectionTitle
-          title="キャラ選択"
-          description="Step 2 の 1 / 2 / 3 / 4 はパーティスロットです。選択すると現在のスロットに反映されます。"
-          action={
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label="閉じる"
-              className="grid h-10 w-10 place-items-center rounded-full bg-[#f2f2f2] text-black"
-            >
-              <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
-                <path d="M6 6L18 18" />
-                <path d="M18 6L6 18" />
-              </svg>
-            </button>
-          }
-        />
+    <ModalFrame
+      onClose={onClose}
+      title="キャラ選択"
+      description="Step 2 の 1 / 2 / 3 / 4 はパーティスロットです。選択すると現在のスロットに反映されます。"
+      className="h-[720px] max-w-[760px]"
+    >
 
         <div className="mt-6 flex min-h-0 flex-1 flex-col gap-4">
           <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
@@ -131,7 +115,6 @@ export function CharacterPickerModal({
             ) : null}
           </div>
         </div>
-      </div>
-    </div>
+    </ModalFrame>
   );
 }

--- a/src/features/submit/modals/GuidelineModal.tsx
+++ b/src/features/submit/modals/GuidelineModal.tsx
@@ -1,4 +1,4 @@
-import { SectionTitle } from "../ui";
+import { ModalFrame } from "../../../components/ui";
 
 export function GuidelineModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
   if (!isOpen) {
@@ -6,22 +6,13 @@ export function GuidelineModal({ isOpen, onClose }: { isOpen: boolean; onClose: 
   }
 
   return (
-    <div className="fixed inset-0 z-[75] flex items-center justify-center bg-black/35 px-4 py-6" onClick={onClose}>
-      <div
-        className="w-full max-w-[720px] rounded-[24px] border border-[#ebebeb] bg-white p-5 shadow-[0_24px_48px_rgba(0,0,0,0.16)] md:p-6"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <SectionTitle
-          title="ガイドライン"
-          description="内容は仮置きですが、導線と同意チェックの位置はこのまま実装しています。"
-          action={
-            <button type="button" onClick={onClose} className="rounded-full bg-[#f2f2f2] px-4 py-2 text-[13px] font-medium text-black">
-              閉じる
-            </button>
-          }
-        />
-
-        <div className="mt-6 space-y-4 text-[14px] leading-[1.8] text-[#49495b]">
+    <ModalFrame
+      onClose={onClose}
+      title="ガイドライン"
+      description="内容は仮置きですが、導線と同意チェックの位置はこのまま実装しています。"
+      className="max-w-[720px]"
+    >
+        <div className="mt-6 space-y-4 overflow-y-auto text-[14px] leading-[1.8] text-[#49495b]">
           <div className="rounded-[18px] bg-[#fafafb] p-4">
             1. 動画 URL は公開 YouTube リンクを想定しています。限定公開や削除済みリンクは比較ビュー・詳細画面で再生できません。
           </div>
@@ -32,7 +23,6 @@ export function GuidelineModal({ isOpen, onClose }: { isOpen: boolean; onClose: 
             3. コメント、いいね、共有、実 submit 永続化はまだ仮実装です。提出後も下書きはブラウザに残ります。
           </div>
         </div>
-      </div>
-    </div>
+    </ModalFrame>
   );
 }

--- a/src/features/submit/modals/WeaponPickerModal.tsx
+++ b/src/features/submit/modals/WeaponPickerModal.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { WeaponIcon } from "../../../components/WeaponIcon";
+import { ModalFrame } from "../../../components/ui";
 import type { WeaponClass, WeaponTier } from "../../../data/mockRuns";
 
 import { WEAPON_OPTIONS } from "../config";
-import { SectionTitle } from "../ui";
 
 const WEAPON_CLASS_FILTER_OPTIONS = [
   { key: "all", label: "すべて" },
@@ -120,28 +120,12 @@ export function WeaponPickerModal({
   }
 
   return (
-    <div className="fixed inset-0 z-[72] flex items-center justify-center bg-black/35 px-4 py-6" onClick={onClose}>
-      <div
-        className="flex h-[720px] max-h-[calc(100vh-48px)] w-full max-w-[760px] flex-col rounded-[24px] border border-[#ebebeb] bg-white p-5 shadow-[0_24px_48px_rgba(0,0,0,0.16)] md:p-6"
-        onClick={(event) => event.stopPropagation()}
-      >
-        <SectionTitle
-          title="武器選択"
-          description="Step 2 の現在スロットに設定する武器を選択します。現在のキャラに合う武器種から優先表示します。"
-          action={
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label="閉じる"
-              className="grid h-10 w-10 place-items-center rounded-full bg-[#f2f2f2] text-black"
-            >
-              <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
-                <path d="M6 6L18 18" />
-                <path d="M18 6L6 18" />
-              </svg>
-            </button>
-          }
-        />
+    <ModalFrame
+      onClose={onClose}
+      title="武器選択"
+      description="Step 2 の現在スロットに設定する武器を選択します。現在のキャラに合う武器種から優先表示します。"
+      className="h-[720px] max-w-[760px]"
+    >
 
         <div className="mt-6 flex min-h-0 flex-1 flex-col gap-4">
           {compatibleWeaponClass ? (
@@ -245,7 +229,6 @@ export function WeaponPickerModal({
             )}
           </div>
         </div>
-      </div>
-    </div>
+    </ModalFrame>
   );
 }

--- a/src/features/submit/sections/Header.tsx
+++ b/src/features/submit/sections/Header.tsx
@@ -1,20 +1,12 @@
+import { BackButton } from "../../../components/ui";
+
 export function Header({ embedded, onBack }: { embedded: boolean; onBack: () => void }) {
   return (
     <>
         {embedded ? (
           <div className="border-b border-[#ebebeb] bg-white">
             <div className="header-font mx-auto flex min-h-[52px] max-w-[1600px] items-center gap-3 px-4 py-2 md:px-6">
-              <button
-                type="button"
-                onClick={onBack}
-                className="grid h-9 w-9 place-items-center rounded-full bg-[#f2f2f2] text-black"
-                aria-label="記録一覧へ戻る"
-              >
-                <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                  <path d="M19 12H5" />
-                  <path d="M11 6L5 12L11 18" />
-                </svg>
-              </button>
+              <BackButton label="記録一覧へ戻る" onClick={onBack} icon="arrow" />
               <div className="text-[16px] font-semibold tracking-tight text-black md:text-[18px]">記録申請</div>
             </div>
           </div>
@@ -22,19 +14,9 @@ export function Header({ embedded, onBack }: { embedded: boolean; onBack: () => 
         <nav className={embedded ? "hidden" : "sticky top-0 z-40 border-b border-[#ebebeb] bg-white shadow-[0_1px_0_rgba(0,0,0,0.02)]"}>
           <div className="header-font mx-auto flex max-w-[1600px] items-center justify-between gap-3 px-4 py-3 md:px-6">
             <div className="flex items-center gap-3">
-              <button
-                type="button"
-                onClick={onBack}
-                className="grid h-10 w-10 place-items-center rounded-full bg-[#f2f2f2] text-black"
-                aria-label="記録詳細へ戻る"
-              >
-                <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                  <path d="M19 12H5" />
-                  <path d="M11 6L5 12L11 18" />
-                </svg>
-              </button>
+              <BackButton label="記録詳細へ戻る" onClick={onBack} icon="arrow" className="h-10 w-10" />
               <div>
-                <div className="text-[24px] font-semibold tracking-tight text-black md:text-[34px]">記録提出</div>
+                <div className="text-[24px] font-semibold tracking-tight text-black md:text-[34px]">記録申請</div>
               </div>
             </div>
           </div>

--- a/src/features/submit/sections/StepBasic.tsx
+++ b/src/features/submit/sections/StepBasic.tsx
@@ -1,6 +1,6 @@
 import { PLATFORM_OPTIONS, RULESET_OPTIONS } from "../config";
 import type { FieldErrors, PlayMode, SubmitDraft, TimeInputParts } from "../types";
-import { FieldError, FieldTitle, MockChoiceButton, MockFieldBox, PlatformChoiceContent, SectionDivider, StepHeroHeader } from "../ui";
+import { CreateChoiceButton, CreateFieldBox, FieldError, FieldTitle, PlatformChoiceContent, SectionDivider, StepHeroHeader } from "../ui";
 
 type StepBasicProps = {
   draft: SubmitDraft;
@@ -22,7 +22,7 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
               <div className="flex flex-col gap-[44px]">
                 <label className="block">
                   <FieldTitle quiet>カテゴリ</FieldTitle>
-                  <MockFieldBox className="mt-2">
+                  <CreateFieldBox className="mt-2">
                     <select
                       value={draft.basicInfo.ruleset}
                       onChange={(event) => updateBasicInfo("ruleset", event.target.value)}
@@ -34,20 +34,20 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
                         </option>
                       ))}
                     </select>
-                  </MockFieldBox>
+                  </CreateFieldBox>
                   <FieldError message={errors["basicInfo.ruleset"]} />
                 </label>
 
                 <label className="block">
                   <FieldTitle quiet>動画URL</FieldTitle>
-                  <MockFieldBox className="mt-2">
+                  <CreateFieldBox className="mt-2">
                     <input
                       value={draft.basicInfo.videoUrl}
                       onChange={(event) => updateBasicInfo("videoUrl", event.target.value)}
                       placeholder="例) https://www.youtube.com/watch?v="
                       className="w-full bg-transparent text-[18px] text-black outline-none md:text-[24px]"
                     />
-                  </MockFieldBox>
+                  </CreateFieldBox>
                   <div className="mt-2 text-[13px] text-[#9999b1]">(記録に対応するYouTubeのリンクを入力)</div>
                   <FieldError message={errors["basicInfo.videoUrl"]} />
                 </label>
@@ -55,7 +55,7 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
                 <label className="block">
                   <FieldTitle quiet>タイム</FieldTitle>
                   <div className="mt-2 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 md:gap-3 md:px-8">
-                    <MockFieldBox className="min-w-0">
+                    <CreateFieldBox className="min-w-0">
                       <input
                         value={timeInput.hours}
                         onChange={(event) => updateTimeInput("hours", event.target.value.replace(/[^\d]/g, "").slice(0, 2))}
@@ -64,9 +64,9 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
                         className="w-full bg-transparent text-center text-[20px] text-black outline-none md:text-[24px]"
                         aria-label="時間"
                       />
-                    </MockFieldBox>
+                    </CreateFieldBox>
                     <span className="text-[24px] font-bold text-[#9999b1] md:text-[28px]">:</span>
-                    <MockFieldBox className="min-w-0">
+                    <CreateFieldBox className="min-w-0">
                       <input
                         value={timeInput.minutes}
                         onChange={(event) => updateTimeInput("minutes", event.target.value.replace(/[^\d]/g, "").slice(0, 2))}
@@ -75,9 +75,9 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
                         className="w-full bg-transparent text-center text-[20px] text-black outline-none md:text-[24px]"
                         aria-label="分"
                       />
-                    </MockFieldBox>
+                    </CreateFieldBox>
                     <span className="text-[24px] font-bold text-[#9999b1] md:text-[28px]">:</span>
-                    <MockFieldBox className="min-w-0">
+                    <CreateFieldBox className="min-w-0">
                       <input
                         value={timeInput.seconds}
                         onChange={(event) => updateTimeInput("seconds", event.target.value.replace(/[^\d]/g, "").slice(0, 2))}
@@ -86,7 +86,7 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
                         className="w-full bg-transparent text-center text-[20px] text-black outline-none md:text-[24px]"
                         aria-label="秒"
                       />
-                    </MockFieldBox>
+                    </CreateFieldBox>
                   </div>
                   <FieldError message={errors["basicInfo.time"]} />
                 </label>
@@ -99,14 +99,14 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
                         { value: "solo", label: "Solo" },
                         { value: "multiplayer", label: "Multiplayer" },
                       ].map((option) => (
-                        <MockChoiceButton
+                        <CreateChoiceButton
                           key={option.value}
                           active={draft.basicInfo.playMode === option.value}
                           onClick={() => updateBasicInfo("playMode", option.value as PlayMode)}
                           className="w-full"
                         >
                           {option.label}
-                        </MockChoiceButton>
+                        </CreateChoiceButton>
                       ))}
                     </div>
                   </div>
@@ -115,14 +115,14 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
                     <FieldTitle quiet>プレイしているプラットフォーム</FieldTitle>
                     <div className="mt-4 grid gap-3 md:grid-cols-3 md:px-8">
                       {PLATFORM_OPTIONS.map((option) => (
-                        <MockChoiceButton
+                        <CreateChoiceButton
                           key={option}
                           active={draft.basicInfo.primaryPlatform === option}
                           onClick={() => updateBasicInfo("primaryPlatform", option)}
                           className="w-full"
                         >
                           <PlatformChoiceContent platform={option} />
-                        </MockChoiceButton>
+                        </CreateChoiceButton>
                       ))}
                     </div>
                   </div>
@@ -132,14 +132,14 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
                       <FieldTitle quiet>2人目のプラットフォーム</FieldTitle>
                       <div className="mt-4 grid gap-3 md:grid-cols-3 md:px-8">
                         {PLATFORM_OPTIONS.map((option) => (
-                          <MockChoiceButton
+                          <CreateChoiceButton
                             key={`secondary-${option}`}
                             active={draft.basicInfo.secondaryPlatform === option}
                             onClick={() => updateBasicInfo("secondaryPlatform", option)}
                             className="w-full"
                           >
                             <PlatformChoiceContent platform={option} />
-                          </MockChoiceButton>
+                          </CreateChoiceButton>
                         ))}
                       </div>
                       <FieldError message={errors["basicInfo.secondaryPlatform"]} />

--- a/src/features/submit/sections/StepParty.tsx
+++ b/src/features/submit/sections/StepParty.tsx
@@ -6,7 +6,7 @@ import { WeaponIcon } from "../../../components/WeaponIcon";
 import { BRACKET_META } from "../config";
 import { normalizeEnkaUidInput } from "../../../lib/enkaNetwork";
 import type { FieldErrors, SubmitDraft, SubmitPartySlot } from "../types";
-import { FieldError, FieldTitle, MockFieldBox, SearchActionIcon, StepHeroHeader } from "../ui";
+import { CreateFieldBox, FieldError, FieldTitle, SearchActionIcon, StepHeroHeader } from "../ui";
 
 type StepPartyProps = {
   activeCharacter: { name: string } | undefined;
@@ -148,7 +148,7 @@ export function StepParty(props: StepPartyProps) {
                               >
                                 {activeCharacter?.name ?? "キャラ未選択"}
                               </button>
-                              <MockFieldBox className="bg-white">
+                              <CreateFieldBox className="bg-white">
                                 <select
                                   value={activePartySlot.cons}
                                   onChange={(event) => updatePartySlot(activeSlot, { cons: Number(event.target.value) })}
@@ -161,7 +161,7 @@ export function StepParty(props: StepPartyProps) {
                                     </option>
                                   ))}
                                 </select>
-                              </MockFieldBox>
+                              </CreateFieldBox>
                             </div>
                           </div>
 
@@ -212,7 +212,7 @@ export function StepParty(props: StepPartyProps) {
                                 {activeWeapon?.name ?? "武器未選択"}
                               </button>
                               <div className="flex flex-col gap-3">
-                                <MockFieldBox className="bg-white">
+                                <CreateFieldBox className="bg-white">
                                   <select
                                     value={activePartySlot.refine}
                                     onChange={(event) => updatePartySlot(activeSlot, { refine: Number(event.target.value) })}
@@ -225,7 +225,7 @@ export function StepParty(props: StepPartyProps) {
                                       </option>
                                     ))}
                                   </select>
-                                </MockFieldBox>
+                                </CreateFieldBox>
                               </div>
                             </div>
                           </div>

--- a/src/features/submit/ui/index.tsx
+++ b/src/features/submit/ui/index.tsx
@@ -1,8 +1,9 @@
-import { type ReactNode, useLayoutEffect, useRef, useState } from "react";
+import type { ReactNode } from "react";
 
 import type { Bracket, Platform } from "../../../data/mockRuns";
 import { PlatformIcon } from "../../../components/UiIcons";
-import { BRACKET_META, SUBMIT_SURFACE_SCALE } from "../config";
+import { BackButton, Button, FieldShell } from "../../../components/ui";
+import { BRACKET_META } from "../config";
 import type { SubmitStep } from "../types";
 
 export function FieldError({ message }: { message?: string }) {
@@ -71,16 +72,7 @@ export function StepIndicator({ currentStep, onBack }: { currentStep: SubmitStep
 
   return (
     <div className="mx-auto grid w-full max-w-[980px] items-start gap-4 px-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:px-0">
-      <button
-        type="button"
-        onClick={onBack}
-        className="flex items-center gap-2 self-center rounded-full px-2 py-2 text-[16px] font-medium text-[#666666] transition hover:text-black md:justify-self-start"
-      >
-        <svg viewBox="0 0 24 24" className="h-5 w-5 shrink-0" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <path d="M15 5L8 12L15 19" />
-        </svg>
-        <span>戻る</span>
-      </button>
+      <BackButton label="戻る" showLabel onClick={onBack} className="self-center text-[16px] md:justify-self-start" />
 
       <div className="flex w-full max-w-[664px] flex-col gap-4 justify-self-center">
         <div className="grid grid-cols-[64px_minmax(0,1fr)_64px_minmax(0,1fr)_64px] items-center">
@@ -128,44 +120,6 @@ export function StepIndicator({ currentStep, onBack }: { currentStep: SubmitStep
       </div>
 
       <div className="hidden md:block md:w-[70px]" aria-hidden="true" />
-    </div>
-  );
-}
-
-export function SubmitSurfaceScale({ children }: { children: ReactNode }) {
-  const contentRef = useRef<HTMLDivElement | null>(null);
-  const [scaledHeight, setScaledHeight] = useState<number | null>(null);
-
-  useLayoutEffect(() => {
-    const node = contentRef.current;
-
-    if (!node) {
-      return;
-    }
-
-    const updateHeight = () => {
-      setScaledHeight(node.offsetHeight * SUBMIT_SURFACE_SCALE);
-    };
-
-    updateHeight();
-
-    if (typeof ResizeObserver === "undefined") {
-      return;
-    }
-
-    const observer = new ResizeObserver(() => {
-      updateHeight();
-    });
-
-    observer.observe(node);
-    return () => observer.disconnect();
-  }, []);
-
-  return (
-    <div className="w-full" style={scaledHeight ? { height: scaledHeight } : undefined}>
-      <div ref={contentRef} style={{ transform: `scale(${SUBMIT_SURFACE_SCALE})`, transformOrigin: "top center" }}>
-        {children}
-      </div>
     </div>
   );
 }
@@ -246,7 +200,7 @@ export function FieldTitle({ children, quiet = false }: { children: ReactNode; q
   );
 }
 
-export function MockFieldBox({
+export function CreateFieldBox({
   children,
   className = "",
   padded = true,
@@ -255,10 +209,14 @@ export function MockFieldBox({
   className?: string;
   padded?: boolean;
 }) {
-  return <div className={`rounded-[8px] bg-[#f6f6f6] ${padded ? "px-4 py-4 md:px-5 md:py-4" : ""} ${className}`}>{children}</div>;
+  return (
+    <FieldShell variant="create" className={`${padded ? "px-4 py-4 md:px-5 md:py-4" : "p-0"} ${className}`}>
+      {children}
+    </FieldShell>
+  );
 }
 
-export function MockChoiceButton({
+export function CreateChoiceButton({
   active,
   children,
   onClick,
@@ -270,15 +228,14 @@ export function MockChoiceButton({
   className?: string;
 }) {
   return (
-    <button
-      type="button"
+    <Button
       onClick={onClick}
-      className={`inline-flex items-center justify-center gap-3 rounded-[42px] px-5 py-4 text-[18px] transition md:text-[24px] ${
-        active ? "bg-[#333333] text-white" : "bg-[#f2f2f2] text-[#9999b1]"
-      } ${className}`}
+      variant={active ? "primary" : "tonal"}
+      size="create"
+      className={`rounded-[42px] ${active ? "bg-[#333333] text-white" : "border-transparent bg-[#f2f2f2] text-[#9999b1]"} ${className}`}
     >
       {children}
-    </button>
+    </Button>
   );
 }
 
@@ -299,29 +256,30 @@ export function BottomActionButtons({
     <div className="mx-auto flex w-full max-w-[500px] flex-col gap-4">
       {currentStep === 3 ? (
         <div className="flex flex-col gap-4 md:flex-row">
-          <button
-            type="button"
+          <Button
             onClick={onSave}
-            className="inline-flex w-fit items-center justify-center self-start whitespace-nowrap rounded-[8px] border border-[#333333] bg-white px-6 py-4 text-[18px] font-medium text-black md:text-[24px]"
+            variant="secondary"
+            size="create"
+            className="w-fit self-start whitespace-nowrap rounded-[8px] border-[#333333] bg-white text-black"
           >
             下書きで保存
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
             onClick={onSubmit}
-            className="w-full rounded-[8px] bg-[#333333] px-6 py-4 text-[20px] font-medium text-white md:flex-1 md:text-[24px]"
+            size="create"
+            className="w-full rounded-[8px] bg-[#333333] md:flex-1"
           >
             {primaryLabel}
-          </button>
+          </Button>
         </div>
       ) : (
-        <button
-          type="button"
+        <Button
           onClick={onAdvance}
-          className="w-full rounded-[8px] bg-[#333333] px-6 py-4 text-[20px] font-medium text-white md:text-[24px]"
+          size="create"
+          className="w-full rounded-[8px] bg-[#333333]"
         >
           {primaryLabel}
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -107,19 +107,6 @@ textarea::placeholder {
   }
 }
 
-.hoyo-card {
-  background: white;
-  border-radius: 12px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-  border: 1px solid #ebebeb;
-  transition: all 0.3s ease;
-}
-
-.hoyo-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
-}
-
 .no-scrollbar::-webkit-scrollbar {
   display: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,30 @@
 @import "tailwindcss";
 
 :root {
+  --erds-color-ink: #111827;
+  --erds-color-ink-soft: #333333;
+  --erds-color-chrome-dark: #111116;
+  --erds-color-surface: #ffffff;
+  --erds-color-surface-muted: #f7f8fa;
+  --erds-color-surface-app: #f5f6f8;
+  --erds-color-surface-create: #f6f6f6;
+  --erds-color-border: #d8dde6;
+  --erds-color-border-muted: #e5e7eb;
+  --erds-color-text-muted: #5f6678;
+  --erds-color-text-subtle: #8d93a3;
+  --erds-color-text-create-muted: #9999b1;
+  --erds-color-danger: #d24b5a;
+  --erds-color-like: #ff8ea1;
+  --erds-radius-xs: 4px;
+  --erds-radius-sm: 8px;
+  --erds-radius-md: 12px;
+  --erds-radius-lg: 16px;
+  --erds-radius-xl: 20px;
+  --erds-radius-modal: 24px;
+  --erds-radius-pill: 999px;
+  --erds-shadow-card: 0 10px 24px rgba(21, 27, 38, 0.06);
+  --erds-shadow-raised: 0 18px 34px rgba(21, 27, 38, 0.11);
+  --erds-shadow-modal: 0 24px 60px rgba(0, 0, 0, 0.18);
   color: #000000;
   background-color: #f0f2f5;
   font-family: "Noto Sans JP", "Segoe UI", sans-serif;


### PR DESCRIPTION
## 概要
- Design System v0.1 の audit と token / primitive 層を追加しました。
- Header、投稿導線、戻る、Version select、Floating CTA を共通 primitive に寄せ、文言を「記録申請」と Version 表記へ統一しました。
- Submit の試験用 `SUBMIT_SURFACE_SCALE = 0.6` を撤去し、Create mode 用のフォーム部品名へ整理しました。
- Library / RecordDetail / Submit のカード、空状態、比較操作、一部 modal を共通 primitive の上に載せました。
- 未使用の `.hoyo-card` CSS を削除しました。

## 追加整理: CTA
- `Button` に dark variant を追加し、Global Header の「記録申請」ボタンを黒基調へ戻しました。
- `FloatingCta` は既存の Home / Library 導線のまま維持し、浮遊CTAの文法を共通化しています。
- inline の主要導線は `InlineCtaButton`、比較・保存・リセットなどの小型操作は `InlineActionButton` / `Button` / `IconButton` に寄せました。
- Library の比較候補、あとで見る、比較ビュー操作、Filter modal / drawer の適用・リセット・閉じるを共通 primitive 側へ寄せています。

## 追加整理: Chip / Badge
- `Chip` に tag / reason variant、`Badge` に count / stat / overlay などの用途 variant を追加しました。
- `CountBadge`, `StatusBadge`, `StatBadge`, `CostBadge` を追加し、件数・状態・コスト/統計表示の小型UIを整理しました。
- `recordDetail/ui` の `TagChip`, `SimilarityReasonChip`, `TinyBadge`, `PlatformBadge` を Design System v0.1 の Chip / Badge の上に載せました。
- Library の検索結果件数、比較候補件数、RecordCard 内の tag / status / cost、武器 tier / include / exclude 表示を共通 primitive に寄せました。

## あえて触らなかったUI
- Heroヘッダー
- Hero上のルールセットタブ
- Leaderboardの表示切替タブ
- Bracketフィルター
- RecordCardの全面再設計
- SubmitのCreate mode全体
- 「×」ボタン内蔵のフィルターチップ
- UID picker の特殊な選択体験

## 方針
- 全画面を同じ見た目に潰さず、View mode と Create mode の差は残しています。
- Ranking / PlayerBlockPanel のブランド表現は大きく触らず、Library / Similar / CompareCandidate から小さく進めています。
- 新しい色の追加は避け、PR #63 で追加した token / primitive の色文法を使っています。

## 確認
- `npm run lint`: エラーなし、warning 2件のみ。
  - `src/components/ui/index.tsx` の mixed export warning
  - 既存 `src/features/home/ui/icons.tsx` の mixed export warning
- `npm run typecheck`: 成功。
- `npm run build`: 成功。Vite の chunk size warning は残っています。