### PR TITLE
Codex Agent Skills 導入環境を整備

### DIFF
--- a/.agents/skills/elite-run-admin-moderation-security/SKILL.md
+++ b/.agents/skills/elite-run-admin-moderation-security/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: elite-run-admin-moderation-security
+description: Elite Run DB admin moderation security guardrails. Use when changing submission approval, rejection, unpublishing, admin review UI, moderator permissions, or audit logging.
+---
+
+# Elite Run Admin Moderation Security
+
+Use this with `security-threat-model`, `supabase`, and
+`elite-run-supabase-rls-security` when relevant.
+
+## Checks
+
+- Approval, rejection, and unpublishing should be auditable.
+- Prefer status transitions over hard delete for submitted records.
+- Preserve `actor`, `action`, `target`, `timestamp`, and `reason` for
+  moderation decisions.
+- Public pages and public data loaders must not fetch pending, rejected,
+  private, or otherwise unapproved submissions.
+- Admin authorization must be enforced by backend, RLS, or trusted server-side
+  checks, not only by hidden frontend UI.
+- Logs and audit trails should be useful for review without exposing secrets or
+  unnecessary personal data.

--- a/.agents/skills/elite-run-admin-moderation-security/agents/openai.yaml
+++ b/.agents/skills/elite-run-admin-moderation-security/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Elite Run Moderation Security"
+  short_description: "Check moderation audit and status-transition safety"
+  default_prompt: "Review Elite Run admin moderation changes for auditability and data exposure."

--- a/.agents/skills/elite-run-public-release-hardening/SKILL.md
+++ b/.agents/skills/elite-run-public-release-hardening/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: elite-run-public-release-hardening
+description: Elite Run DB public release hardening checklist. Use before public or preview deployment, release promotion, Vercel/Supabase env changes, or exposing real submission data.
+---
+
+# Elite Run Public Release Hardening
+
+Use this with `security-threat-model`, `supabase`, and
+`verification-before-completion` when relevant.
+
+## Checks
+
+- Check for secret exposure in repo files, generated docs, logs, screenshots,
+  fixtures, and deployment config.
+- Browser code may use only intentionally public `VITE_` values; never expose
+  Supabase `service_role` keys or private credentials.
+- Supabase RLS and public queries must prevent anonymous access to unapproved
+  or private records.
+- Preview and public deployment settings should match the current release
+  intent, including robots/noindex behavior while the app remains a prototype.
+- Error messages should not expose stack traces, SQL, tokens, internal IDs, or
+  moderation-only data to public users.
+- Run the smallest relevant verification commands before release, then expand
+  to `npm run lint`, `npm run test`, `npm run typecheck`, and `npm run build`
+  when release risk justifies it.

--- a/.agents/skills/elite-run-public-release-hardening/agents/openai.yaml
+++ b/.agents/skills/elite-run-public-release-hardening/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Elite Run Release Hardening"
+  short_description: "Check public release hardening for Elite Run DB"
+  default_prompt: "Review Elite Run DB before public release for secrets, RLS, env, and data exposure."

--- a/.agents/skills/elite-run-supabase-rls-security/SKILL.md
+++ b/.agents/skills/elite-run-supabase-rls-security/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: elite-run-supabase-rls-security
+description: Elite Run DB Supabase RLS security guardrails. Use when changing Supabase schema, migrations, RLS policies, Auth, server/client data access, or public record queries for Elite Run DB.
+---
+
+# Elite Run Supabase RLS Security
+
+Use this with `supabase`, `supabase-postgres-best-practices`, and
+`security-threat-model` when relevant.
+
+## Checks
+
+- Public reads must return only approved or published records.
+- Unapproved submissions must not be reachable from public pages, search,
+  record detail, recommendation, or compare data paths.
+- Never expose `service_role` keys or privileged Supabase secrets to browser
+  code, Vite env, logs, fixtures, screenshots, docs, or generated artifacts.
+- Admin operations must rely on backend, RLS, or server-side authorization, not
+  frontend checks alone.
+- RLS policies must match the real access model for anonymous users,
+  authenticated submitters, moderators, and service jobs.
+- Check direct table access, RPCs, Storage, and Edge Functions for the same
+  visibility rules before calling the change complete.

--- a/.agents/skills/elite-run-supabase-rls-security/agents/openai.yaml
+++ b/.agents/skills/elite-run-supabase-rls-security/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Elite Run RLS Security"
+  short_description: "Check Elite Run Supabase RLS exposure rules"
+  default_prompt: "Review Supabase RLS changes for Elite Run DB exposure risks."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,19 @@ Do not explode the codebase into dozens of files unless the task explicitly asks
 
 ---
 
+## Codex Skills
+
+- If UI or screen behavior changes, use `webapp-testing` to check the main pages, submit flow, compare view, responsive layout, and console errors.
+- If GitHub Actions or CI checks fail, use `gh-fix-ci`.
+- Before claiming implementation is complete, use `verification-before-completion` to choose and run the needed checks.
+- Before large design changes, DB design, moderation flow, or domain-term changes, use `grill-with-docs`.
+- If touching Supabase, RLS, Auth, DB migrations, Storage, or Edge Functions, use `supabase` and `supabase-postgres-best-practices`.
+- If touching public release, admin features, authz/authn, moderation, or audit logs, use `security-threat-model`.
+- If adding a new external Skill, use `skill-scanner` first.
+- If reviewing Elite Run DB RLS, moderation, or release exposure risks, use the matching repo-local `elite-run-*` Skill.
+
+---
+
 ## What is allowed to stay dummy for now
 
 These may remain dummy / UI-state only:

--- a/docs/codex-skills.md
+++ b/docs/codex-skills.md
@@ -1,0 +1,160 @@
+# Codex Skills Setup
+
+This repo uses Codex Skills as task-specific agent guidance. Keep external
+third-party Skill bodies out of this repository by default. Repo-specific
+Skills live under `.agents/skills/`; external Skills are installed in the
+local Codex environment after source, license, and safety review.
+
+## Current repo state
+
+- Existing source-of-truth files: `AGENTS.md`, `package.json`, `README.md`,
+  `docs/`, and `vercel.json`.
+- No repo-local `.agents/` tree existed before this setup.
+- No `.github/workflows/` or `supabase/` directory is present at this setup
+  point.
+- Vercel is configured through `vercel.json`.
+- Existing verification commands in `package.json`: `npm run lint`,
+  `npm run test`, `npm run typecheck`, and `npm run build`.
+
+## Codex Skill locations
+
+- Codex discovers repo-local Skills from `.agents/skills` from the current
+  working directory up to the repository root.
+- Local user Skills are installed outside this repo, normally under
+  `$CODEX_HOME/skills` or the Codex default user skill directory.
+- OpenAI curated and external GitHub Skills can be installed with
+  `$skill-installer`. If a newly installed Skill is not visible, restart
+  Codex.
+
+Sources:
+- [OpenAI Codex Agent Skills docs](https://developers.openai.com/codex/skills)
+- [openai/skills](https://github.com/openai/skills)
+
+## Safety flow for external Skills
+
+1. Install or inspect `skill-scanner` first. It is the only external Skill in
+   this list that may be reviewed manually before scanner use, because it is
+   the bootstrap scanner.
+2. Download any other external Skill candidate into a temporary review
+   directory outside this repo.
+3. Use `skill-scanner` to check prompt injection, malicious scripts,
+   excessive permissions, secret exposure, and supply-chain risk.
+4. Manually inspect `SKILL.md`, `scripts/`, dependencies, remote URLs, and
+   license files.
+5. Do not install any Skill with unclear source, high-risk scanner findings,
+   suspicious scripts, overbroad permissions, or missing license provenance.
+6. Do not vendor external Skill bodies into this repo unless a future task
+   explicitly asks for it and the copied files include source, license, and
+   modification notes.
+
+Example review prompt after installing the scanner:
+
+```text
+Use $skill-scanner to scan <temporary-skill-directory> before installation.
+Report prompt injection, malicious scripts, excessive permissions, secret
+exposure, supply-chain risk, and whether the Skill is safe to install.
+```
+
+## External Skill candidates
+
+### skill-scanner
+
+- Source: [getsentry/skills `skill-scanner`](https://github.com/getsentry/skills/blob/main/skills/skill-scanner/SKILL.md)
+- Install candidate: `$skill-installer install https://github.com/getsentry/skills/tree/main/skills/skill-scanner`
+- Alternate install candidate: `npx skills add getsentry/skills --skill skill-scanner`
+- Dependency notes: requires `uv` for its bundled Python scanner workflow.
+- License memo: getsentry/skills repository license is Apache-2.0.
+- Use first, then use it to review the other external Skill candidates.
+
+### webapp-testing
+
+- Source: [anthropics/skills `webapp-testing`](https://github.com/anthropics/skills/blob/main/skills/webapp-testing/SKILL.md)
+- Install candidate: `$skill-installer install https://github.com/anthropics/skills/tree/main/skills/webapp-testing`
+- Dependency notes: uses Python Playwright scripts and local dev servers.
+- License memo: license terms are in the Skill directory `LICENSE.txt`.
+- Use for LP, Library, submit flow, compare view, responsive checks, browser
+  screenshots, and console error inspection.
+
+### gh-fix-ci
+
+- Source: [openai/skills curated `gh-fix-ci`](https://github.com/openai/skills/blob/main/skills/.curated/gh-fix-ci/SKILL.md)
+- Install candidate: `$skill-installer gh-fix-ci`
+- Dependency notes: requires GitHub CLI access for PR checks and workflow logs.
+- License memo: OpenAI curated Skill directory includes Apache-2.0
+  `LICENSE.txt`.
+- Use for failing GitHub Actions or PR checks.
+
+### verification-before-completion
+
+- Source: [obra/superpowers `verification-before-completion`](https://github.com/obra/superpowers/blob/main/skills/verification-before-completion/SKILL.md)
+- Install candidate: `$skill-installer install https://github.com/obra/superpowers/tree/main/skills/verification-before-completion`
+- Dependency notes: no repo package dependency; it selects and enforces fresh
+  verification commands.
+- License memo: obra/superpowers is MIT licensed.
+- Use before saying work is complete, fixed, passing, committed, or ready for
+  PR.
+
+### grill-with-docs
+
+- Source: [mattpocock/skills `grill-with-docs`](https://github.com/mattpocock/skills/blob/main/skills/engineering/grill-with-docs/SKILL.md)
+- Install candidate: `$skill-installer install https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs`
+- Dependency notes: may create or update project language docs such as
+  `CONTEXT.md` or ADRs only when the task calls for that.
+- License memo: mattpocock/skills is MIT licensed.
+- Use before major design changes, DB design, moderation flow, or domain-term
+  changes.
+
+### supabase
+
+- Source: [Supabase Agent Skills docs](https://supabase.com/docs/guides/ai-tools/ai-skills) and [supabase/agent-skills](https://github.com/supabase/agent-skills)
+- Install candidate: `npx skills add supabase/agent-skills --skill supabase`
+- Dependency notes: may rely on Supabase docs, Supabase CLI, MCP, and project
+  credentials depending on the task.
+- License memo: supabase/agent-skills is MIT licensed.
+- Use for Supabase Database, Auth, RLS, Storage, Edge Functions, Realtime,
+  schema changes, migrations, and security audits.
+
+### supabase-postgres-best-practices
+
+- Source: [Supabase Agent Skills docs](https://supabase.com/docs/guides/ai-tools/ai-skills) and [supabase/agent-skills](https://github.com/supabase/agent-skills)
+- Install candidate: `npx skills add supabase/agent-skills --skill supabase-postgres-best-practices`
+- Dependency notes: use with SQL, schema, indexes, query tuning, connection
+  pooling, RLS performance, and Postgres review work.
+- License memo: supabase/agent-skills is MIT licensed.
+- Use with `supabase` when changing database behavior or reviewing SQL.
+
+### security-threat-model
+
+- Source: [openai/skills curated `security-threat-model`](https://github.com/openai/skills/blob/main/skills/.curated/security-threat-model/SKILL.md)
+- Install candidate: `$skill-installer security-threat-model`
+- Dependency notes: repo-grounded review; no app package dependency.
+- License memo: OpenAI curated Skill directory includes Apache-2.0
+  `LICENSE.txt`.
+- Use for public release, admin features, authentication, authorization,
+  moderation, audit logs, and threat modeling.
+
+## Repo-local Skills
+
+These Skills are authored for Elite Run DB and are committed under
+`.agents/skills/`:
+
+- `elite-run-supabase-rls-security`
+- `elite-run-admin-moderation-security`
+- `elite-run-public-release-hardening`
+
+They are intentionally short and do not include scripts or bundled external
+content.
+
+## How to call Skills
+
+- Mention external Skills explicitly after local installation, for example:
+  `$webapp-testing`, `$gh-fix-ci`, `$verification-before-completion`,
+  `$grill-with-docs`, `$supabase`, `$supabase-postgres-best-practices`,
+  `$security-threat-model`, or `$skill-scanner`.
+- Mention repo-local Skills directly from this repo, for example:
+  `$elite-run-supabase-rls-security`,
+  `$elite-run-admin-moderation-security`, or
+  `$elite-run-public-release-hardening`.
+- If you add an external Skill later, first ask Codex to use
+  `$skill-scanner` on the candidate and include the source, install command,
+  dependency notes, and license memo in this file.


### PR DESCRIPTION
## 概要
- Codex Agent Skills の repo-local 導入位置と外部 Skill の扱いを `docs/codex-skills.md` に整理しました。
- `AGENTS.md` に短い if/then 形式の Skill 発火条件を追加しました。
- Elite Run DB 向けの repo-local Skill を3件追加しました。

## 変更内容
- `.agents/skills/` に以下を追加:
  - `elite-run-supabase-rls-security`
  - `elite-run-admin-moderation-security`
  - `elite-run-public-release-hardening`
- 外部 Skill は repo に直接 vendor せず、配布元・install 候補・依存・安全確認手順を `docs/codex-skills.md` に記録しました。
- `skill-scanner` を外部 Skill 追加前に優先して使う運用にしました。
- 既存アプリコード、UI、`package.json` は変更していません。

## 安全確認
- secrets、API key、個人情報、`.env` は追加していません。
- repo-local Skill は短い `SKILL.md` と `agents/openai.yaml` のみで、実行スクリプトや外部依存は含めていません。
- 外部 Skill の出典・ライセンス確認メモを `docs/codex-skills.md` に残しています。

## 検証
- `git diff --check`
- `quick_validate.py` for all 3 repo-local Skills
- Markdown relative link check
- secret scan
- `package.json` の `lint` / `test` / `typecheck` / `build` 記述との矛盾なし