### PR TITLE
Libraryフィルターエントランス刷新とUI調整

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,330 +1,463 @@
 # AGENTS.md
 
 ## Project
-Elite Run DB prototype for Genshin elite-hunting run records.
 
-This repository is in the **UI / flow integration phase**.
-The immediate goal is to make the app usable end-to-end with coherent screens and interactions.
-This repository is **not yet** in the full architecture-refactor phase.
+Elite Run DB is a UI/UX prototype for Genshin Impact elite-hunting RTA records.
 
----
+The product goal is not just to show a fastest-time leaderboard.
+The goal is to make elite-hunting records easier to find, compare, understand, and preserve by showing routes, teams, costs, versions, categories, and record context in a useful way.
 
-## Current phase priority
-
-### Priority order
-1. Integrate and stabilize the main user-facing screens and flows
-2. Preserve the current prototype behavior where possible
-3. Add missing UI/interaction logic required by the spec
-4. Only do **minimal necessary component extraction**
-5. Leave large-scale file structure refactors for a later dedicated task
-
-### Important
-Do **not** perform a broad feature-based rearchitecture yet.
-Do **not** spend the task budget on “clean architecture” unless the current task explicitly asks for it.
-Do **not** convert the whole repo into a polished long-term structure during UI integration tasks.
+This is an unofficial fan-made prototype.
 
 ---
 
-## Source of truth
+## Current Phase
 
-Before making changes, read these files first:
+This repository is currently in the **public-demo UI stabilization and design validation phase**.
 
-### Core spec
-- `docs/specs/elite-run-db-integration-spec.md`
+The main goal is to complete a coherent public-facing prototype before implementing real backend, authentication, admin, and review systems.
 
-### UI mocks / design references
-- `docs/mocks/record-detail.mock.tsx`
-- `docs/mocks/compare-view.mock.tsx`
-- `docs/mocks/submit-step1.mock.tsx`
-- `docs/mocks/submit-step2.mock.tsx`
-- `docs/mocks/submit-step2-uid-modal.mock.tsx`
-- `docs/mocks/submit-step3.mock.tsx`
+Current priorities are:
 
-### Legacy prototype reference
-- `docs/mocks/submit-page-ui-prototype.html`
+1. Complete and stabilize the LP / landing experience.
+2. Improve the Library / record search experience.
+3. Add or refine large Library discovery features.
+4. Unify modal and overlay UI quality.
+5. Preserve the existing product world, visual direction, and navigation.
+6. Prepare the codebase so future DB/auth/admin work can be added safely.
+7. Avoid backend-driven simplification of the current UI concept.
 
-Most files under `docs/` are **reference materials**, not production code.
-Use them to understand layout, hierarchy, and interaction intent.
-- `docs/mocks/submit-page-ui-prototype.html` is a legacy prototype reference only.
-- Do not treat files under `docs/` as the real implementation target unless a task explicitly says otherwise.
-- Build the real app in the actual source tree under `src/`.
-- Use the HTML prototype to understand existing flow, data shape, and interaction intent, then migrate those ideas into the real app code.
+Backend, auth, admin, reviewer, moderation, and security work are important, but they should be implemented after the main UI direction and core user experience are more stable.
 
 ---
 
-## Repository intent
+## Product Direction
 
-This repo should become a maintainable React frontend later, but **right now** the focus is:
+The app has two different public-facing roles:
 
-- get the Record Detail flow working
-- get the Compare View working
-- get the Submission flow working
-- get UID-based character selection working
-- get local draft persistence working
+- **Ranking / Home**: a shared competitive stage for comparing records under common conditions.
+- **Library / Search**: a research and discovery space for finding useful records based on characters, teams, costs, versions, tags, and player context.
 
-The current phase should move the app forward inside `src/`, using the legacy HTML prototype only as a migration reference.
+Do not collapse these two roles into one generic search page or one generic leaderboard.
 
-Do not keep expanding the real implementation inside `docs/`.
+The UI should support both:
+
+- the competitive appeal of elite-hunting RTA
+- the research value of diverse records, off-meta teams, low-cost runs, and past-version context
 
 ---
 
-## Implementation rules
+## Current Architecture
 
-### General
-- Prefer incremental integration over rewrite
-- Reuse existing code patterns when possible
-- Reuse current asset-loading / image-handling patterns already used in the prototype
-- Do not leave parallel dead-end implementations if you can integrate into the existing flow
-- Do not keep raw Figma `FrameXX` names in production code
-- Replace them with meaningful component names
+The real app lives under `src/`.
 
-### Mock fidelity
-- When a task says to follow a mock, prioritize reproducing the mock's visual layout as closely as practical
-- Correct behavior matters, but visual fidelity also matters and should not be traded away casually
-- Do not replace mock-specific layout with a more generic UI just to improve cross-page consistency or reduce implementation effort unless the human explicitly allows that deviation
-- Match spacing, sizing, alignment, density, hierarchy, and relative positioning as closely as practical
-- If extra UI is required for functionality that the mock did not show, attach it beneath or adjacent to the most semantically related mock element instead of redesigning the layout around it
-- If the implementation must deviate from the mock for a concrete reason, explicitly say so and keep the deviation as small as possible
+Current important areas include:
 
-### Componentization
-Minimal necessary componentization is encouraged.
-Good examples:
-- `RecordDetailPage`
-- `CompareDrawer`
-- `SubmitFlow`
-- `UidCharacterPickerModal`
+- `src/app`
+  - app-level route types, route parsing, navigation behavior, and placeholders
+- `src/features/home`
+  - ranking / home experience
+- `src/features/library`
+  - record search and discovery experience
+- `src/features/lp`
+  - landing page
+- `src/features/recordDetail`
+  - record detail page
+- `src/features/submit`
+  - record submission flow
+- `src/components/ui`
+  - shared UI primitives
+- `src/data`
+  - mock app/run data
+- `src/lib`
+  - shared logic and helpers
+- `docs/mocks`
+  - design references and generated mock code
+- `docs/specs`
+  - product, integration, and migration notes
+- `.agents/skills`
+  - repo-local Codex Skills
 
-Do not explode the codebase into dozens of files unless the task explicitly asks for architecture refactoring.
+When changing a feature, prefer keeping feature-specific code inside that feature directory unless there is a clear reason to extract shared logic.
 
-### State
-- Prefer predictable local/component state
-- Prefer derived values for computed UI like cost/bracket
-- Keep logic replaceable for future DB/API integration
-- Avoid overengineering global state unless clearly needed
+---
+
+## Source of Truth
+
+Before implementing, inspect the relevant current source files first.
+
+For product and project intent, read:
+
+- `README.md`
+- relevant issues / PR descriptions
+- relevant files under `docs/specs/`
+
+For UI/design tasks, read:
+
+- the relevant current implementation under `src/features/...`
+- the relevant mock or reference under `docs/mocks/...` if one exists
+- screenshots or visual references provided by the human, if any
+
+For DB-related planning tasks, read:
+
+- `docs/specs/db-migration-roadmap.md`
+
+For Codex Skills and agent-skill operations, read:
+
+- `docs/codex-skills.md`
+- relevant repo-local Skills under `.agents/skills/...`
+
+Do not assume old mock files are always up to date.
+Prefer the current implementation and the most recent issue/PR/task description when there is conflict.
 
 ---
 
 ## Codex Skills
 
-- If UI or screen behavior changes, use `webapp-testing` to check the main pages, submit flow, compare view, responsive layout, and console errors.
-- If GitHub Actions or CI checks fail, use `gh-fix-ci`.
-- Before claiming implementation is complete, use `verification-before-completion` to choose and run the needed checks.
-- Before large design changes, DB design, moderation flow, or domain-term changes, use `grill-with-docs`.
-- If touching Supabase, RLS, Auth, DB migrations, Storage, or Edge Functions, use `supabase` and `supabase-postgres-best-practices`.
-- If touching public release, admin features, authz/authn, moderation, or audit logs, use `security-threat-model`.
-- If adding a new external Skill, use `skill-scanner` first.
-- If reviewing Elite Run DB RLS, moderation, or release exposure risks, use the matching repo-local `elite-run-*` Skill.
+This repository uses Codex Skills as task-specific guidance.
+
+Read `docs/codex-skills.md` before changing Skill setup, adding repo-local Skills, installing external Skills, or changing Skill trigger rules.
+
+Use Skills when they match the task.
+Do not claim that a Skill was used if it is not installed, not available, or not actually used in the current Codex environment.
+
+Skill trigger rules:
+
+- If UI or screen behavior changes, use `webapp-testing` when available to check main pages, submit flow, compare view, responsive layout, screenshots, and console errors.
+- If GitHub Actions or CI checks fail, use `gh-fix-ci` when available.
+- Before claiming implementation is complete, use `verification-before-completion` when available to choose and run the needed checks.
+- Before large design changes, DB design, moderation flow, or domain-term changes, use `grill-with-docs` when available.
+- If touching Supabase, RLS, Auth, DB migrations, Storage, Edge Functions, or public record queries, use `supabase`, `supabase-postgres-best-practices`, and the repo-local `elite-run-supabase-rls-security` Skill when relevant.
+- If touching admin features, moderation, review status, approval/rejection/unpublish flows, reviewer/admin permissions, or audit logs, use `security-threat-model` and `elite-run-admin-moderation-security` when relevant.
+- If touching public release, preview/public deployment, Vercel/Supabase env changes, robots/noindex behavior, or exposing real submission data, use `security-threat-model`, `verification-before-completion`, and `elite-run-public-release-hardening` when relevant.
+- If adding a new external Skill, use `skill-scanner` first and follow `docs/codex-skills.md`.
+
+Do not vendor external Skill bodies into this repository unless a task explicitly asks for it and the source, license, and modification notes are documented.
 
 ---
 
-## What is allowed to stay dummy for now
+## Figma / Mock Workflow
 
-These may remain dummy / UI-state only:
-- like actions
-- share actions
-- comment posting
-- actual submit persistence to backend
+Design work may come from several sources:
 
-These should still look and behave coherently in the UI, but do not need backend persistence yet.
+- Figma-generated React code placed under `docs/mocks`
+- manually written mock files under `docs/mocks`
+- screenshots or reference UI images provided by the human
+- simple screens designed directly in implementation by Codex
 
----
+Files under `docs/mocks` are **reference materials**, not production code.
 
-## What should be implemented now
+Use mock files to understand:
 
-### Record Detail
-- redesigned detail screen integration
-- expandable summary / tags (“もっと見る”)
-- similar runs section
-- similar run action menu
+- layout
+- spacing
+- hierarchy
+- visual rhythm
+- interaction intent
+- content structure
 
-### Compare View
-- desktop-only compare entry from similar-run action menu
-- right-side slide-over compare panel
-- left pane = current record
-- right pane = selected similar run
-- right pane updates when another compare action is triggered
-- independent scrolling for left and right panes
-- YouTube synchronized play/pause only
+Do not treat mock files as the final implementation target unless the task explicitly says so.
 
-### Submission flow
-- Step 1: basic info
-- Step 2: party/build info
-- Step 2 UID character picker modal
-- Step 3: detail info / guidelines
-- local draft save/restore via browser storage
-- guideline modal shell
-- validation messages under fields
+Build real app changes under `src/`.
 
-### UID integration
-Use Enka.Network as the intended data source.
-Best effort autofill target:
-- showcased characters
-- constellation
-- weapon
-- refinement
+When implementing from a Figma/mock reference:
+
+- preserve the intended visual hierarchy and layout as closely as practical
+- do not replace a distinctive design with a generic SaaS-like UI
+- do not simplify the worldbuilding or visual identity just to make implementation easier
+- if the mock is not technically suitable, adapt it carefully while preserving the design intent
+- if a deviation is necessary, explain the reason in the PR body
+
+For simple screens, Codex may design directly without a mock if the human request allows it.
+For important LP, Library, modal, or large feature screens, prefer using mocks or visual references.
 
 ---
 
-## Compare View rules
+## Implementation Principles
 
-- Compare View is **desktop only**
-- Do not expose compare action on mobile
-- The center divider is only visual; the important part is independent scroll behavior
-- Sync play button only needs to synchronize play/pause
-- Seek sync and speed sync are not required now
+Prefer incremental, scoped changes.
 
----
+Do:
 
-## Submission flow rules
+- keep changes focused on the requested task
+- preserve existing UI behavior unless the task explicitly asks to change it
+- preserve current visual direction and product intent
+- make code easier to read and maintain
+- keep logic replaceable for future DB/API integration
+- use feature-local types and helpers for large new features
+- add tests for pure logic when practical
+- document non-obvious tradeoffs in the PR body
 
-### Step count
-The real top-level submission flow is exactly **3 steps**:
-1. Basic Info
-2. Party / Build
-3. Detail Info / Guidelines
+Avoid:
 
-### Step 2 internal slots
-Any `1 / 2 / 3 / 4` controls inside Step 2 refer to the **four party member slots**, not top-level steps.
-
-### UID modal behavior
-The UID picker should mimic Spiral Abyss character selection semantics as closely as practical:
-- left side: up to 12 profile characters
-- right side: 4 used-character slots
-- tapping a left-side character selects it
-- selected characters get a numeric order overlay on the upper part of the icon
-- 5th selection does nothing if 4 are already selected
-- to replace, the user clears a used-character slot first
-- duplicate character selection is not allowed
-
-### Cost / bracket
-- recalculate live during editing
-- do not wait until final submit
-
-### Main attacker
-- optional in normal cases
-- single-select normally
-- multiplayer may allow multiple selection
-- user-declared, not auto-inferred
-
-### Search tags
-- predefined candidates only for now
-- no freeform tag creation yet
-
-### Notes field
-Use one free-text field for summary / notes / comments.
-
-### Guidelines
-- guideline agreement is required for actual submit
-- draft save is allowed without agreement
-
-### Draft save
-Use browser-local persistence.
-Restoring previous submission draft state is desired even after a dummy “submit”.
+- broad rewrites without explicit task scope
+- changing unrelated screens
+- replacing product-specific UI with generic UI
+- mixing large visual redesign and data architecture changes in one PR
+- introducing backend/auth/admin assumptions into unrelated UI tasks
+- deleting mock data or mock flows before replacement paths exist
 
 ---
 
-## Similar-run heuristic logic
+## Refactor Rules
 
-Full clustering is not required.
-Implement a pragmatic replaceable heuristic.
+Refactoring is allowed when it directly improves maintainability or prepares the app for planned work.
 
-Preferred signals:
-- same ruleset/category
-- same season
-- same main attacker or overlapping core characters
-- character overlap matters more than weapon overlap
+Good refactors include:
 
-Keep this isolated in a helper/module so it can be replaced later.
+- splitting oversized files by responsibility
+- moving route parsing or navigation side effects out of page components
+- isolating pure logic into testable modules
+- extracting feature-local helpers
+- splitting shared UI primitives into clear files
+- removing dead-end duplicate implementations
 
----
+Do not refactor just to make the architecture look more abstract.
 
-## Mobile / responsive rules
+Avoid introducing heavy architecture patterns unless they solve a concrete current problem.
 
-- Compare View is hidden on mobile
-- Submission Step 2 may rely on horizontal scrolling rather than a large redesign
-- Keep the UI usable, even if not fully elegant yet
-- Do not redesign the product beyond the provided design direction unless necessary
+Preserve current behavior and visual output during refactor-only tasks.
 
 ---
 
-## Temporary copy / placeholders
+## UI / Design Rules
 
-Strings containing `SVD` are temporary placeholders.
-Do not “fix” or rename them globally unless the task explicitly asks for copy replacement.
+This project should not look like a generic SaaS dashboard.
 
-Examples:
-- `検索SVD`
-- `PC+PCのSVD`
-- `〇のSVD`
+The UI should support the world and culture of elite-hunting RTA:
 
-These will be replaced later.
+- competitive
+- research-oriented
+- record-focused
+- visually distinctive
+- useful for comparing teams, routes, costs, and versions
+
+For Library/search UI:
+
+- preserve the existing search/filter content unless the task says otherwise
+- design changes may be large, but the search meaning should remain clear
+- large discovery features should be feature-local and not hardwired into unrelated pages
+
+For modals:
+
+- unify visual quality and interaction patterns where practical
+- do not change field meaning or flow unless explicitly requested
+- avoid one-off modal styles that cannot scale to future auth/admin/review flows
+
+For LP:
+
+- communicate the appeal and value of elite-hunting RTA
+- do not make the LP feel like only a generic product sales page
+- include unofficial/fan-made positioning when working on public-facing final copy
 
 ---
 
-## Git / change management
+## Large Feature Rules
 
-Branch policy for this repository:
-- `main` is the protected release branch conceptually. Do not use it as the working branch for normal implementation tasks.
-- `develop` is the integration branch for day-to-day work.
-- For each implementation task, start from the latest `develop` and create a dedicated working branch such as `feat/<short-slug>` or `fix/<short-slug>`.
+Large user-facing features should be developed as isolated feature slices.
+
+A good large feature PR should usually include:
+
+- feature-local types
+- feature-local mock/view data if needed
+- UI components scoped to the feature
+- pure logic separated from visual components when practical
+- clear PR explanation of what changed and why
+
+For large Library features, do not directly scatter logic across unrelated files.
+
+Expected future Library-scale features may include things like:
+
+- version meta team discovery
+- owned-character-based search
+- cost efficiency map
+
+These should not force premature DB implementation, but they should be written in a way that can later receive real data through adapters or API results.
+
+---
+
+## Data / DB Preparation Rules
+
+The app is still mock-data based.
+
+Do not implement real DB/auth/admin work unless the task explicitly asks for it.
+
+For now:
+
+- keep mock data available
+- do not delete `mockRuns` or equivalent data without a replacement
+- do not reshape the entire app around a guessed DB schema
+- do not simplify the UI because a future DB may be difficult
+- keep UI display types separate from future DB storage types where practical
+
+When DB work is explicitly requested:
+
+- follow the relevant issue and `docs/specs/db-migration-roadmap.md`
+- use the matching Codex Skills and security guardrails listed in the Codex Skills section
+- do not use the UI display model as the DB schema directly
+- prefer adapters between DB payloads and UI view models
+- migrate one area at a time
+- start with the smallest safe data loop
+
+---
+
+## Auth / Admin / Review Rules
+
+Auth, admin, reviewer, moderation, review status, and security-sensitive flows are planned future work.
+
+Do not casually add fake production-like auth or admin behavior during unrelated UI work.
+
+When these areas are implemented later:
+
+- follow the relevant issue or design document
+- use the matching Codex Skills and security guardrails listed in the Codex Skills section
+- design the data and permission model first
+- keep public and privileged surfaces clearly separated
+- avoid leaking admin/reviewer assumptions into public UI code
+- add explicit empty/loading/error/permission states
+- preserve auditability and review status concepts
+
+Placeholder pages may exist, but do not treat them as final admin/account implementations.
+
+---
+
+## Routing Rules
+
+Route behavior is app-level infrastructure.
+
+When changing routes:
+
+- inspect `src/app/routes.ts`
+- inspect `src/app/useAppNavigation.ts`
+- preserve existing hash URL behavior unless the task explicitly changes it
+- preserve home state retention and scroll restoration unless explicitly changed
+- keep route parsing and navigation side effects separated from page rendering
+- add or update route tests for pure route logic
+
+Do not introduce a routing library unless the task explicitly asks for it or the PR explains why it is necessary.
+
+---
+
+## Shared UI Rules
+
+Shared UI primitives live under `src/components/ui`.
+
+Use shared primitives when they fit.
+
+Do not force all product-specific UI into generic primitives.
+
+Good shared UI candidates:
+
+- buttons
+- badges
+- chips
+- cards
+- panels
+- modal frames
+- drawer frames
+- empty states
+- form shells
+
+Keep product-specific layouts inside feature directories.
+
+If a primitive needs a new variant, make sure it is genuinely reusable and does not damage existing screens.
+
+---
+
+## Testing / Verification
+
+Use the smallest useful verification first.
+
+For most implementation tasks, run:
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test`
+- `npm run build`
+
+For logic-heavy changes, add or update targeted tests.
+
+For visual-only changes, still run typecheck/build if the environment supports it.
+
+If any verification step is skipped, explain why in the final summary or PR body.
+
+Known warnings should not be hidden.
+If a warning is pre-existing, state that clearly.
+
+Before claiming work is complete, prefer using `verification-before-completion` when available.
+
+---
+
+## Git / Change Management
+
+Branch policy:
+
+- `main` is the conceptual release branch.
+- `develop` is the day-to-day integration branch.
+- Create task branches from the latest `develop`.
+- Open PRs back into `develop` for normal work.
 - Do not implement directly on `main`.
-- Do not open pull requests directly into `main` for normal feature work.
-- Normal task flow is: `develop` -> task branch -> pull request back into `develop`.
-- Only use `main` as the merge target for explicit release or promotion tasks requested by the human.
+- Do not open normal feature PRs directly into `main`.
+- Do not change repository-wide git settings.
+- Do not create unrelated commits.
 
-If the required branches do not exist yet:
-- create `develop` from the current integration baseline
-- push it to origin
-- then branch off from `develop`
+Before editing:
 
-Do not assume the human has already checked out the correct branch.
-Check the current branch first when a coding task begins.
-If needed, switch to `develop`, update it, and create a dedicated task branch before editing.
-Do not change repository-wide git settings.
-Do not create unrelated commits.
+- check the current branch
+- update from `develop` if needed
+- create a dedicated task branch
+
 Keep changes scoped to the requested task.
 
-If the environment supports tests/build:
-- run the smallest relevant verification first
-- for refactor / logic tasks, prefer running `npm run lint`, `npm run test`, `npm run typecheck`, then `npm run build`
-- prefer targeted checks before expensive full checks
-- if something is skipped, state that clearly in the final summary
+---
 
-When creating a pull request:
-- write the pull request title and body in Japanese unless the human explicitly asks for another language
-- include what changed
-- include why the code was written that way
-- include the intent behind non-obvious implementation choices or tradeoffs
-- do not rely on the human to ask for implementation rationale separately every time
+## Pull Request Expectations
+
+PR title and body should be written in Japanese unless the human explicitly asks otherwise.
+
+The PR body should include:
+
+- what changed
+- why it changed
+- how the implementation was split
+- what behavior was preserved
+- non-obvious tradeoffs
+- verification commands and results
+- known warnings or skipped checks
+- any relevant Skills used, if available and actually used
+
+Do not rely on the human to ask for implementation rationale afterward.
 
 ---
 
-## Prompting expectations for future tasks
+## What Not To Do
 
-When responding to a task in this repo:
-- first inspect relevant source files
-- read the spec and mocks
-- make a brief implementation plan internally
-- then implement in small, coherent edits
+Do not:
 
-Good tasks in this repo are usually:
-- one UI flow
-- one interaction cluster
-- one integration slice
-- one refactor slice
-
-Avoid trying to solve every future architecture concern in a single pass.
+- turn the app into a generic CRUD dashboard
+- redesign unrelated screens during a scoped task
+- remove distinctive visual direction for convenience
+- introduce real backend/auth/admin functionality without explicit request
+- convert all mocks into production code blindly
+- delete mock data before a safe replacement exists
+- mix DB migration, UI redesign, and routing overhaul in one task
+- vendor external Skills into the repo without explicit approval and source/license notes
+- claim a Skill, test, or verification step was used if it was not
+- hide uncertainty or skipped verification
+- make broad architecture changes without explaining the reason
 
 ---
 
-## Definition of success for current phase
+## Definition of Success for This Phase
 
-The current phase is successful if:
-- the main UI flows exist and connect properly
-- the visual direction matches the provided mocks
-- the interactions match the spec closely enough
-- local draft persistence works
-- UID picker flow works or is scaffolded cleanly
-- compare view works on desktop
-- dummy behaviors are clearly isolated
-- future refactor remains possible without major rewrites
+This phase is successful when:
+
+- the public demo feels coherent and intentional
+- LP communicates the appeal and value of elite-hunting RTA
+- Ranking and Library have clearly different roles
+- Library/search feels useful and visually aligned with the project world
+- major modals and overlays no longer feel like unrelated temporary UI
+- large discovery features can be added without breaking existing flows
+- the code remains ready for future DB/auth/admin/review work
+- the project can be shown to external reviewers for feedback
+- feedback can be reflected without rewriting the whole app

--- a/docs/mocks/library-new.filterentrance.tsx
+++ b/docs/mocks/library-new.filterentrance.tsx
@@ -1,0 +1,284 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+
+const images = [
+  "https://upload-os-bbs.hoyolab.com/upload/2025/01/26/fdd32de994246663d3329df80945351a_9019649747265555038.png?x-oss-process=image/auto-orient,0/interlace,1/format,webp/quality,q_70",
+  "https://upload-os-bbs.hoyolab.com/upload/2024/04/12/91148e90e86c89e4d565c4d46c092352_7325119691657342334.png?x-oss-process=image%2Fauto-orient%2C0%2Finterlace%2C1%2Fformat%2Cwebp%2Fquality%2Cq_70",
+  "https://upload-os-bbs.hoyolab.com/upload/2022/09/18/98252c0073c87263e6fbb51447cb6d2e_7381897631492436601.png?x-oss-process=image%2Fauto-orient%2C0%2Finterlace%2C1%2Fformat%2Cwebp%2Fquality%2Cq_70",
+  "https://upload-os-bbs.hoyolab.com/upload/2022/06/22/20d03d5c03560a68a9b5ca1c5ddf2293_5646653669169504614.png?x-oss-process=image%2Fauto-orient%2C0%2Finterlace%2C1%2Fformat%2Cwebp%2Fquality%2Cq_70",
+  "https://upload-os-bbs.hoyolab.com/upload/2026/04/30/25cc0894bf35a35b322dafbc722cf0b8_3127599890961230812.png?x-oss-process=image%2Fresize%2Cs_1000%2Fauto-orient%2C0%2Finterlace%2C1%2Fformat%2Cwebp%2Fquality%2Cq_70",
+];
+
+const panels = [
+  {
+    no: "01",
+    label: "キャラ・編成",
+    meta: "CHARACTER / TEAM",
+    lead: "キャラ・編成から探す",
+    image: images[0],
+    desktopImageClass: "left-1/2 bottom-[-7px] h-[272px] w-[214px] -translate-x-1/2 object-[50%_100%]",
+    mobileImageClass: "right-[-20px] bottom-[-30px] h-[154px] w-[184px] object-[50%_100%]",
+  },
+  {
+    no: "02",
+    label: "武器",
+    meta: "WEAPON",
+    lead: "武器から探す",
+    image: images[1],
+    desktopImageClass: "left-1/2 bottom-[-5px] h-[272px] w-[222px] -translate-x-1/2 object-[48%_100%]",
+    mobileImageClass: "right-[-24px] bottom-[-28px] h-[154px] w-[190px] object-[48%_100%]",
+  },
+  {
+    no: "03",
+    label: "凸・精錬",
+    meta: "C / R",
+    lead: "凸・精錬で絞る",
+    image: images[2],
+    desktopImageClass: "left-1/2 bottom-[-22px] h-[304px] w-[248px] -translate-x-1/2 object-[54%_100%]",
+    mobileImageClass: "right-[-36px] bottom-[-44px] h-[178px] w-[218px] object-[54%_100%]",
+  },
+  {
+    no: "04",
+    label: "カテゴリ・期間",
+    meta: "CATEGORY / SEASON",
+    lead: "カテゴリ・期間で探す",
+    image: images[3],
+    desktopImageClass: "left-1/2 bottom-[-11px] h-[282px] w-[230px] -translate-x-1/2 object-[48%_100%]",
+    mobileImageClass: "right-[-28px] bottom-[-36px] h-[164px] w-[198px] object-[48%_100%]",
+  },
+  {
+    no: "05",
+    label: "タグ",
+    meta: "TAGS",
+    lead: "タグから探す",
+    image: images[4],
+    desktopImageClass: "left-1/2 bottom-[-12px] h-[280px] w-[226px] -translate-x-1/2 object-[50%_100%]",
+    mobileImageClass: "right-[-30px] bottom-[-36px] h-[166px] w-[202px] object-[50%_100%]",
+  },
+];
+
+const MOBILE_LAYOUT = {
+  width: 360,
+  height: 640,
+  cardWidth: 360,
+  cardHeight: 120,
+  gap: 10,
+};
+
+const DESKTOP_LAYOUT = {
+  width: 828,
+  height: 390,
+  cardWidth: 156,
+  cardHeight: 312,
+  gap: 12,
+};
+
+function useMediaQuery(query) {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const update = () => setMatches(media.matches);
+
+    update();
+    media.addEventListener?.("change", update);
+    return () => media.removeEventListener?.("change", update);
+  }, [query]);
+
+  return matches;
+}
+
+function useFitScale(ref, baseWidth, maxScale = 1) {
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const update = () => {
+      const availableWidth = node.clientWidth;
+      const nextScale = Math.min(maxScale, availableWidth / baseWidth);
+      setScale(Number.isFinite(nextScale) && nextScale > 0 ? nextScale : 1);
+    };
+
+    update();
+
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(update);
+      observer.observe(node);
+      window.addEventListener("resize", update);
+      return () => {
+        observer.disconnect();
+        window.removeEventListener("resize", update);
+      };
+    }
+
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, [ref, baseWidth, maxScale]);
+
+  return scale;
+}
+
+function DownArrowIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-[28px] w-[28px] shrink-0"
+      viewBox="0 0 32 32"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.35"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12.8 8.7v9.2" />
+      <path d="M19.2 8.7v9.2" />
+      <path d="M10 16.9 16 22.9l6-6" />
+    </svg>
+  );
+}
+
+function ActionButtons() {
+  return (
+    <button
+      type="button"
+      className="group mx-auto flex w-fit items-center justify-center gap-[16px] text-[#050505] transition duration-200 hover:-translate-y-[1px]"
+      aria-label="この条件で絞り込む"
+    >
+      <span className="font-['Inter','Noto_Sans_JP',sans-serif] text-[18px] font-black leading-none tracking-[-0.04em] sm:text-[19px]">
+        この条件で絞り込む
+      </span>
+      <span className="flex h-[52px] w-[52px] shrink-0 items-center justify-center rounded-full bg-black text-white transition duration-200 group-hover:scale-[1.04] group-hover:bg-[#1a1a1a]">
+        <DownArrowIcon />
+      </span>
+    </button>
+  );
+}
+
+function SummaryCard({ item, isDesktop }) {
+  const imageClass = isDesktop ? item.desktopImageClass : item.mobileImageClass;
+
+  return (
+    <button
+      className="group relative shrink-0 text-left outline-none"
+      style={{ width: isDesktop ? DESKTOP_LAYOUT.cardWidth : MOBILE_LAYOUT.cardWidth }}
+      aria-label={`${item.label}で記録を探す`}
+      type="button"
+    >
+      <div
+        className="relative overflow-hidden rounded-[7px] bg-[#d9d9d7] shadow-[10px_13px_20px_rgba(30,32,35,0.14)] transition duration-300 group-hover:-translate-y-1 group-hover:shadow-[14px_18px_26px_rgba(30,32,35,0.2)]"
+        style={{
+          width: isDesktop ? DESKTOP_LAYOUT.cardWidth : MOBILE_LAYOUT.cardWidth,
+          height: isDesktop ? DESKTOP_LAYOUT.cardHeight : MOBILE_LAYOUT.cardHeight,
+        }}
+      >
+        <div className="absolute inset-0 bg-[linear-gradient(115deg,rgba(255,255,255,0.44),rgba(255,255,255,0.08)_45%,rgba(0,0,0,0.08))]" />
+        <div
+          className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-[#d6d6d4] via-[#d6d6d4]/72 to-transparent"
+          style={{ height: isDesktop ? "45%" : "60%" }}
+        />
+
+        <div className="absolute left-[-2px] top-[-5px] z-20 font-['Arial_Narrow',Arial,sans-serif] text-[64px] font-black leading-[0.78] tracking-[-0.11em] text-white/92">
+          {item.no}
+        </div>
+
+        {!isDesktop && (
+          <div className="absolute left-[86px] top-[25px] z-20 flex max-w-[150px] flex-col items-start">
+            <p className="font-['Arial_Narrow',Arial,sans-serif] text-[15px] font-black uppercase leading-none tracking-[-0.04em] text-[#3e4144]">
+              {item.label}
+            </p>
+            <p className="mt-[6px] whitespace-nowrap font-['Arial_Narrow',Arial,sans-serif] text-[8px] font-black uppercase tracking-[0.13em] text-[#7d7f80]">
+              {item.meta}
+            </p>
+            <div className="mt-[8px] flex w-[126px] items-center justify-center gap-2">
+              <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
+              <span className="whitespace-nowrap font-['Arial_Narrow',Arial,sans-serif] text-[8px] font-black tracking-[0.08em] text-[#868787]">
+                {item.lead}
+              </span>
+              <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
+            </div>
+          </div>
+        )}
+
+        <img
+          src={item.image}
+          alt=""
+          className={`absolute z-10 max-w-none object-contain transition duration-300 group-hover:scale-[1.045] ${imageClass}`}
+        />
+      </div>
+
+      {isDesktop && (
+        <div className="mt-[16px] flex flex-col items-center text-center">
+          <p className="font-['Arial_Narrow',Arial,sans-serif] text-[15px] font-black uppercase leading-none tracking-[-0.04em] text-[#3e4144]">
+            {item.label}
+          </p>
+          <p className="mt-[6px] whitespace-nowrap font-['Arial_Narrow',Arial,sans-serif] text-[8px] font-black uppercase tracking-[0.13em] text-[#7d7f80]">
+            {item.meta}
+          </p>
+          <div className="mt-[9px] flex w-[124px] items-center justify-center gap-2">
+            <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
+            <span className="whitespace-nowrap font-['Arial_Narrow',Arial,sans-serif] text-[8px] font-black tracking-[0.08em] text-[#868787]">
+              {item.lead}
+            </span>
+            <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
+          </div>
+        </div>
+      )}
+    </button>
+  );
+}
+
+export default function EliteLibrarySummaryMockup() {
+  const scaleAreaRef = useRef(null);
+  const isDesktop = useMediaQuery("(min-width: 640px)");
+  const layout = isDesktop ? DESKTOP_LAYOUT : MOBILE_LAYOUT;
+  const scale = useFitScale(scaleAreaRef, layout.width, 1);
+
+  const scaledStageStyle = useMemo(
+    () => ({
+      width: layout.width,
+      height: layout.height,
+      transform: `translateX(-50%) scale(${scale})`,
+      transformOrigin: "top center",
+      left: "50%",
+      top: 0,
+    }),
+    [layout.width, layout.height, scale],
+  );
+
+  return (
+    <div className="w-full">
+      <div ref={scaleAreaRef} className="w-full">
+        <div
+          className="relative mx-auto overflow-visible"
+          style={{
+            width: layout.width * scale,
+            height: layout.height * scale,
+          }}
+        >
+          <div className="absolute" style={scaledStageStyle}>
+            <div
+              className="flex"
+              style={{
+                width: layout.width,
+                height: layout.height,
+                flexDirection: isDesktop ? "row" : "column",
+                gap: layout.gap,
+                alignItems: isDesktop ? "flex-start" : "center",
+                justifyContent: "flex-start",
+              }}
+            >
+              {panels.map((item) => (
+                <SummaryCard key={item.no} item={item} isDesktop={isDesktop} />
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-[26px] flex w-full justify-center sm:mt-[30px]">
+        <ActionButtons />
+      </div>
+    </div>
+  );
+}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -518,8 +518,8 @@ export function AppShell({
   children: ReactNode;
 }) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const lightChrome = routeName === "home" || routeName === "detail";
   const useDarkChrome = true;
+  const shellBackgroundClass = routeName === "submit" ? "bg-white" : "bg-[#EDECEC]";
 
   useEffect(() => {
     if (!isDrawerOpen) {
@@ -548,7 +548,7 @@ export function AppShell({
   };
 
   return (
-    <div className="relative min-h-screen bg-[#f8f9fb] font-['Noto_Sans_JP',sans-serif] text-[#333333]">
+    <div className={classNames("relative min-h-screen font-['Noto_Sans_JP',sans-serif] text-[#333333]", shellBackgroundClass)}>
       {isDrawerOpen ? (
         <div className="fixed inset-0 z-40 bg-[rgba(0,0,0,0.5)] transition-opacity" onClick={() => setIsDrawerOpen(false)} />
       ) : null}
@@ -562,7 +562,7 @@ export function AppShell({
       />
 
       <div className="flex min-h-screen">
-        <div className="flex min-w-0 flex-1 flex-col bg-[#f8f9fb]">
+        <div className={classNames("flex min-w-0 flex-1 flex-col", shellBackgroundClass)}>
           <GlobalHeader
             routeName={routeName}
             hasUnreadNotifications={hasUnreadNotifications}
@@ -572,7 +572,7 @@ export function AppShell({
             onRequestSubmit={onRequestSubmit}
           />
 
-          <main className={classNames("min-w-0 flex-1 text-[#333333]", routeName === "home" ? "bg-[#EDECEC]" : lightChrome ? "bg-[#f5f6f8]" : "bg-[#f0f2f5]")}>{children}</main>
+          <main className={classNames("min-w-0 flex-1 text-[#333333]", shellBackgroundClass)}>{children}</main>
         </div>
       </div>
     </div>

--- a/src/components/PlaceholderPage.tsx
+++ b/src/components/PlaceholderPage.tsx
@@ -12,7 +12,7 @@ export function PlaceholderPage({
   children?: ReactNode;
 }) {
   return (
-    <div className="min-h-full bg-[#f0f2f5] text-[#333333]">
+    <div className="min-h-full bg-[#EDECEC] text-[#333333]">
       <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-6 px-4 py-6 md:px-6 md:py-8">
         <section className="rounded-[20px] border border-black/8 bg-white px-6 py-7 shadow-[0_12px_30px_rgba(0,0,0,0.06)]">
           <div className="text-[12px] font-bold tracking-[0.18em] text-[#9999b1] uppercase">{label}</div>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -18,7 +18,7 @@ const buttonSizeClass: Record<ButtonSize, string> = {
   sm: "min-h-8 px-3 py-1.5 text-[12px]",
   md: "min-h-9 px-4 py-2 text-[13px] md:text-[14px]",
   lg: "min-h-11 px-5 py-2.5 text-[15px] md:text-[16px]",
-  create: "min-h-[56px] px-6 py-4 text-[18px] md:text-[24px]",
+  create: "min-h-[45px] px-5 py-3 text-[15px] md:text-[19px]",
 };
 
 export function Button({

--- a/src/components/ui/tokens.ts
+++ b/src/components/ui/tokens.ts
@@ -6,7 +6,7 @@ export const dsTokens = {
     chromeDarkHover: "#17171d",
     surface: "#ffffff",
     surfaceMuted: "#f7f8fa",
-    surfaceApp: "#f5f6f8",
+    surfaceApp: "#EDECEC",
     surfaceCreate: "#f6f6f6",
     surfaceRaised: "#fbfcfd",
     border: "#d8dde6",

--- a/src/features/library/Page.tsx
+++ b/src/features/library/Page.tsx
@@ -17,7 +17,7 @@ export function LibraryPage({ onOpenRankings, onSelectRun }: LibraryPageProps) {
   const libraryState = useLibraryPageState({ onSelectRun });
 
   return (
-    <div className="min-h-full bg-[#f2f3f5] text-[#111827]">
+    <div className="min-h-full bg-[#EDECEC] text-[#111827]">
       <LibraryHero
         imageUrl={LIBRARY_HERO_IMAGE_URL}
         backgroundColor={LIBRARY_COLORS.pageBackground}

--- a/src/features/library/config.ts
+++ b/src/features/library/config.ts
@@ -1,7 +1,7 @@
 export const LIBRARY_HERO_IMAGE_URL = "https://cdn.asoworld.com/img/865f059851cb4fb0a1584a711a8bd338.jpg";
 
 export const LIBRARY_COLORS = {
-  pageBackground: "#f2f3f5",
+  pageBackground: "#EDECEC",
 } as const;
 
 export const LIBRARY_LABELS = {

--- a/src/features/library/config.ts
+++ b/src/features/library/config.ts
@@ -13,8 +13,9 @@ export const LIBRARY_LABELS = {
 
 export const LIBRARY_FILTER_PANELS = [
   { key: "character", label: "キャラ・編成", icon: "character" },
-  { key: "build", label: "凸・武器", icon: "weapon" },
-  { key: "category", label: "カテゴリ・期間", icon: "calendar" },
+  { key: "weapon", label: "武器", icon: "weapon" },
+  { key: "cost", label: "凸・精錬", icon: "cost" },
+  { key: "category", label: "カテゴリ・期間", icon: "category" },
   { key: "tag", label: "タグ", icon: "tag" },
   { key: "search", label: "検索", icon: "search" },
 ] as const;

--- a/src/features/library/hooks/useLibraryFilterEntrance.ts
+++ b/src/features/library/hooks/useLibraryFilterEntrance.ts
@@ -12,8 +12,6 @@ import {
   isSelectableFilterKey,
 } from "../logic/searchFilters";
 import type {
-  CharacterSummaryGroup,
-  CharacterSummaryTarget,
   LibraryBuildFilterState,
   LibraryCategoryFilterState,
   LibraryFilterKey,
@@ -40,8 +38,6 @@ export function useLibraryFilterEntrance({
   const [buildFilters, setBuildFilters] = useState<LibraryBuildFilterState>(() => createEmptyLibraryBuildFilterState());
   const [categoryFilters, setCategoryFilters] = useState<LibraryCategoryFilterState>(() => createEmptyLibraryCategoryFilterState());
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
-  const [isCharacterModalOpen, setIsCharacterModalOpen] = useState(false);
-  const [isWeaponModalOpen, setIsWeaponModalOpen] = useState(false);
   const activeLabel = useMemo(() => LIBRARY_FILTER_PANELS.find((panel) => panel.key === activeKey)?.label ?? "", [activeKey]);
 
   const createCurrentSearchFilters = (): LibrarySearchFilters => ({
@@ -55,7 +51,7 @@ export function useLibraryFilterEntrance({
     onSearch?.(createCurrentSearchFilters());
   };
 
-  const handleDesktopPanelClick = (key: LibraryFilterKey) => {
+  const handlePanelClick = (key: LibraryFilterKey) => {
     if (key === "search") {
       handleSearch();
       return;
@@ -67,35 +63,9 @@ export function useLibraryFilterEntrance({
     }
   };
 
-  const handleMobilePanelClick = (key: LibraryFilterKey) => {
-    if (key === "search") {
-      handleSearch();
-      return;
-    }
-
-    if (isSelectableFilterKey(key)) {
-      setActiveKey(key);
-    }
-  };
-
-  const handleRemoveCharacterFilter = (group: CharacterSummaryGroup, target: CharacterSummaryTarget, characterId: string) => {
-    const key = target === "include" ? "includeIds" : "excludeIds";
-    setCharacterFilters((current) => ({
-      ...current,
-      [group]: {
-        ...current[group],
-        [key]: current[group][key].filter((id) => id !== characterId),
-      },
-    }));
-  };
-
-  const handleToggleTag = (tag: string) => {
-    setSelectedTags((current) => (current.includes(tag) ? current.filter((item) => item !== tag) : [...current, tag]));
-  };
-
   useEffect(() => {
-    onModalOpenChange?.(desktopModalKey !== null || isCharacterModalOpen || isWeaponModalOpen);
-  }, [desktopModalKey, isCharacterModalOpen, isWeaponModalOpen, onModalOpenChange]);
+    onModalOpenChange?.(desktopModalKey !== null);
+  }, [desktopModalKey, onModalOpenChange]);
 
   useEffect(() => {
     if (!restoreRequest) {
@@ -117,19 +87,13 @@ export function useLibraryFilterEntrance({
     categoryFilters,
     characterFilters,
     desktopModalKey,
-    isCharacterModalOpen,
-    isWeaponModalOpen,
     selectedTags,
-    handleDesktopPanelClick,
-    handleMobilePanelClick,
-    handleRemoveCharacterFilter,
-    handleToggleTag,
+    handleDesktopPanelClick: handlePanelClick,
+    handleMobilePanelClick: handlePanelClick,
     setBuildFilters,
     setCategoryFilters,
     setCharacterFilters,
     setDesktopModalKey,
-    setIsCharacterModalOpen,
-    setIsWeaponModalOpen,
     setSelectedTags,
   };
 }

--- a/src/features/library/logic/actionStorage.ts
+++ b/src/features/library/logic/actionStorage.ts
@@ -14,6 +14,8 @@ import {
   createEmptyLibraryBuildFilterState,
   createEmptyLibraryCategoryFilterState,
   createEmptyLibrarySearchFilters,
+  hasActiveCostFilters,
+  hasActiveWeaponFilters,
 } from "./searchFilters";
 
 export const LIBRARY_ACTION_STORAGE_KEY = "elite-run-db.libraryActions.v1";
@@ -272,8 +274,12 @@ function getFilterSummaryParts(filters: LibrarySearchFilters) {
     parts.push(`キャラ${characterCount}`);
   }
 
-  if (hasActiveBuildFilters(filters.buildFilters)) {
-    parts.push("凸・武器");
+  if (hasActiveWeaponFilters(filters.buildFilters)) {
+    parts.push("武器");
+  }
+
+  if (hasActiveCostFilters(filters.buildFilters)) {
+    parts.push("凸・精錬");
   }
 
   if (hasActiveCategoryFilters(filters.categoryFilters)) {
@@ -300,16 +306,7 @@ function hasActiveFilters(filters: LibrarySearchFilters) {
 }
 
 function hasActiveBuildFilters(filters: LibraryBuildFilterState) {
-  return (
-    filters.costBracket !== null ||
-    !isDefaultRange(filters.charCostRange, LIBRARY_BUILD_RANGE_LIMITS.charCost) ||
-    !isDefaultRange(filters.weaponCostRange, LIBRARY_BUILD_RANGE_LIMITS.weaponCost) ||
-    !isDefaultRange(filters.fiveStarWeaponCountRange, LIBRARY_BUILD_RANGE_LIMITS.fiveStarWeaponCount) ||
-    filters.maxConstellation !== null ||
-    filters.maxFiveStarRefinement !== null ||
-    filters.weaponIds.include.length > 0 ||
-    filters.weaponIds.exclude.length > 0
-  );
+  return hasActiveWeaponFilters(filters) || hasActiveCostFilters(filters);
 }
 
 function hasActiveCategoryFilters(filters: LibraryCategoryFilterState) {
@@ -354,10 +351,6 @@ function readRange(value: unknown, limit: NumericRange): NumericRange {
   const min = clamp(Math.min(value.min, value.max), limit.min, limit.max);
   const max = clamp(Math.max(value.min, value.max), limit.min, limit.max);
   return { min, max };
-}
-
-function isDefaultRange(range: NumericRange, limit: NumericRange) {
-  return range.min === limit.min && range.max === limit.max;
 }
 
 function clamp(value: number, min: number, max: number) {

--- a/src/features/library/logic/libraryLogic.test.ts
+++ b/src/features/library/logic/libraryLogic.test.ts
@@ -60,9 +60,13 @@ describe("library search filter logic", () => {
     characterFilters.characterFilters.partyCharacters.includeIds.push("chasca");
     expect(getFirstActivePanelFromFilters(characterFilters)).toBe("character");
 
-    const buildFilters = createEmptyLibrarySearchFilters();
-    buildFilters.buildFilters.costBracket = 3;
-    expect(getFirstActivePanelFromFilters(buildFilters)).toBe("build");
+    const weaponFilters = createEmptyLibrarySearchFilters();
+    weaponFilters.buildFilters.weaponIds.include.push("favoniusWarbow");
+    expect(getFirstActivePanelFromFilters(weaponFilters)).toBe("weapon");
+
+    const costFilters = createEmptyLibrarySearchFilters();
+    costFilters.buildFilters.costBracket = 3;
+    expect(getFirstActivePanelFromFilters(costFilters)).toBe("cost");
 
     const categoryFilters = createEmptyLibrarySearchFilters();
     categoryFilters.categoryFilters.ruleset = "高難度";

--- a/src/features/library/logic/searchFilters.ts
+++ b/src/features/library/logic/searchFilters.ts
@@ -4,12 +4,9 @@ import {
   type LibraryBuildFilterState,
   type LibraryCategoryFilterState,
   type LibraryFilterKey,
-  type LibraryFilterPanel,
   type LibrarySearchFilters,
   type NumericRange,
-  type SearchFilterPanel,
   type SelectableFilterKey,
-  type SelectableFilterPanel,
 } from "../types";
 
 export function createEmptyLibraryBuildFilterState(): LibraryBuildFilterState {
@@ -73,14 +70,6 @@ export function isSelectableFilterKey(key: LibraryFilterKey): key is SelectableF
   return key !== "search";
 }
 
-export function isSelectableFilterPanel(panel: LibraryFilterPanel): panel is SelectableFilterPanel {
-  return isSelectableFilterKey(panel.key);
-}
-
-export function isSearchFilterPanel(panel: LibraryFilterPanel): panel is SearchFilterPanel {
-  return panel.key === "search";
-}
-
 export function isDefaultRange(value: NumericRange, limit: NumericRange) {
   return value.min === limit.min && value.max === limit.max;
 }
@@ -96,17 +85,12 @@ export function getFirstActivePanelFromFilters(filters: LibrarySearchFilters): S
     return "character";
   }
 
-  if (
-    filters.buildFilters.costBracket !== null ||
-    !isDefaultRange(filters.buildFilters.charCostRange, LIBRARY_BUILD_RANGE_LIMITS.charCost) ||
-    !isDefaultRange(filters.buildFilters.weaponCostRange, LIBRARY_BUILD_RANGE_LIMITS.weaponCost) ||
-    !isDefaultRange(filters.buildFilters.fiveStarWeaponCountRange, LIBRARY_BUILD_RANGE_LIMITS.fiveStarWeaponCount) ||
-    filters.buildFilters.maxConstellation !== null ||
-    filters.buildFilters.maxFiveStarRefinement !== null ||
-    filters.buildFilters.weaponIds.include.length > 0 ||
-    filters.buildFilters.weaponIds.exclude.length > 0
-  ) {
-    return "build";
+  if (hasActiveWeaponFilters(filters.buildFilters)) {
+    return "weapon";
+  }
+
+  if (hasActiveCostFilters(filters.buildFilters)) {
+    return "cost";
   }
 
   if (filters.categoryFilters.ruleset || filters.categoryFilters.version || filters.categoryFilters.playStyle || filters.categoryFilters.food || filters.categoryFilters.device) {
@@ -118,4 +102,19 @@ export function getFirstActivePanelFromFilters(filters: LibrarySearchFilters): S
   }
 
   return null;
+}
+
+export function hasActiveWeaponFilters(filters: LibraryBuildFilterState) {
+  return filters.weaponIds.include.length > 0 || filters.weaponIds.exclude.length > 0;
+}
+
+export function hasActiveCostFilters(filters: LibraryBuildFilterState) {
+  return (
+    filters.costBracket !== null ||
+    !isDefaultRange(filters.charCostRange, LIBRARY_BUILD_RANGE_LIMITS.charCost) ||
+    !isDefaultRange(filters.weaponCostRange, LIBRARY_BUILD_RANGE_LIMITS.weaponCost) ||
+    !isDefaultRange(filters.fiveStarWeaponCountRange, LIBRARY_BUILD_RANGE_LIMITS.fiveStarWeaponCount) ||
+    filters.maxConstellation !== null ||
+    filters.maxFiveStarRefinement !== null
+  );
 }

--- a/src/features/library/sections/FilterEntrance.tsx
+++ b/src/features/library/sections/FilterEntrance.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useState, type CSSProperties, type Dispatch, type ReactNode, type SetStateAction } from "react";
+import { useEffect, useId, useMemo, useRef, useState, type CSSProperties, type ReactNode, type RefObject } from "react";
 
 import { CharacterIcon } from "../../../components/CharacterIcon";
 import { WeaponIcon } from "../../../components/WeaponIcon";
@@ -16,9 +16,7 @@ import { formatVersionLabel, versionRank } from "../../../lib/versionLabels";
 import { HOME_ELEMENT_FILTER_OPTIONS, HOME_FILTER_TAG_GROUP_DEFINITIONS, HOME_FILTER_TARGET_OPTIONS } from "../../home/config";
 import { cloneHomeFilterState, createEmptyHomeFilterState, updateSelectionGroup } from "../../home/logic";
 import type { CharacterFilterTabKey, HomeFilterState, SelectionTarget } from "../../home/types";
-import { FilterDrawer } from "../../home/ui/FilterDrawer";
 import { SearchIcon } from "../../home/ui/icons";
-import categoryPeriodImageUrl from "../assets/library-category-period.png";
 import { LIBRARY_FILTER_PANELS, LIBRARY_LABELS } from "../config";
 import { useLibraryFilterEntrance } from "../hooks/useLibraryFilterEntrance";
 import type { LibraryFilterRestoreRequest } from "../logic/actionStorage";
@@ -27,34 +25,23 @@ import {
   cloneLibraryCategoryFilterState,
   createEmptyLibraryBuildFilterState,
   createEmptyLibraryCategoryFilterState,
-  isSearchFilterPanel,
-  isSelectableFilterPanel,
 } from "../logic/searchFilters";
 import {
   LIBRARY_BUILD_RANGE_LIMITS as BUILD_RANGE_LIMITS,
   type CharacterSummaryGroup,
   type CharacterSummaryTarget,
   type LibraryBuildFilterState,
-  type LibraryBuildFilterTab,
   type LibraryCategoryFilterState,
   type LibraryFilterKey,
-  type LibraryFilterPanel,
   type LibrarySearchFilters,
   type NumericRange,
-  type SearchFilterPanel,
   type SelectableFilterKey,
-  type SelectableFilterPanel,
   type WeaponSummaryTarget,
 } from "../types";
 
 const CHARACTER_FILTER_MODAL_TABS: { key: CharacterFilterTabKey; label: string }[] = [
   { key: "partyCharacters", label: "編成キャラ" },
   { key: "mainAttackers", label: "メイン" },
-];
-
-const LIBRARY_BUILD_FILTER_TABS: { key: LibraryBuildFilterTab; label: string }[] = [
-  { key: "cost", label: "コスト指定" },
-  { key: "weapon", label: "武器指定" },
 ];
 
 const COST_BRACKET_OPTIONS = [
@@ -103,36 +90,91 @@ const UI = {
   cardBorder: "#CFCFCF",
 } as const;
 
-const FILTER_CARD_DIM_CLASS = "bg-black/[0.58] group-hover:bg-black/[0.36] group-focus-visible:bg-black/[0.36]";
-const FILTER_CARD_DETAILS: Record<SelectableFilterKey, { number: string; subLabel: string }> = {
-  character: { number: "01", subLabel: "PARTY / MAIN" },
-  build: { number: "02", subLabel: "CONST / WEAPON" },
-  category: { number: "03", subLabel: "RULE / VERSION" },
-  tag: { number: "04", subLabel: "TAG CLUSTER" },
-};
+const FILTER_ENTRANCE_IMAGES = [
+  "https://upload-os-bbs.hoyolab.com/upload/2025/01/26/fdd32de994246663d3329df80945351a_9019649747265555038.png?x-oss-process=image/auto-orient,0/interlace,1/format,webp/quality,q_70",
+  "https://upload-os-bbs.hoyolab.com/upload/2024/04/12/91148e90e86c89e4d565c4d46c092352_7325119691657342334.png?x-oss-process=image%2Fauto-orient%2C0%2Finterlace%2C1%2Fformat%2Cwebp%2Fquality%2Cq_70",
+  "https://upload-os-bbs.hoyolab.com/upload/2022/09/18/98252c0073c87263e6fbb51447cb6d2e_7381897631492436601.png?x-oss-process=image%2Fauto-orient%2C0%2Finterlace%2C1%2Fformat%2Cwebp%2Fquality%2Cq_70",
+  "https://upload-os-bbs.hoyolab.com/upload/2022/06/22/20d03d5c03560a68a9b5ca1c5ddf2293_5646653669169504614.png?x-oss-process=image%2Fauto-orient%2C0%2Finterlace%2C1%2Fformat%2Cwebp%2Fquality%2Cq_70",
+  "https://upload-os-bbs.hoyolab.com/upload/2026/04/30/25cc0894bf35a35b322dafbc722cf0b8_3127599890961230812.png?x-oss-process=image%2Fresize%2Cs_1000%2Fauto-orient%2C0%2Finterlace%2C1%2Fformat%2Cwebp%2Fquality%2Cq_70",
+] as const;
 
-const DESKTOP_FILTER_CARD_META: Record<SelectableFilterKey, { imageUrl: string; backgroundColor: string; objectPosition: string }> = {
-  character: {
-    imageUrl: "https://enka.network/ui/UI_Gacha_AvatarImg_Chasca.png",
-    backgroundColor: "#274060",
-    objectPosition: "50% 18%",
+const FILTER_ENTRANCE_CARDS: Array<{
+  key: SelectableFilterKey;
+  no: string;
+  label: string;
+  meta: string;
+  lead: string;
+  image: string;
+  desktopImageClass: string;
+  mobileImageClass: string;
+}> = [
+  {
+    key: "character",
+    no: "01",
+    label: "キャラ・編成",
+    meta: "CHARACTER / TEAM",
+    lead: "キャラ・編成から探す",
+    image: FILTER_ENTRANCE_IMAGES[0],
+    desktopImageClass: "left-1/2 bottom-[-7px] h-[272px] w-[214px] -translate-x-1/2 object-[50%_100%]",
+    mobileImageClass: "right-[-20px] bottom-[-30px] h-[154px] w-[184px] object-[50%_100%]",
   },
-  build: {
-    imageUrl: "https://enka.network/ui/UI_EquipIcon_Claymore_Wolfmound.png",
-    backgroundColor: "#2c3e3d",
-    objectPosition: "50% 44%",
+  {
+    key: "weapon",
+    no: "02",
+    label: "武器",
+    meta: "WEAPON",
+    lead: "武器から探す",
+    image: FILTER_ENTRANCE_IMAGES[1],
+    desktopImageClass: "left-1/2 bottom-[-5px] h-[272px] w-[222px] -translate-x-1/2 object-[48%_100%]",
+    mobileImageClass: "right-[-24px] bottom-[-28px] h-[154px] w-[190px] object-[48%_100%]",
   },
-  category: {
-    imageUrl: categoryPeriodImageUrl,
-    backgroundColor: "#4a3528",
-    objectPosition: "50% 34%",
+  {
+    key: "cost",
+    no: "03",
+    label: "凸・精錬",
+    meta: "C / R",
+    lead: "凸・精錬で絞る",
+    image: FILTER_ENTRANCE_IMAGES[2],
+    desktopImageClass: "left-1/2 bottom-[-22px] h-[304px] w-[248px] -translate-x-1/2 object-[54%_100%]",
+    mobileImageClass: "right-[-36px] bottom-[-44px] h-[178px] w-[218px] object-[54%_100%]",
   },
-  tag: {
-    imageUrl: "https://static.wikia.nocookie.net/gensin-impact/images/6/65/Item_An_Appellative_Stroke.png/revision/latest?cb=20221207135611",
-    backgroundColor: "#3d2a4a",
-    objectPosition: "50% 42%",
+  {
+    key: "category",
+    no: "04",
+    label: "カテゴリ・期間",
+    meta: "CATEGORY / SEASON",
+    lead: "カテゴリ・期間で探す",
+    image: FILTER_ENTRANCE_IMAGES[3],
+    desktopImageClass: "left-1/2 bottom-[-11px] h-[282px] w-[230px] -translate-x-1/2 object-[48%_100%]",
+    mobileImageClass: "right-[-28px] bottom-[-36px] h-[164px] w-[198px] object-[48%_100%]",
   },
-};
+  {
+    key: "tag",
+    no: "05",
+    label: "タグ",
+    meta: "TAGS",
+    lead: "タグから探す",
+    image: FILTER_ENTRANCE_IMAGES[4],
+    desktopImageClass: "left-1/2 bottom-[-12px] h-[280px] w-[226px] -translate-x-1/2 object-[50%_100%]",
+    mobileImageClass: "right-[-30px] bottom-[-36px] h-[166px] w-[202px] object-[50%_100%]",
+  },
+];
+
+const FILTER_ENTRANCE_MOBILE_LAYOUT = {
+  width: 360,
+  height: 640,
+  cardWidth: 360,
+  cardHeight: 120,
+  gap: 10,
+} as const;
+
+const FILTER_ENTRANCE_DESKTOP_LAYOUT = {
+  width: 828,
+  height: 390,
+  cardWidth: 156,
+  cardHeight: 312,
+  gap: 12,
+} as const;
 
 export function FilterEntrance({
   onModalOpenChange,
@@ -148,35 +190,7 @@ export function FilterEntrance({
   return (
     <section className="relative z-10 mx-auto -mt-24 max-w-[1340px] px-4 md:-mt-56 lg:px-8" style={{ color: UI.textMain }}>
       <ResponsiveStyle />
-      <div className="overflow-hidden border shadow-[0_18px_45px_rgba(21,27,38,0.14)]" style={{ borderColor: UI.cardBorder }}>
-        <header className="relative flex min-h-[55px] items-stretch bg-[#111116]">
-          <div className="flex min-w-0 flex-1 items-center gap-3 px-4 sm:gap-4 sm:px-5">
-            <span className="inline-flex h-[22px] shrink-0 items-center border border-white/40 px-3 text-[12px] font-bold uppercase leading-none tracking-[0.14em] text-[#d9d9d9]">
-              {LIBRARY_LABELS.searchBadge}
-            </span>
-            <h2 className="shrink-0 text-[15px] font-black leading-none tracking-[0.04em] text-[#d9d9d9] sm:text-[19px]">{LIBRARY_LABELS.searchTitle}</h2>
-            <span className="hidden h-[3px] w-[3px] shrink-0 rounded-full bg-white/25 sm:block" />
-            <span className="truncate text-[11px] font-normal uppercase leading-none tracking-[0.08em] text-[#d9d9d9] sm:text-[12px]">
-              {filterEntranceState.activeLabel || LIBRARY_LABELS.searchSummaryFallback}
-            </span>
-          </div>
-        </header>
-        <div className="h-px bg-white/10" />
-        <div className="p-3 sm:p-4" style={{ background: UI.sectionBody }}>
-          <FilterCardBar activeKey={filterEntranceState.activeKey} onPanelClick={filterEntranceState.handleDesktopPanelClick} variant="desktop" className="hidden sm:block" />
-          <FilterCardBar activeKey={filterEntranceState.activeKey} onPanelClick={filterEntranceState.handleMobilePanelClick} variant="mobile" className="sm:hidden" />
-          <div className="mt-3 sm:hidden">
-            {filterEntranceState.activeKey === "character" ? (
-              <CharacterFilterSummaryPanel filters={filterEntranceState.characterFilters} onOpenPicker={() => filterEntranceState.setIsCharacterModalOpen(true)} onRemoveFilter={filterEntranceState.handleRemoveCharacterFilter} />
-            ) : null}
-            {filterEntranceState.activeKey === "build" ? (
-              <BuildFilterControlsPanel filters={filterEntranceState.buildFilters} onChange={filterEntranceState.setBuildFilters} onOpenWeaponPicker={() => filterEntranceState.setIsWeaponModalOpen(true)} />
-            ) : null}
-            {filterEntranceState.activeKey === "category" ? <CategoryFilterPanel filters={filterEntranceState.categoryFilters} onChange={filterEntranceState.setCategoryFilters} /> : null}
-            {filterEntranceState.activeKey === "tag" ? <TagFilterPanel selectedTags={filterEntranceState.selectedTags} onToggleTag={filterEntranceState.handleToggleTag} /> : null}
-          </div>
-        </div>
-      </div>
+      <FilterEntranceShowcase activeKey={filterEntranceState.activeKey} onPanelClick={filterEntranceState.handleDesktopPanelClick} />
       <LibraryFilterModal
         activeKey={filterEntranceState.desktopModalKey}
         characterFilters={filterEntranceState.characterFilters}
@@ -201,92 +215,224 @@ export function FilterEntrance({
           filterEntranceState.setDesktopModalKey(null);
         }}
       />
-      <FilterDrawer
-        isOpen={filterEntranceState.isCharacterModalOpen}
-        onClose={() => filterEntranceState.setIsCharacterModalOpen(false)}
-        onApply={filterEntranceState.setCharacterFilters}
-        initialFilters={filterEntranceState.characterFilters}
-        characters={selectableCharacters}
-        tagGroups={[]}
-        title="キャラ・編成を絞り込む"
-        resetLabel="リセット"
-        applyLabel="適用する"
-        filterTabs={[
-          { key: "partyCharacters", label: "編成キャラ" },
-          { key: "mainAttackers", label: "メインアタッカー" },
-        ]}
-        filterTargetOptions={HOME_FILTER_TARGET_OPTIONS}
-        elementFilterOptions={HOME_ELEMENT_FILTER_OPTIONS}
-        characterSearchPlaceholder="キャラ名で検索"
-        tagSearchPlaceholder=""
-        emptyCharacterResultLabel="該当するキャラがありません"
-        emptyTagResultLabel=""
-      />
-      <LibraryWeaponFilterDrawer
-        isOpen={filterEntranceState.isWeaponModalOpen}
-        initialWeaponIds={filterEntranceState.buildFilters.weaponIds}
-        onClose={() => filterEntranceState.setIsWeaponModalOpen(false)}
-        onApply={(weaponIds) => {
-          filterEntranceState.setBuildFilters((current) => ({ ...current, weaponIds }));
-          filterEntranceState.setIsWeaponModalOpen(false);
-        }}
-      />
     </section>
   );
 }
 
-function CharacterFilterSummaryPanel({
-  filters,
-  onOpenPicker,
-  onRemoveFilter,
-}: {
-  filters: HomeFilterState;
-  onOpenPicker: () => void;
-  onRemoveFilter: (group: CharacterSummaryGroup, target: CharacterSummaryTarget, characterId: string) => void;
-}) {
-  const selectedIds = getUniqueSelectedCharacterIds(filters).slice(0, 4);
-  const selectedCount = getSelectedCharacterCount(filters);
+function FilterEntranceShowcase({ activeKey, onPanelClick }: { activeKey: SelectableFilterKey | null; onPanelClick: (key: LibraryFilterKey) => void }) {
+  const scaleAreaRef = useRef<HTMLDivElement | null>(null);
+  const isDesktop = useMediaQuery("(min-width: 640px)");
+  const layout = isDesktop ? FILTER_ENTRANCE_DESKTOP_LAYOUT : FILTER_ENTRANCE_MOBILE_LAYOUT;
+  const scale = useFitScale(scaleAreaRef, layout.width, 1);
+  const scaledStageStyle = useMemo<CSSProperties>(
+    () => ({
+      width: layout.width,
+      height: layout.height,
+      transform: `translateX(-50%) scale(${scale})`,
+      transformOrigin: "top center",
+      left: "50%",
+      top: 0,
+    }),
+    [layout.height, layout.width, scale],
+  );
 
   return (
-    <div className="rounded-b-[8px] border-x border-b bg-white px-4 py-4 shadow-[0_10px_16px_rgba(0,0,0,0.05)]" style={{ borderColor: UI.panelBorder }}>
-      <div className="grid gap-4 lg:grid-cols-[310px_1fr]">
-        <LibraryCharacterPickerTile selectedIds={selectedIds} selectedCount={selectedCount} onOpenPicker={onOpenPicker} />
-        <div className="grid gap-3 md:grid-cols-2">
-          <CombinedCharacterSummaryBox title="編成キャラ" includeIds={filters.partyCharacters.includeIds} excludeIds={filters.partyCharacters.excludeIds} group="partyCharacters" onRemove={onRemoveFilter} />
-          <CombinedCharacterSummaryBox title="メインアタッカー" includeIds={filters.mainAttackers.includeIds} excludeIds={filters.mainAttackers.excludeIds} group="mainAttackers" onRemove={onRemoveFilter} />
+    <div className="mx-auto w-full max-w-[828px]" role="group" aria-label={LIBRARY_LABELS.searchTitle}>
+      <div ref={scaleAreaRef} className="w-full">
+        <div className="relative mx-auto overflow-visible" style={{ width: layout.width * scale, height: layout.height * scale }}>
+          <div className="absolute" style={scaledStageStyle}>
+            <div
+              className="flex"
+              style={{
+                width: layout.width,
+                height: layout.height,
+                flexDirection: isDesktop ? "row" : "column",
+                gap: layout.gap,
+                alignItems: isDesktop ? "flex-start" : "center",
+                justifyContent: "flex-start",
+              }}
+            >
+              {FILTER_ENTRANCE_CARDS.map((item) => (
+                <FilterEntranceSummaryCard
+                  key={item.key}
+                  item={item}
+                  isActive={activeKey === item.key}
+                  isDesktop={isDesktop}
+                  onClick={() => onPanelClick(item.key)}
+                />
+              ))}
+            </div>
+          </div>
         </div>
+      </div>
+      <div className="mt-[26px] flex w-full justify-center sm:mt-[30px]">
+        <button
+          type="button"
+          className="group mx-auto flex w-fit items-center justify-center gap-[16px] text-[#050505] transition duration-200 hover:-translate-y-[1px] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50"
+          aria-label="この条件で絞り込む"
+          onClick={() => onPanelClick("search")}
+        >
+          <span className="font-['Inter','Noto_Sans_JP',sans-serif] text-[18px] font-black leading-none tracking-[0] sm:text-[19px]">
+            この条件で絞り込む
+          </span>
+          <span className="flex h-[52px] w-[52px] shrink-0 items-center justify-center rounded-full bg-black text-white transition duration-200 group-hover:scale-[1.04] group-hover:bg-[#1a1a1a]">
+            <DownArrowIcon />
+          </span>
+        </button>
       </div>
     </div>
   );
 }
 
-function LibraryCharacterPickerTile({ selectedIds, selectedCount, onOpenPicker }: { selectedIds: string[]; selectedCount: number; onOpenPicker: () => void }) {
-  const hasSelection = selectedCount > 0;
+function FilterEntranceSummaryCard({
+  item,
+  isActive,
+  isDesktop,
+  onClick,
+}: {
+  item: (typeof FILTER_ENTRANCE_CARDS)[number];
+  isActive: boolean;
+  isDesktop: boolean;
+  onClick: () => void;
+}) {
+  const imageClass = isDesktop ? item.desktopImageClass : item.mobileImageClass;
+  const layout = isDesktop ? FILTER_ENTRANCE_DESKTOP_LAYOUT : FILTER_ENTRANCE_MOBILE_LAYOUT;
 
   return (
-    <button type="button" onClick={onOpenPicker} className="group flex min-h-[128px] items-center gap-4 rounded-[8px] border bg-[#f6f6f6] p-4 text-left transition hover:bg-[#f1f1f1] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50" style={{ borderColor: UI.panelBorder }}>
-      <span className="grid h-[96px] w-[96px] shrink-0 place-items-center overflow-hidden rounded-[8px] bg-white">
-        {hasSelection ? (
-          <span className="grid w-full grid-cols-2 gap-1 p-2">
-            {selectedIds.map((characterId) => {
-              const character = characterDb[characterId];
-              return (
-                <span key={characterId} className="grid h-9 w-9 place-items-center overflow-hidden rounded-full bg-[#f2f2f2]">
-                  <CharacterIcon characterId={characterId} alt={character?.name ?? characterId} fallbackLabel={character?.name ?? characterId} size={36} />
-                </span>
-              );
-            })}
-          </span>
-        ) : (
-          <span className="text-[76px] font-normal leading-none text-[#c2c2c2] transition group-hover:text-[#a9a9b5]">+</span>
-        )}
-      </span>
-      <span className="min-w-0">
-        <span className="block text-[18px] font-black tracking-[0.02em] text-[#333333]">{hasSelection ? "キャラ条件を編集" : "キャラ条件を選択"}</span>
-        <span className="mt-2 block text-[12px] font-bold leading-5 text-[#777777]">{hasSelection ? `${selectedCount}件の条件を選択中` : "編成キャラとメインアタッカーをまとめて指定できます。"}</span>
-      </span>
+    <button
+      className="group relative shrink-0 text-left outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/55"
+      style={{ width: layout.cardWidth }}
+      aria-label={`${item.label}で記録を探す`}
+      aria-pressed={isActive}
+      type="button"
+      onClick={onClick}
+    >
+      <div
+        className="relative overflow-hidden rounded-[7px] bg-[#d9d9d7] shadow-[10px_13px_20px_rgba(30,32,35,0.14)] transition duration-300 group-hover:-translate-y-1 group-hover:shadow-[14px_18px_26px_rgba(30,32,35,0.2)]"
+        style={{
+          width: layout.cardWidth,
+          height: layout.cardHeight,
+        }}
+      >
+        <div className="absolute inset-0 bg-[linear-gradient(115deg,rgba(255,255,255,0.44),rgba(255,255,255,0.08)_45%,rgba(0,0,0,0.08))]" />
+        <div
+          className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-[#d6d6d4] via-[#d6d6d4]/72 to-transparent"
+          style={{ height: isDesktop ? "45%" : "60%" }}
+        />
+        <div className="absolute left-[-2px] top-[-5px] z-20 font-['Arial_Narrow',Arial,sans-serif] text-[64px] font-black leading-[0.78] tracking-[0] text-white/92">
+          {item.no}
+        </div>
+
+        {!isDesktop ? (
+          <div className="absolute left-[86px] top-[25px] z-20 flex max-w-[150px] flex-col items-start">
+            <p className="font-['Arial_Narrow',Arial,sans-serif] text-[15px] font-black uppercase leading-none tracking-[0] text-[#3e4144]">
+              {item.label}
+            </p>
+            <p className="mt-[6px] whitespace-nowrap font-['Arial_Narrow',Arial,sans-serif] text-[8px] font-black uppercase tracking-[0.13em] text-[#7d7f80]">
+              {item.meta}
+            </p>
+            <div className="mt-[8px] flex w-[126px] items-center justify-center gap-2">
+              <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
+              <span className="whitespace-nowrap font-['Arial_Narrow',Arial,sans-serif] text-[8px] font-black tracking-[0.08em] text-[#868787]">
+                {item.lead}
+              </span>
+              <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
+            </div>
+          </div>
+        ) : null}
+
+        <img
+          src={item.image}
+          alt=""
+          className={`absolute z-10 max-w-none object-contain transition duration-300 group-hover:scale-[1.045] ${imageClass}`}
+          loading="lazy"
+        />
+      </div>
+
+      {isDesktop ? (
+        <div className="mt-[16px] flex flex-col items-center text-center">
+          <p className="font-['Arial_Narrow',Arial,sans-serif] text-[15px] font-black uppercase leading-none tracking-[0] text-[#3e4144]">
+            {item.label}
+          </p>
+          <p className="mt-[6px] whitespace-nowrap font-['Arial_Narrow',Arial,sans-serif] text-[8px] font-black uppercase tracking-[0.13em] text-[#7d7f80]">
+            {item.meta}
+          </p>
+          <div className="mt-[9px] flex w-[124px] items-center justify-center gap-2">
+            <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
+            <span className="whitespace-nowrap font-['Arial_Narrow',Arial,sans-serif] text-[8px] font-black tracking-[0.08em] text-[#868787]">
+              {item.lead}
+            </span>
+            <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
+          </div>
+        </div>
+      ) : null}
     </button>
   );
+}
+
+function DownArrowIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-[28px] w-[28px] shrink-0"
+      viewBox="0 0 32 32"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.35"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12.8 8.7v9.2" />
+      <path d="M19.2 8.7v9.2" />
+      <path d="M10 16.9 16 22.9l6-6" />
+    </svg>
+  );
+}
+
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    const update = () => setMatches(media.matches);
+
+    update();
+    media.addEventListener?.("change", update);
+    return () => media.removeEventListener?.("change", update);
+  }, [query]);
+
+  return matches;
+}
+
+function useFitScale(ref: RefObject<HTMLElement | null>, baseWidth: number, maxScale = 1) {
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+
+    const update = () => {
+      const nextScale = Math.min(maxScale, node.clientWidth / baseWidth);
+      setScale(Number.isFinite(nextScale) && nextScale > 0 ? nextScale : 1);
+    };
+
+    update();
+
+    if (typeof ResizeObserver !== "undefined") {
+      const observer = new ResizeObserver(update);
+      observer.observe(node);
+      window.addEventListener("resize", update);
+      return () => {
+        observer.disconnect();
+        window.removeEventListener("resize", update);
+      };
+    }
+
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, [baseWidth, maxScale, ref]);
+
+  return scale;
 }
 
 function CombinedCharacterSummaryBox({
@@ -324,40 +470,6 @@ function CombinedCharacterSummaryBox({
         )}
       </div>
     </section>
-  );
-}
-
-function getUniqueSelectedCharacterIds(filters: HomeFilterState) {
-  return Array.from(new Set([...filters.partyCharacters.includeIds, ...filters.partyCharacters.excludeIds, ...filters.mainAttackers.includeIds, ...filters.mainAttackers.excludeIds]));
-}
-
-function getSelectedCharacterCount(filters: HomeFilterState) {
-  return filters.partyCharacters.includeIds.length + filters.partyCharacters.excludeIds.length + filters.mainAttackers.includeIds.length + filters.mainAttackers.excludeIds.length;
-}
-
-function CategoryFilterPanel({
-  filters,
-  onChange,
-}: {
-  filters: LibraryCategoryFilterState;
-  onChange: Dispatch<SetStateAction<LibraryCategoryFilterState>>;
-}) {
-  const update = <Key extends keyof LibraryCategoryFilterState>(key: Key, value: LibraryCategoryFilterState[Key]) => {
-    onChange((current) => ({ ...current, [key]: value }));
-  };
-
-  return (
-    <div className="rounded-b-[8px] border-x border-b bg-white px-4 py-4 shadow-[0_10px_16px_rgba(0,0,0,0.05)]" style={{ borderColor: UI.panelBorder }}>
-      <div className="grid gap-3 lg:grid-cols-2">
-        <LibrarySelectControl title="カテゴリ" value={filters.ruleset} options={RULESET_OPTIONS} placeholder="カテゴリを選択" onChange={(value) => update("ruleset", value)} />
-        <LibrarySelectControl title="期間・バージョン" value={filters.version} options={VERSION_OPTIONS} placeholder="期間を選択" onChange={(value) => update("version", value)} />
-      </div>
-      <div className="mt-3 grid gap-3 lg:grid-cols-3">
-        <ChoiceFilterGroup title="人数" options={PLAY_STYLE_OPTIONS} value={filters.playStyle} onChange={(value) => update("playStyle", value)} />
-        <ChoiceFilterGroup title="飯バフ" options={FOOD_OPTIONS} value={filters.food} onChange={(value) => update("food", value)} />
-        <ChoiceFilterGroup title="端末" options={DEVICE_OPTIONS} value={filters.device} onChange={(value) => update("device", value)} />
-      </div>
-    </div>
   );
 }
 
@@ -429,104 +541,6 @@ function ChoiceFilterGroup({
         })}
       </div>
     </section>
-  );
-}
-
-function TagFilterPanel({ selectedTags, onToggleTag }: { selectedTags: string[]; onToggleTag: (tag: string) => void }) {
-  return (
-    <div className="rounded-b-[8px] border-x border-b bg-white px-4 py-4 shadow-[0_10px_16px_rgba(0,0,0,0.05)]" style={{ borderColor: UI.panelBorder }}>
-      <div className="grid gap-3 lg:grid-cols-2">
-        {HOME_FILTER_TAG_GROUP_DEFINITIONS.map((group) => (
-          <section key={group.key} className="rounded-[8px] border bg-[#f7f7f7] p-3" style={{ borderColor: UI.panelBorder }}>
-            <p className="mb-2 text-[12px] font-black tracking-[0.08em] text-[#777777]">{group.label}</p>
-            <div className="flex flex-wrap gap-2">
-              {group.tags.map((tag) => {
-                const active = selectedTags.includes(tag);
-                return (
-                  <button
-                    key={`${group.key}-${tag}`}
-                    type="button"
-                    onClick={() => onToggleTag(tag)}
-                    className={[
-                      "inline-flex min-h-9 items-center rounded-full border px-3 py-2 text-[12px] font-medium transition-colors",
-                      active ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]",
-                    ].join(" ")}
-                  >
-                    #{tag}
-                  </button>
-                );
-              })}
-            </div>
-          </section>
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function BuildFilterControlsPanel({
-  filters,
-  onChange,
-  onOpenWeaponPicker,
-}: {
-  filters: LibraryBuildFilterState;
-  onChange: Dispatch<SetStateAction<LibraryBuildFilterState>>;
-  onOpenWeaponPicker: () => void;
-}) {
-  const selectedWeaponIds = getUniqueSelectedWeaponIds(filters).slice(0, 4);
-  const selectedWeaponCount = filters.weaponIds.include.length + filters.weaponIds.exclude.length;
-
-  const updateRange = (key: "charCostRange" | "weaponCostRange" | "fiveStarWeaponCountRange", range: NumericRange) => {
-    onChange((current) => ({ ...current, [key]: range }));
-  };
-
-  return (
-    <div className="rounded-b-[8px] border-x border-b bg-white px-4 py-4 shadow-[0_10px_16px_rgba(0,0,0,0.05)]" style={{ borderColor: UI.panelBorder }}>
-      <div className="grid gap-4 lg:grid-cols-[310px_1fr]">
-        <LibraryWeaponPickerTile selectedIds={selectedWeaponIds} selectedCount={selectedWeaponCount} onOpenPicker={onOpenWeaponPicker} />
-        <div className="grid gap-3">
-          <div className="grid gap-3 lg:grid-cols-3">
-            <CostBracketSelector value={filters.costBracket} onChange={(value) => onChange((current) => ({ ...current, costBracket: value }))} />
-            <MaxValueSelector title="最大凸数" prefix="C" max={6} value={filters.maxConstellation} onChange={(value) => onChange((current) => ({ ...current, maxConstellation: value }))} />
-            <MaxValueSelector title="最大精錬" prefix="R" min={1} max={5} value={filters.maxFiveStarRefinement} onChange={(value) => onChange((current) => ({ ...current, maxFiveStarRefinement: value }))} />
-          </div>
-          <div className="grid gap-3 xl:grid-cols-3">
-            <RangeFilterControl title="キャラCost" value={filters.charCostRange} limit={BUILD_RANGE_LIMITS.charCost} onChange={(range) => updateRange("charCostRange", range)} />
-            <RangeFilterControl title="武器Cost" value={filters.weaponCostRange} limit={BUILD_RANGE_LIMITS.weaponCost} onChange={(range) => updateRange("weaponCostRange", range)} />
-            <RangeFilterControl title="星5武器装備数" value={filters.fiveStarWeaponCountRange} limit={BUILD_RANGE_LIMITS.fiveStarWeaponCount} onChange={(range) => updateRange("fiveStarWeaponCountRange", range)} />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function LibraryWeaponPickerTile({ selectedIds, selectedCount, onOpenPicker }: { selectedIds: string[]; selectedCount: number; onOpenPicker: () => void }) {
-  const hasSelection = selectedCount > 0;
-
-  return (
-    <button type="button" onClick={onOpenPicker} className="group flex min-h-[128px] items-center gap-4 rounded-[8px] border bg-[#f6f6f6] p-4 text-left transition hover:bg-[#f1f1f1] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50" style={{ borderColor: UI.panelBorder }}>
-      <span className="grid h-[96px] w-[96px] shrink-0 place-items-center overflow-hidden rounded-[8px] bg-white">
-        {hasSelection ? (
-          <span className="grid w-full grid-cols-2 gap-1 p-2">
-            {selectedIds.map((weaponId) => {
-              const weapon = weaponDb[weaponId];
-              return weapon ? (
-                <span key={weaponId} className="grid h-9 w-9 place-items-center overflow-hidden rounded-[8px] bg-[#eef0f4]">
-                  <WeaponIcon imageUrl={weapon.imageUrl} alt={weapon.name} fallbackLabel={weapon.shortLabel} size={34} className="p-1" />
-                </span>
-              ) : null;
-            })}
-          </span>
-        ) : (
-          <span className="text-[76px] font-normal leading-none text-[#c2c2c2] transition group-hover:text-[#a9a9b5]">+</span>
-        )}
-      </span>
-      <span className="min-w-0">
-        <span className="block text-[18px] font-black tracking-[0.02em] text-[#333333]">{hasSelection ? "武器条件を編集" : "武器条件を選択"}</span>
-        <span className="mt-2 block text-[12px] font-bold leading-5 text-[#777777]">{hasSelection ? `${selectedCount}件の武器条件を選択中` : "具体的な武器を含める/除外する条件として指定できます。"}</span>
-      </span>
-    </button>
   );
 }
 
@@ -636,164 +650,6 @@ function CombinedWeaponSummaryBox({ includeIds, excludeIds, onRemove }: { includ
   );
 }
 
-function LibraryWeaponFilterDrawer({
-  isOpen,
-  initialWeaponIds,
-  onClose,
-  onApply,
-}: {
-  isOpen: boolean;
-  initialWeaponIds: LibraryBuildFilterState["weaponIds"];
-  onClose: () => void;
-  onApply: (weaponIds: LibraryBuildFilterState["weaponIds"]) => void;
-}) {
-  const [draft, setDraft] = useState<LibraryBuildFilterState["weaponIds"]>(initialWeaponIds);
-  const [activeTarget, setActiveTarget] = useState<WeaponSummaryTarget>("include");
-  const [query, setQuery] = useState("");
-  const [classFilter, setClassFilter] = useState<(typeof WEAPON_CLASS_FILTER_OPTIONS)[number]["key"]>("all");
-  const [tierFilter, setTierFilter] = useState<(typeof WEAPON_TIER_FILTER_OPTIONS)[number]["key"]>("all");
-
-  const filteredWeapons = useMemo(() => {
-    const normalizedQuery = query.trim().toLowerCase();
-    return selectableWeapons.filter((weapon) => {
-      const matchesClass = classFilter === "all" || weapon.weaponClass === classFilter;
-      const matchesTier = tierFilter === "all" || weapon.tier === tierFilter;
-      const matchesQuery = normalizedQuery.length === 0 || weapon.name.toLowerCase().includes(normalizedQuery) || weapon.id.toLowerCase().includes(normalizedQuery) || weapon.shortLabel.toLowerCase().includes(normalizedQuery);
-      return matchesClass && matchesTier && matchesQuery;
-    });
-  }, [classFilter, query, tierFilter]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    setDraft({ include: [...initialWeaponIds.include], exclude: [...initialWeaponIds.exclude] });
-    setActiveTarget("include");
-    setQuery("");
-    setClassFilter("all");
-    setTierFilter("all");
-  }, [initialWeaponIds, isOpen]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const previousBodyOverflow = document.body.style.overflow;
-    const previousHtmlOverflow = document.documentElement.style.overflow;
-    document.body.style.overflow = "hidden";
-    document.documentElement.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = previousBodyOverflow;
-      document.documentElement.style.overflow = previousHtmlOverflow;
-    };
-  }, [isOpen]);
-
-  if (!isOpen) return null;
-
-  const toggleWeapon = (weaponId: string) => {
-    const oppositeTarget = activeTarget === "include" ? "exclude" : "include";
-    setDraft((current) => {
-      const exists = current[activeTarget].includes(weaponId);
-      return {
-        ...current,
-        [activeTarget]: exists ? current[activeTarget].filter((id) => id !== weaponId) : [...current[activeTarget], weaponId],
-        [oppositeTarget]: current[oppositeTarget].filter((id) => id !== weaponId),
-      };
-    });
-  };
-
-  return (
-    <div className="fixed inset-0 z-[72] bg-black/35 backdrop-blur-[2px]" onClick={onClose}>
-      <div className="absolute inset-y-0 right-0 flex w-full max-w-[720px] flex-col border-l border-[#e5e7eb] bg-white text-[#333333] shadow-[-24px_0_60px_rgba(31,41,55,0.16)]" onClick={(event) => event.stopPropagation()}>
-        <div className="shrink-0 border-b border-[#e5e7eb]">
-          <div className="flex items-start justify-between gap-4 px-5 pb-5 pt-8 md:px-6">
-            <div className="text-[24px] font-semibold text-[#111827]">武器条件を選択</div>
-            <button type="button" className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[#d8dde6] bg-[#f7f8fa] text-[#5f6678] transition-colors hover:bg-[#eef1f5] hover:text-[#111827]" onClick={onClose} aria-label="閉じる">
-              <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M6 6L18 18" />
-                <path d="M18 6L6 18" />
-              </svg>
-            </button>
-          </div>
-        </div>
-        <div className="flex-1 overflow-y-auto overscroll-contain px-5 py-6 md:px-6">
-          <div className="space-y-6">
-            <section className="space-y-4">
-              <div className="flex justify-center">
-                <div className="flex w-full max-w-[320px] items-center overflow-hidden rounded-full border border-[#d8dde6] bg-[#edf1f5] sm:max-w-[360px]" aria-label="Selection target">
-                  {(["include", "exclude"] as const).map((target) => (
-                    <button key={target} type="button" className={`flex-1 px-5 py-2 text-[13px] font-semibold transition-colors sm:px-7 ${activeTarget === target ? "bg-[#111827] text-white" : "bg-transparent text-[#5f6678] hover:bg-white hover:text-[#111827]"}`} onClick={() => setActiveTarget(target)}>
-                      {target === "include" ? "含める" : "除外する"} {draft[target].length}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            </section>
-            <section className="space-y-2">
-              <label className="relative block">
-                <SearchIcon size={16} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[#8d93a3]" />
-                <input type="text" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="武器名 / ID / 略称で検索" className="h-11 w-full rounded-[14px] border border-[#d8dde6] bg-[#f7f8fa] pl-11 pr-4 text-[14px] text-[#333333] placeholder:text-[#8d93a3] outline-none transition-colors focus:border-[#9aa7ba] focus:bg-white" />
-              </label>
-            </section>
-            <div className="flex flex-wrap gap-2">
-              {WEAPON_CLASS_FILTER_OPTIONS.map((option) => (
-                <button key={option.key} type="button" onClick={() => setClassFilter(option.key)} className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${classFilter === option.key ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"}`}>
-                  {option.label}
-                </button>
-              ))}
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {WEAPON_TIER_FILTER_OPTIONS.map((option) => (
-                <button key={option.key} type="button" onClick={() => setTierFilter(option.key)} className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${tierFilter === option.key ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"}`}>
-                  {option.label}
-                </button>
-              ))}
-            </div>
-            <div className="rounded-[16px] bg-[#f6f7f9] p-3">
-              {filteredWeapons.length === 0 ? (
-                <div className="grid min-h-[240px] place-items-center text-center text-[14px] text-[#7b7b8d]">条件に一致する武器がありません。</div>
-              ) : (
-                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                  {filteredWeapons.map((weapon) => {
-                    const isInclude = draft.include.includes(weapon.id);
-                    const isExclude = draft.exclude.includes(weapon.id);
-                    const isActive = activeTarget === "include" ? isInclude : isExclude;
-                    return (
-                      <button key={weapon.id} type="button" onClick={() => toggleWeapon(weapon.id)} className={`relative rounded-[16px] border bg-white p-4 text-left transition hover:-translate-y-[1px] ${isActive ? "border-[#0f1419] shadow-[0_6px_18px_rgba(0,0,0,0.08)]" : "border-transparent"}`}>
-                        <div className="flex items-start gap-3">
-                          <WeaponIcon imageUrl={weapon.imageUrl} alt={weapon.name} fallbackLabel={weapon.shortLabel} size={64} className="rounded-[14px] p-1.5" />
-                          <div className="min-w-0 flex-1">
-                            <div className="flex flex-wrap items-center gap-2">
-                              <div className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${getWeaponTierBadgeClass(weapon.tier)}`}>{formatWeaponTierLabel(weapon.tier)}</div>
-                              <div className="text-[12px] text-[#7b7b8d]">{formatWeaponClassLabel(weapon.weaponClass)}</div>
-                            </div>
-                            <div className="mt-2 text-[15px] font-semibold text-black">{weapon.name}</div>
-                            <div className="mt-1 text-[12px] text-[#7b7b8d]">{weapon.id}</div>
-                          </div>
-                        </div>
-                        {isInclude || isExclude ? (
-                          <span className={["absolute right-2 top-2 flex h-6 items-center rounded-full px-2 text-[11px] font-bold text-white", isExclude ? "bg-[#c27642]" : "bg-[#6bbbd0]"].join(" ")}>
-                            {isExclude ? "除外" : "含む"}
-                          </span>
-                        ) : null}
-                      </button>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-        <div className="grid shrink-0 grid-cols-[1fr_minmax(220px,360px)_1fr] items-center gap-3 border-t border-[#e5e7eb] px-5 py-4 md:px-6">
-          <button type="button" className="justify-self-start text-[13px] font-medium text-[#5f6678] underline decoration-[#c8ced8] underline-offset-4 hover:text-[#333333]" onClick={() => setDraft({ include: [], exclude: [] })}>
-            リセット
-          </button>
-          <button type="button" className="w-full rounded-full border border-[#111827] bg-[#111827] px-6 py-2.5 text-[13px] font-semibold text-white transition-colors hover:bg-[#263142]" onClick={() => onApply(draft)}>
-            適用する
-          </button>
-          <div aria-hidden="true" />
-        </div>
-      </div>
-    </div>
-  );
-}
-
 function LibraryFilterModal({
   activeKey,
   characterFilters,
@@ -843,8 +699,12 @@ function LibraryFilterModal({
     return <LibraryCharacterFilterModal title={panel.label} initialFilters={characterFilters} onClose={onClose} onApply={onApplyCharacter} />;
   }
 
-  if (activeKey === "build") {
-    return <LibraryBuildFilterModal title={panel.label} initialFilters={buildFilters} onClose={onClose} onApply={onApplyBuild} />;
+  if (activeKey === "weapon") {
+    return <LibraryWeaponFilterModal title={panel.label} initialFilters={buildFilters} onClose={onClose} onApply={onApplyBuild} />;
+  }
+
+  if (activeKey === "cost") {
+    return <LibraryCostFilterModal title={panel.label} initialFilters={buildFilters} onClose={onClose} onApply={onApplyBuild} />;
   }
 
   if (activeKey === "category") {
@@ -1096,7 +956,7 @@ function LibraryCharacterFilterModal({
   );
 }
 
-function LibraryBuildFilterModal({
+function LibraryWeaponFilterModal({
   title,
   initialFilters,
   onClose,
@@ -1108,7 +968,6 @@ function LibraryBuildFilterModal({
   onApply: (filters: LibraryBuildFilterState) => void;
 }) {
   const [draft, setDraft] = useState<LibraryBuildFilterState>(() => cloneLibraryBuildFilterState(initialFilters));
-  const [activeBuildTab, setActiveBuildTab] = useState<LibraryBuildFilterTab>("cost");
   const [activeTarget, setActiveTarget] = useState<WeaponSummaryTarget>("include");
   const [query, setQuery] = useState("");
   const [classFilter, setClassFilter] = useState<(typeof WEAPON_CLASS_FILTER_OPTIONS)[number]["key"]>("all");
@@ -1116,7 +975,6 @@ function LibraryBuildFilterModal({
 
   useEffect(() => {
     setDraft(cloneLibraryBuildFilterState(initialFilters));
-    setActiveBuildTab("cost");
     setActiveTarget("include");
     setQuery("");
     setClassFilter("all");
@@ -1132,10 +990,6 @@ function LibraryBuildFilterModal({
       return matchesClass && matchesTier && matchesQuery;
     });
   }, [classFilter, query, tierFilter]);
-
-  const updateRange = (key: "charCostRange" | "weaponCostRange" | "fiveStarWeaponCountRange", range: NumericRange) => {
-    setDraft((current) => ({ ...current, [key]: range }));
-  };
 
   const toggleWeapon = (weaponId: string) => {
     const oppositeTarget = activeTarget === "include" ? "exclude" : "include";
@@ -1163,8 +1017,7 @@ function LibraryBuildFilterModal({
   };
 
   const reset = () => {
-    setDraft(createEmptyLibraryBuildFilterState());
-    setActiveBuildTab("cost");
+    setDraft((current) => ({ ...current, weaponIds: { include: [], exclude: [] } }));
     setActiveTarget("include");
     setQuery("");
     setClassFilter("all");
@@ -1173,106 +1026,124 @@ function LibraryBuildFilterModal({
 
   return (
     <LibraryModalFrame title={title} onClose={onClose} onReset={reset} onApply={() => onApply(cloneLibraryBuildFilterState(draft))}>
-      <div className="space-y-5">
-        <div className="border-b border-[#e5e7eb]">
-          <div className="flex items-end justify-between overflow-x-auto px-1 pb-0 text-[13px] font-semibold md:text-[14px]">
-            {LIBRARY_BUILD_FILTER_TABS.map((tab) => (
-              <button
-                key={tab.key}
-                type="button"
-                onClick={() => setActiveBuildTab(tab.key)}
-                className={`-mb-px flex-1 shrink-0 border-b-2 pb-4 text-center transition-colors ${
-                  activeBuildTab === tab.key ? "border-[#111827] text-[#111827]" : "border-transparent text-[#8d93a3] hover:text-[#333333]"
-                }`}
-              >
-                {tab.label}
-              </button>
-            ))}
+      <section className="rounded-[18px] border border-[#e5e7eb] bg-[#f7f8fa] p-4">
+        <div className="grid gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
+          <div className="space-y-4">
+            <div className="flex items-center overflow-hidden rounded-full border border-[#d8dde6] bg-[#edf1f5]">
+              {(["include", "exclude"] as const).map((target) => (
+                <button key={target} type="button" className={`flex-1 px-5 py-2 text-[13px] font-semibold transition-colors ${activeTarget === target ? "bg-[#111827] text-white" : "bg-transparent text-[#5f6678] hover:bg-white hover:text-[#111827]"}`} onClick={() => setActiveTarget(target)}>
+                  {target === "include" ? "含める" : "除外する"} {draft.weaponIds[target].length}
+                </button>
+              ))}
+            </div>
+            <CombinedWeaponSummaryBox includeIds={draft.weaponIds.include} excludeIds={draft.weaponIds.exclude} onRemove={removeWeapon} />
+          </div>
+          <div className="min-w-0 space-y-3">
+            <label className="relative block">
+              <SearchIcon size={16} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[#8d93a3]" />
+              <input type="text" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="武器名 / ID / 略称で検索" className="h-11 w-full rounded-[14px] border border-[#d8dde6] bg-white pl-11 pr-4 text-[14px] text-[#333333] placeholder:text-[#8d93a3] outline-none transition-colors focus:border-[#9aa7ba]" />
+            </label>
+            <div className="flex flex-wrap gap-2">
+              {WEAPON_CLASS_FILTER_OPTIONS.map((option) => (
+                <button key={option.key} type="button" onClick={() => setClassFilter(option.key)} className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${classFilter === option.key ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"}`}>
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {WEAPON_TIER_FILTER_OPTIONS.map((option) => (
+                <button key={option.key} type="button" onClick={() => setTierFilter(option.key)} className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${tierFilter === option.key ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"}`}>
+                  {option.label}
+                </button>
+              ))}
+            </div>
+            <div className="max-h-[430px] overflow-y-auto rounded-[16px] bg-white p-3">
+              {filteredWeapons.length === 0 ? (
+                <div className="grid min-h-[220px] place-items-center text-center text-[14px] text-[#7b7b8d]">条件に一致する武器がありません。</div>
+              ) : (
+                <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+                  {filteredWeapons.map((weapon) => {
+                    const isInclude = draft.weaponIds.include.includes(weapon.id);
+                    const isExclude = draft.weaponIds.exclude.includes(weapon.id);
+                    const isActive = activeTarget === "include" ? isInclude : isExclude;
+                    return (
+                      <button key={weapon.id} type="button" onClick={() => toggleWeapon(weapon.id)} className={`relative rounded-[16px] border bg-white p-4 text-left transition hover:-translate-y-[1px] ${isActive ? "border-[#0f1419] shadow-[0_6px_18px_rgba(0,0,0,0.08)]" : "border-[#edf0f4]"}`}>
+                        <div className="flex items-start gap-3">
+                          <WeaponIcon imageUrl={weapon.imageUrl} alt={weapon.name} fallbackLabel={weapon.shortLabel} size={58} className="rounded-[14px] p-1.5" />
+                          <div className="min-w-0 flex-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <div className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${getWeaponTierBadgeClass(weapon.tier)}`}>{formatWeaponTierLabel(weapon.tier)}</div>
+                              <div className="text-[12px] text-[#7b7b8d]">{formatWeaponClassLabel(weapon.weaponClass)}</div>
+                            </div>
+                            <div className="mt-2 text-[14px] font-semibold text-black">{weapon.name}</div>
+                            <div className="mt-1 text-[12px] text-[#7b7b8d]">{weapon.id}</div>
+                          </div>
+                        </div>
+                        {isInclude || isExclude ? (
+                          <span className={["absolute right-2 top-2 flex h-6 items-center rounded-full px-2 text-[11px] font-bold text-white", isExclude ? "bg-[#c27642]" : "bg-[#6bbbd0]"].join(" ")}>
+                            {isExclude ? "除外" : "含む"}
+                          </span>
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
           </div>
         </div>
+      </section>
+    </LibraryModalFrame>
+  );
+}
 
-        {activeBuildTab === "cost" ? (
-          <div className="space-y-4">
-            <div className="grid gap-3 lg:grid-cols-3">
-              <CostBracketSelector value={draft.costBracket} onChange={(value) => setDraft((current) => ({ ...current, costBracket: value }))} />
-              <MaxValueSelector title="最大凸数" prefix="C" max={6} value={draft.maxConstellation} onChange={(value) => setDraft((current) => ({ ...current, maxConstellation: value }))} />
-              <MaxValueSelector title="最大精錬" prefix="R" min={1} max={5} value={draft.maxFiveStarRefinement} onChange={(value) => setDraft((current) => ({ ...current, maxFiveStarRefinement: value }))} />
-            </div>
-            <div className="grid gap-3 xl:grid-cols-3">
-              <RangeFilterControl title="キャラCost" value={draft.charCostRange} limit={BUILD_RANGE_LIMITS.charCost} onChange={(range) => updateRange("charCostRange", range)} />
-              <RangeFilterControl title="武器Cost" value={draft.weaponCostRange} limit={BUILD_RANGE_LIMITS.weaponCost} onChange={(range) => updateRange("weaponCostRange", range)} />
-              <RangeFilterControl title="星5武器装備数" value={draft.fiveStarWeaponCountRange} limit={BUILD_RANGE_LIMITS.fiveStarWeaponCount} onChange={(range) => updateRange("fiveStarWeaponCountRange", range)} />
-            </div>
-          </div>
-        ) : (
-          <section className="rounded-[18px] border border-[#e5e7eb] bg-[#f7f8fa] p-4">
-            <div className="grid gap-4 lg:grid-cols-[260px_minmax(0,1fr)]">
-              <div className="space-y-4">
-                <div className="flex items-center overflow-hidden rounded-full border border-[#d8dde6] bg-[#edf1f5]">
-                  {(["include", "exclude"] as const).map((target) => (
-                    <button key={target} type="button" className={`flex-1 px-5 py-2 text-[13px] font-semibold transition-colors ${activeTarget === target ? "bg-[#111827] text-white" : "bg-transparent text-[#5f6678] hover:bg-white hover:text-[#111827]"}`} onClick={() => setActiveTarget(target)}>
-                      {target === "include" ? "含める" : "除外する"} {draft.weaponIds[target].length}
-                    </button>
-                  ))}
-                </div>
-                <CombinedWeaponSummaryBox includeIds={draft.weaponIds.include} excludeIds={draft.weaponIds.exclude} onRemove={removeWeapon} />
-              </div>
-              <div className="min-w-0 space-y-3">
-                <label className="relative block">
-                  <SearchIcon size={16} className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-[#8d93a3]" />
-                  <input type="text" value={query} onChange={(event) => setQuery(event.target.value)} placeholder="武器名 / ID / 略称で検索" className="h-11 w-full rounded-[14px] border border-[#d8dde6] bg-white pl-11 pr-4 text-[14px] text-[#333333] placeholder:text-[#8d93a3] outline-none transition-colors focus:border-[#9aa7ba]" />
-                </label>
-                <div className="flex flex-wrap gap-2">
-                  {WEAPON_CLASS_FILTER_OPTIONS.map((option) => (
-                    <button key={option.key} type="button" onClick={() => setClassFilter(option.key)} className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${classFilter === option.key ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"}`}>
-                      {option.label}
-                    </button>
-                  ))}
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  {WEAPON_TIER_FILTER_OPTIONS.map((option) => (
-                    <button key={option.key} type="button" onClick={() => setTierFilter(option.key)} className={`inline-flex min-h-8 items-center rounded-full border px-3 py-1.5 text-[12px] font-medium transition-colors ${tierFilter === option.key ? "border-transparent bg-[#111827] text-white" : "border-[#d8dde6] bg-white text-[#5f6678] hover:bg-[#eef1f5] hover:text-[#333333]"}`}>
-                      {option.label}
-                    </button>
-                  ))}
-                </div>
-                <div className="max-h-[430px] overflow-y-auto rounded-[16px] bg-white p-3">
-                  {filteredWeapons.length === 0 ? (
-                    <div className="grid min-h-[220px] place-items-center text-center text-[14px] text-[#7b7b8d]">条件に一致する武器がありません。</div>
-                  ) : (
-                    <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-                      {filteredWeapons.map((weapon) => {
-                        const isInclude = draft.weaponIds.include.includes(weapon.id);
-                        const isExclude = draft.weaponIds.exclude.includes(weapon.id);
-                        const isActive = activeTarget === "include" ? isInclude : isExclude;
-                        return (
-                          <button key={weapon.id} type="button" onClick={() => toggleWeapon(weapon.id)} className={`relative rounded-[16px] border bg-white p-4 text-left transition hover:-translate-y-[1px] ${isActive ? "border-[#0f1419] shadow-[0_6px_18px_rgba(0,0,0,0.08)]" : "border-[#edf0f4]"}`}>
-                            <div className="flex items-start gap-3">
-                              <WeaponIcon imageUrl={weapon.imageUrl} alt={weapon.name} fallbackLabel={weapon.shortLabel} size={58} className="rounded-[14px] p-1.5" />
-                              <div className="min-w-0 flex-1">
-                                <div className="flex flex-wrap items-center gap-2">
-                                  <div className={`rounded-full px-2.5 py-1 text-[11px] font-semibold ${getWeaponTierBadgeClass(weapon.tier)}`}>{formatWeaponTierLabel(weapon.tier)}</div>
-                                  <div className="text-[12px] text-[#7b7b8d]">{formatWeaponClassLabel(weapon.weaponClass)}</div>
-                                </div>
-                                <div className="mt-2 text-[14px] font-semibold text-black">{weapon.name}</div>
-                                <div className="mt-1 text-[12px] text-[#7b7b8d]">{weapon.id}</div>
-                              </div>
-                            </div>
-                            {isInclude || isExclude ? (
-                              <span className={["absolute right-2 top-2 flex h-6 items-center rounded-full px-2 text-[11px] font-bold text-white", isExclude ? "bg-[#c27642]" : "bg-[#6bbbd0]"].join(" ")}>
-                                {isExclude ? "除外" : "含む"}
-                              </span>
-                            ) : null}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-              </div>
-            </div>
-          </section>
-        )}
+function LibraryCostFilterModal({
+  title,
+  initialFilters,
+  onClose,
+  onApply,
+}: {
+  title: string;
+  initialFilters: LibraryBuildFilterState;
+  onClose: () => void;
+  onApply: (filters: LibraryBuildFilterState) => void;
+}) {
+  const [draft, setDraft] = useState<LibraryBuildFilterState>(() => cloneLibraryBuildFilterState(initialFilters));
+
+  useEffect(() => {
+    setDraft(cloneLibraryBuildFilterState(initialFilters));
+  }, [initialFilters]);
+
+  const updateRange = (key: "charCostRange" | "weaponCostRange" | "fiveStarWeaponCountRange", range: NumericRange) => {
+    setDraft((current) => ({ ...current, [key]: range }));
+  };
+
+  const reset = () => {
+    const emptyFilters = createEmptyLibraryBuildFilterState();
+    setDraft((current) => ({
+      ...current,
+      costBracket: emptyFilters.costBracket,
+      charCostRange: emptyFilters.charCostRange,
+      weaponCostRange: emptyFilters.weaponCostRange,
+      fiveStarWeaponCountRange: emptyFilters.fiveStarWeaponCountRange,
+      maxConstellation: emptyFilters.maxConstellation,
+      maxFiveStarRefinement: emptyFilters.maxFiveStarRefinement,
+    }));
+  };
+
+  return (
+    <LibraryModalFrame title={title} onClose={onClose} onReset={reset} onApply={() => onApply(cloneLibraryBuildFilterState(draft))}>
+      <div className="space-y-4">
+        <div className="grid gap-3 lg:grid-cols-3">
+          <MaxValueSelector title="最大凸数" prefix="C" max={6} value={draft.maxConstellation} onChange={(value) => setDraft((current) => ({ ...current, maxConstellation: value }))} />
+          <MaxValueSelector title="最大精錬" prefix="R" min={1} max={5} value={draft.maxFiveStarRefinement} onChange={(value) => setDraft((current) => ({ ...current, maxFiveStarRefinement: value }))} />
+          <CostBracketSelector value={draft.costBracket} onChange={(value) => setDraft((current) => ({ ...current, costBracket: value }))} />
+        </div>
+        <div className="grid gap-3 xl:grid-cols-3">
+          <RangeFilterControl title="キャラCost" value={draft.charCostRange} limit={BUILD_RANGE_LIMITS.charCost} onChange={(range) => updateRange("charCostRange", range)} />
+          <RangeFilterControl title="武器Cost" value={draft.weaponCostRange} limit={BUILD_RANGE_LIMITS.weaponCost} onChange={(range) => updateRange("weaponCostRange", range)} />
+          <RangeFilterControl title="星5武器装備数" value={draft.fiveStarWeaponCountRange} limit={BUILD_RANGE_LIMITS.fiveStarWeaponCount} onChange={(range) => updateRange("fiveStarWeaponCountRange", range)} />
+        </div>
       </div>
     </LibraryModalFrame>
   );
@@ -1367,10 +1238,6 @@ function LibraryTagFilterModal({
   );
 }
 
-function getUniqueSelectedWeaponIds(filters: LibraryBuildFilterState) {
-  return Array.from(new Set([...filters.weaponIds.include, ...filters.weaponIds.exclude]));
-}
-
 function filterChipClass(isExclude: boolean) {
   return [
     "inline-flex h-8 max-w-full items-center justify-center gap-1.5 rounded-full px-2.5 text-[11px] font-medium transition-colors",
@@ -1401,149 +1268,6 @@ function getWeaponTierBadgeClass(tier: WeaponTier) {
     case "one_star":
       return "bg-[#f2f2f2] text-[#6d6d7d]";
   }
-}
-
-function FilterCardBar({
-  activeKey,
-  onPanelClick,
-  variant,
-  className,
-}: {
-  activeKey: SelectableFilterKey | null;
-  onPanelClick: (key: LibraryFilterKey) => void;
-  variant: "desktop" | "mobile";
-  className?: string;
-}) {
-  const isMobile = variant === "mobile";
-
-  return (
-    <div className={[isMobile ? "" : "no-scrollbar overflow-x-auto", className].filter(Boolean).join(" ")} role="group" aria-label={LIBRARY_LABELS.searchTitle}>
-      <div
-        className={
-          isMobile
-            ? "grid grid-cols-1 gap-px overflow-hidden border border-black/25 bg-[#08080c] shadow-[0_14px_30px_rgba(15,23,42,0.18)]"
-            : "grid min-w-[932px] grid-cols-[repeat(4,210px)_92px] gap-px overflow-hidden border border-black/25 bg-[#08080c] shadow-[0_14px_30px_rgba(15,23,42,0.18)] sm:min-w-0 sm:grid-cols-[repeat(4,minmax(0,1fr))_minmax(92px,0.42fr)]"
-        }
-      >
-        {LIBRARY_FILTER_PANELS.map((panel) => {
-          const isSearch = panel.key === "search";
-          const isActive = !isSearch && panel.key === activeKey;
-          const backgroundColor = getFilterCardBackgroundColor(panel);
-
-          return (
-            <button
-              key={panel.key}
-              type="button"
-              aria-pressed={isSearch ? undefined : isActive}
-              onClick={() => onPanelClick(panel.key)}
-              className={[
-                isMobile
-                  ? "group relative h-[58px] overflow-hidden text-[#d9d9d9] outline-none transition focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/75"
-                  : "group relative h-[138px] overflow-hidden text-[#d9d9d9] outline-none transition focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/75 sm:h-[168px] md:h-[190px]",
-                isActive ? "ring-2 ring-inset ring-white/70" : "",
-              ].join(" ")}
-              style={
-                {
-                  backgroundColor,
-                } as CSSProperties
-              }
-            >
-              {renderFilterCardContent(panel, variant)}
-            </button>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-function getFilterCardBackgroundColor(panel: LibraryFilterPanel) {
-  return isSelectableFilterPanel(panel) ? DESKTOP_FILTER_CARD_META[panel.key].backgroundColor : "#111116";
-}
-
-function renderFilterCardContent(panel: LibraryFilterPanel, variant: "desktop" | "mobile") {
-  if (isSearchFilterPanel(panel)) {
-    return <SearchFilterCardContent panel={panel} variant={variant} />;
-  }
-
-  if (isSelectableFilterPanel(panel)) {
-    return <SelectableFilterCardContent panel={panel} variant={variant} />;
-  }
-
-  return null;
-}
-
-function SelectableFilterCardContent({ panel, variant }: { panel: SelectableFilterPanel; variant: "desktop" | "mobile" }) {
-  const meta = DESKTOP_FILTER_CARD_META[panel.key];
-  const details = FILTER_CARD_DETAILS[panel.key];
-
-  if (variant === "mobile") {
-    return (
-      <>
-        <img
-          src={meta.imageUrl}
-          alt=""
-          className="absolute inset-0 h-full w-full scale-[1.05] object-cover opacity-[0.62] transition duration-300 group-hover:scale-[1.09] group-hover:opacity-80 group-focus-visible:scale-[1.09] group-focus-visible:opacity-80"
-          style={{ objectPosition: meta.objectPosition }}
-          loading="lazy"
-        />
-        <span className={`absolute inset-0 transition-colors duration-200 ${FILTER_CARD_DIM_CLASS}`} />
-        <span className="relative z-10 flex h-full min-w-0 items-center gap-2.5 px-4 text-left">
-          <span className="shrink-0 text-[18px] font-black leading-none text-[#d9d9d9]/[0.9] drop-shadow-[0_2px_8px_rgba(0,0,0,0.55)]">{details.number}</span>
-          <span className="flex min-w-0 items-baseline gap-2">
-            <span className="shrink-0 whitespace-nowrap text-[16px] font-black leading-none tracking-[0.02em] text-white drop-shadow-[0_2px_10px_rgba(0,0,0,0.65)]">{panel.label}</span>
-            <span className="min-w-0 truncate text-[10px] font-black uppercase leading-none tracking-[0.08em] text-[#d9d9d9]/75">{details.subLabel}</span>
-          </span>
-        </span>
-      </>
-    );
-  }
-
-  return (
-    <>
-      <img
-        src={meta.imageUrl}
-        alt=""
-        className="absolute inset-0 h-full w-full scale-[1.08] object-cover opacity-[0.72] transition duration-300 group-hover:scale-[1.13] group-hover:opacity-90 group-focus-visible:scale-[1.13] group-focus-visible:opacity-90"
-        style={{ objectPosition: meta.objectPosition }}
-        loading="lazy"
-      />
-      <span className={`absolute inset-0 transition-colors duration-200 ${FILTER_CARD_DIM_CLASS}`} />
-      <span className="absolute left-4 top-4 z-10 text-[22px] font-black leading-none text-[#d9d9d9]/[0.88] drop-shadow-[0_2px_8px_rgba(0,0,0,0.55)] sm:left-5 sm:top-5 sm:text-[24px]">
-        {details.number}
-      </span>
-      <span className="relative z-10 flex h-full translate-y-0.5 items-end px-4 pb-5 pt-16 text-left sm:px-5 sm:pb-6">
-        <span className="min-w-0">
-          <span className="block whitespace-nowrap text-[19px] font-black leading-tight tracking-[0.02em] text-white drop-shadow-[0_2px_10px_rgba(0,0,0,0.65)]">{panel.label}</span>
-          <span className="mt-1 block text-[11px] font-black uppercase leading-none tracking-[0.08em] text-[#d9d9d9]/75">{details.subLabel}</span>
-        </span>
-      </span>
-    </>
-  );
-}
-
-function SearchFilterCardContent({ panel, variant }: { panel: SearchFilterPanel; variant: "desktop" | "mobile" }) {
-  if (variant === "mobile") {
-    return (
-      <>
-        <span className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.10),rgba(255,255,255,0)_48%)] opacity-75 transition duration-300 group-hover:opacity-100 group-focus-visible:opacity-100" />
-        <span className="relative z-10 flex h-full items-center justify-center gap-2.5 px-4 text-center">
-          <SearchIcon size={22} className="text-[#d9d9d9] drop-shadow-[0_8px_20px_rgba(0,0,0,0.4)] transition duration-300 group-hover:text-white group-focus-visible:text-white" />
-          <span className="text-[16px] font-black leading-none tracking-[0.02em] text-white">{panel.label}</span>
-        </span>
-      </>
-    );
-  }
-
-  return (
-    <>
-      <span className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.10),rgba(255,255,255,0)_48%)] opacity-75 transition duration-300 group-hover:opacity-100 group-focus-visible:opacity-100" />
-      <span className="relative z-10 flex h-full flex-col items-center justify-center gap-3 px-4 text-center">
-        <SearchIcon size={38} className="text-[#d9d9d9] drop-shadow-[0_8px_20px_rgba(0,0,0,0.4)] transition duration-300 group-hover:text-white group-focus-visible:text-white" />
-        <span className="text-[22px] font-black leading-none tracking-[0.02em] text-white sm:text-[23px]">{panel.label}</span>
-      </span>
-    </>
-  );
 }
 
 function ResponsiveStyle() {

--- a/src/features/library/sections/Hero.tsx
+++ b/src/features/library/sections/Hero.tsx
@@ -16,7 +16,7 @@ export function LibraryHero({ imageUrl, backgroundColor, ariaLabel, keyword, onK
       style={{ backgroundColor, backgroundImage: `url(${imageUrl})` }}
       aria-label={ariaLabel}
     >
-      <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.08)_0%,rgba(0,0,0,0)_52%,rgba(242,243,245,0.46)_78%,#f2f3f5_100%)]" />
+      <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.08)_0%,rgba(0,0,0,0)_52%,rgba(237,236,236,0.46)_78%,#EDECEC_100%)]" />
       <div className="absolute left-1/2 top-4 w-[90%] max-w-4xl -translate-x-1/2 rounded-full border border-white/30 bg-black/15 px-4 py-2 backdrop-blur-sm">
         <label className="flex h-9 items-center gap-3 text-white md:h-10">
           <SearchIcon size={18} className="shrink-0 text-white/80" />
@@ -33,7 +33,7 @@ export function LibraryHero({ imageUrl, backgroundColor, ariaLabel, keyword, onK
           />
         </label>
       </div>
-      <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-b from-transparent to-[#f2f3f5]" />
+      <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-b from-transparent to-[#EDECEC]" />
     </section>
   );
 }

--- a/src/features/library/sections/LibraryCompareDrawer.tsx
+++ b/src/features/library/sections/LibraryCompareDrawer.tsx
@@ -70,7 +70,7 @@ export function LibraryCompareDrawer({
   };
 
   return (
-    <div className="fixed inset-x-0 bottom-0 top-[80px] z-40 hidden bg-[#f5f6f8] text-[#333333] shadow-[0_-20px_40px_rgba(31,41,55,0.18)] lg:block" aria-modal="false" role="complementary">
+    <div className="fixed inset-x-0 bottom-0 top-[80px] z-40 hidden bg-[#EDECEC] text-[#333333] shadow-[0_-20px_40px_rgba(31,41,55,0.18)] lg:block" aria-modal="false" role="complementary">
       <div className="flex h-full flex-col border-t border-[#e5e7eb]">
         <div className="flex min-h-[52px] items-center justify-between border-b border-[#e5e7eb] bg-white px-4 py-2">
           <div className="min-w-0">
@@ -109,7 +109,7 @@ function LibraryCompareRunPane({
   const partyBuildItems = getPartyBuildItems(run);
 
   return (
-    <div className="min-h-0 overflow-y-auto bg-[#f5f6f8] px-3 py-3">
+    <div className="min-h-0 overflow-y-auto bg-[#EDECEC] px-3 py-3">
       <div className="mb-3 inline-flex rounded-full border border-[#d8dde6] bg-white px-3 py-1 text-[12px] font-black text-[#5f6678]">{label}</div>
       <VideoFrame title={run.title} videoUrl={run.videoUrl} iframeRef={iframeRef} mute={muted} />
       <div className="mt-4 flex flex-col gap-[12px]">

--- a/src/features/library/types.ts
+++ b/src/features/library/types.ts
@@ -2,16 +2,11 @@ import type { Bracket } from "../../data/mockRuns";
 import type { HomeFilterState } from "../home/types";
 
 export type NumericRange = { min: number; max: number };
-export type LibraryFilterKey = "character" | "build" | "category" | "tag" | "search";
+export type LibraryFilterKey = "character" | "weapon" | "cost" | "category" | "tag" | "search";
 export type SelectableFilterKey = Exclude<LibraryFilterKey, "search">;
-export type SearchFilterKey = Extract<LibraryFilterKey, "search">;
-export type LibraryFilterPanel = { key: LibraryFilterKey; label: string; icon: string };
-export type SelectableFilterPanel = LibraryFilterPanel & { key: SelectableFilterKey };
-export type SearchFilterPanel = LibraryFilterPanel & { key: SearchFilterKey };
 export type CharacterSummaryGroup = "partyCharacters" | "mainAttackers";
 export type CharacterSummaryTarget = "include" | "exclude";
 export type WeaponSummaryTarget = "include" | "exclude";
-export type LibraryBuildFilterTab = "cost" | "weapon";
 
 export type LibraryCategoryFilterState = {
   ruleset: string;

--- a/src/features/lp/sections/WhatYouCanDoSection.tsx
+++ b/src/features/lp/sections/WhatYouCanDoSection.tsx
@@ -320,7 +320,7 @@ function FeatureCardBody({ feature, layout }: { feature: LpFeatureCard; layout: 
         </div>
 
         <div
-          className="max-w-[900px] pl-[52px] pr-2 text-[24px] font-bold leading-[40px] tracking-[1.2px] text-[#333333]"
+          className="max-w-[900px] pl-[52px] pr-2 text-[24px] font-bold leading-[40px] tracking-[1.2px] text-[#333333] max-[640px]:max-w-[760px] max-[640px]:text-[34px] max-[640px]:leading-[48px] max-[640px]:tracking-[1.4px]"
           style={{ fontFamily: '"Zen Kaku Gothic New", "Noto Sans JP", sans-serif' }}
         >
           {feature.body.map((line) => (

--- a/src/features/recordDetail/Page.tsx
+++ b/src/features/recordDetail/Page.tsx
@@ -171,7 +171,7 @@ export function RecordDetailPage({
 
   return (
     <>
-      <main className={`bg-[#f5f6f8] text-[#333333] transition-[width] duration-300 ${mainSurfaceClass}`}>
+      <main className={`bg-[#EDECEC] text-[#333333] transition-[width] duration-300 ${mainSurfaceClass}`}>
         <Header
           embedded={embedded}
           forceMobileLayout={forceMobileLayout}

--- a/src/features/recordDetail/config.ts
+++ b/src/features/recordDetail/config.ts
@@ -8,7 +8,7 @@ export const collapsedCopyStyle: CSSProperties = {
 };
 
 export const DETAIL_PANEL_SHELL_CLASS =
-  "relative overflow-hidden rounded-[20px] bg-[linear-gradient(135deg,#ffffff_0%,#f1eadf_34%,#dfe8f2_68%,#f8f6f1_100%)] shadow-[0_18px_34px_rgba(37,44,58,0.10)]";
-export const DETAIL_PANEL_INNER_CLASS = "relative z-[1] m-[2px] rounded-[18px] bg-white text-[#333333]";
-export const DETAIL_MUTED_SURFACE_CLASS = "rounded-[16px] border border-[#e5e7eb] bg-[#f7f8fa]";
+  "relative overflow-hidden rounded-[20px] bg-[#f4f3f1] shadow-[0_18px_34px_rgba(37,44,58,0.10)]";
+export const DETAIL_PANEL_INNER_CLASS = "relative z-[1] m-[2px] rounded-[18px] bg-[#f4f3f1] text-[#333333]";
+export const DETAIL_MUTED_SURFACE_CLASS = "rounded-[16px] border border-[#e5e7eb] bg-[#FFFCF9]";
 export const DETAIL_LIKE_ACTIVE_ICON_CLASS = "text-[#ff8ea1]";

--- a/src/features/recordDetail/sections/CompareDrawer.tsx
+++ b/src/features/recordDetail/sections/CompareDrawer.tsx
@@ -21,7 +21,7 @@ function CompareRunPane({ run, iframeRef }: { run: RunRecord; iframeRef: React.R
   const partyBuildItems = getPartyBuildItems(run);
 
   return (
-    <div className="flex min-h-full flex-col gap-[16px] bg-[#f5f6f8] px-3 py-3 text-[#333333]">
+    <div className="flex min-h-full flex-col gap-[16px] bg-[#EDECEC] px-3 py-3 text-[#333333]">
       <VideoFrame title={run.title} videoUrl={run.videoUrl} iframeRef={iframeRef} mute />
 
       <div className="flex flex-col gap-[12px]">
@@ -124,7 +124,7 @@ export function CompareDrawer({
 
   return (
     <div className={embedded ? "fixed top-[80px] right-0 bottom-0 z-20 hidden lg:block" : "fixed inset-y-0 right-0 z-50 hidden lg:block"} aria-modal="false" role="complementary">
-      <div className="flex h-full w-[50vw] flex-col border-l border-[#e5e7eb] bg-[#f5f6f8] shadow-[-20px_0_40px_rgba(31,41,55,0.16)]">
+      <div className="flex h-full w-[50vw] flex-col border-l border-[#e5e7eb] bg-[#EDECEC] shadow-[-20px_0_40px_rgba(31,41,55,0.16)]">
         <div className="flex min-h-[52px] items-center justify-between border-b border-[#e5e7eb] bg-white px-4 py-2">
           <div className="min-w-0">
             <div className="text-[16px] font-semibold text-[#111827] md:text-[18px]">比較ビュー</div>
@@ -153,7 +153,7 @@ export function CompareDrawer({
           </div>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-y-auto bg-[#f5f6f8]">
+        <div className="min-h-0 flex-1 overflow-y-auto bg-[#EDECEC]">
           <CompareRunPane run={comparedRun} iframeRef={comparedIframeRef} />
         </div>
       </div>

--- a/src/features/recordDetail/sections/Sidebar.tsx
+++ b/src/features/recordDetail/sections/Sidebar.tsx
@@ -64,7 +64,7 @@ export function Sidebar({
               })}
             </div>
           ) : (
-            <div className="rounded-[16px] border border-dashed border-[#d8dde6] bg-[#f7f8fa] px-[14px] py-[16px] text-[13px] leading-[1.7] text-[#8d93a3]">
+            <div className="rounded-[16px] border border-dashed border-[#d8dde6] bg-[#FFFCF9] px-[14px] py-[16px] text-[13px] leading-[1.7] text-[#8d93a3]">
               近い条件の記録はまだありません。
             </div>
           )}

--- a/src/features/recordDetail/sections/SimilarRunCard.tsx
+++ b/src/features/recordDetail/sections/SimilarRunCard.tsx
@@ -112,7 +112,8 @@ export function SimilarRunCard({
       onKeyDown={handleKeyDown}
       interactive={canOpenDetail}
       selected={isCompareSelected}
-      className={`rounded-[16px] p-[14px] shadow-none ${!isCompareSelected ? "hover:bg-[#f7f8fa]" : ""}`}
+      style={isCompareSelected ? undefined : { backgroundColor: "#FFFCF9" }}
+      className={`rounded-[16px] p-[14px] shadow-none ${isCompareSelected ? "" : "bg-[#FFFCF9]"}`}
     >
       <div className="flex items-start gap-[10px]">
         <div className="min-w-0 flex-1">
@@ -130,7 +131,7 @@ export function SimilarRunCard({
             </div>
           </div>
 
-          <div className="mt-[12px] rounded-[16px] border border-[#e5e7eb] bg-[#f7f8fa] px-[10px] py-[9px]">
+          <div className="mt-[12px] rounded-[16px] border border-[#e5e7eb] bg-[#FFFCF9] px-[10px] py-[9px]">
             <div className="flex items-center justify-between gap-[8px]">
               {match.run.party.map((member) => {
                 const characterName = characterDb[member.characterId]?.name ?? member.characterId;

--- a/src/features/recordDetail/ui/index.tsx
+++ b/src/features/recordDetail/ui/index.tsx
@@ -47,14 +47,17 @@ export function PillButton({
   onClick?: () => void;
   className?: string;
 }) {
+  const inactiveSurfaceStyle = !dark && !active ? { backgroundColor: "#FFFCF9" } : undefined;
+
   return (
     <button
       type="button"
       onClick={onClick}
+      style={inactiveSurfaceStyle}
       className={`inline-flex items-center justify-center gap-2 rounded-[42px] px-[14px] py-[7px] text-[14px] font-medium leading-none transition duration-150 hover:-translate-y-[1px] hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)] md:text-[15px] ${
         dark || active
           ? "border border-black/50 bg-black text-white"
-          : "border border-[#d8dde6] bg-[#f7f8fa] text-[#333333] hover:bg-[#eef1f5]"
+          : "border border-[#d8dde6] bg-[#FFFCF9] text-[#333333] hover:bg-[#FFFCF9]"
       } ${className}`}
     >
       {children}
@@ -84,7 +87,6 @@ export function SidebarPanel({ children }: { children: ReactNode }) {
   return (
     <section className={`w-full ${DETAIL_PANEL_SHELL_CLASS}`}>
       <div className={`${DETAIL_PANEL_INNER_CLASS} p-[16px]`}>
-        <div className="pointer-events-none absolute -left-[30%] -top-[44%] h-[220px] w-[220px] rounded-full bg-[radial-gradient(circle,rgba(255,255,255,0.72),rgba(232,224,210,0.24)_48%,rgba(255,255,255,0)_72%)] blur-[72px]" />
         <div className="relative z-[1]">{children}</div>
       </div>
     </section>
@@ -102,7 +104,7 @@ export function SidebarSectionHeader({ title, meta }: { title: ReactNode; meta?:
 
 export function PartyBuildItemCard({ entry }: { entry: PartyBuildItem }) {
   return (
-    <div className="rounded-[16px] border border-[#e5e7eb] bg-[#f7f8fa] p-[12px] md:p-[14px]">
+    <div className="rounded-[16px] border border-[#e5e7eb] bg-[#FFFCF9] p-[12px] md:p-[14px]">
       <div className="flex items-start gap-[12px] md:gap-[14px]">
         <CharacterIcon characterId={entry.characterId} alt={entry.characterName} fallbackLabel={entry.characterName} size={56} />
         <div className="min-w-0 flex-1">

--- a/src/features/submit/Page.tsx
+++ b/src/features/submit/Page.tsx
@@ -66,7 +66,7 @@ export function SubmitPage({ onBack, embedded = false }: { onBack: () => void; e
       <main className="min-h-screen bg-white text-[#333333]">
         <Header embedded={embedded} onBack={onBack} />
 
-        <div className="mx-auto flex w-full max-w-[1600px] flex-col gap-6 px-4 py-6 md:px-6">
+        <div className="mx-auto flex w-full max-w-[1280px] flex-col gap-5 px-3 py-4 md:px-5">
           <StepIndicator currentStep={draft.currentStep} onBack={handleStepBack} />
 
             {draft.currentStep === 1 ? (

--- a/src/features/submit/sections/FooterActions.tsx
+++ b/src/features/submit/sections/FooterActions.tsx
@@ -13,14 +13,14 @@ export function FooterActions({
   onSubmit: () => void;
 }) {
   return (
-<div className="mt-8 flex flex-col gap-4">
+<div className="mt-6 flex flex-col gap-3">
               <BottomActionButtons
                 currentStep={currentStep}
                 onSave={onSave}
                 onAdvance={onAdvance}
                 onSubmit={onSubmit}
               />
-              <div className="mx-auto w-full max-w-[500px] text-center text-[13px] leading-[1.7] text-[#7b7b8d]">
+              <div className="mx-auto w-full max-w-[400px] text-center text-[11px] leading-[1.7] text-[#7b7b8d]">
                 下書きはブラウザに保持され、ダミー submit 後も自動では消しません。
               </div>
             </div>

--- a/src/features/submit/sections/Header.tsx
+++ b/src/features/submit/sections/Header.tsx
@@ -5,18 +5,18 @@ export function Header({ embedded, onBack }: { embedded: boolean; onBack: () => 
     <>
         {embedded ? (
           <div className="border-b border-[#ebebeb] bg-white">
-            <div className="header-font mx-auto flex min-h-[52px] max-w-[1600px] items-center gap-3 px-4 py-2 md:px-6">
+            <div className="header-font mx-auto flex min-h-[42px] max-w-[1280px] items-center gap-2.5 px-3 py-1.5 md:px-5">
               <BackButton label="記録一覧へ戻る" onClick={onBack} icon="arrow" />
-              <div className="text-[16px] font-semibold tracking-tight text-black md:text-[18px]">記録申請</div>
+              <div className="text-[13px] font-semibold tracking-tight text-black md:text-[14px]">記録申請</div>
             </div>
           </div>
         ) : null}
         <nav className={embedded ? "hidden" : "sticky top-0 z-40 border-b border-[#ebebeb] bg-white shadow-[0_1px_0_rgba(0,0,0,0.02)]"}>
-          <div className="header-font mx-auto flex max-w-[1600px] items-center justify-between gap-3 px-4 py-3 md:px-6">
-            <div className="flex items-center gap-3">
-              <BackButton label="記録詳細へ戻る" onClick={onBack} icon="arrow" className="h-10 w-10" />
+          <div className="header-font mx-auto flex max-w-[1280px] items-center justify-between gap-2.5 px-3 py-2 md:px-5">
+            <div className="flex items-center gap-2.5">
+              <BackButton label="記録詳細へ戻る" onClick={onBack} icon="arrow" className="h-8 w-8" />
               <div>
-                <div className="text-[24px] font-semibold tracking-tight text-black md:text-[34px]">記録申請</div>
+                <div className="text-[19px] font-semibold tracking-tight text-black md:text-[27px]">記録申請</div>
               </div>
             </div>
           </div>

--- a/src/features/submit/sections/StepBasic.tsx
+++ b/src/features/submit/sections/StepBasic.tsx
@@ -12,21 +12,21 @@ type StepBasicProps = {
 
 export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTimeInput }: StepBasicProps) {
   return (
-<section className="mx-auto flex w-full max-w-[980px] flex-col gap-8">
+<section className="mx-auto flex w-full max-w-[784px] flex-col gap-6">
               <StepHeroHeader
                 title="1.基本情報の入力"
                 description="記録申請に必要な情報を入力して下さい。※この項目は必須項目です。"
               />
               <SectionDivider label="基本情報" />
 
-              <div className="flex flex-col gap-[44px]">
+              <div className="flex flex-col gap-[35px]">
                 <label className="block">
                   <FieldTitle quiet>カテゴリ</FieldTitle>
                   <CreateFieldBox className="mt-2">
                     <select
                       value={draft.basicInfo.ruleset}
                       onChange={(event) => updateBasicInfo("ruleset", event.target.value)}
-                      className="w-full bg-transparent text-[20px] text-black outline-none md:text-[24px]"
+                      className="w-full bg-transparent text-[16px] text-black outline-none md:text-[19px]"
                     >
                       {RULESET_OPTIONS.map((option) => (
                         <option key={option} value={option}>
@@ -45,45 +45,45 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
                       value={draft.basicInfo.videoUrl}
                       onChange={(event) => updateBasicInfo("videoUrl", event.target.value)}
                       placeholder="例) https://www.youtube.com/watch?v="
-                      className="w-full bg-transparent text-[18px] text-black outline-none md:text-[24px]"
+                      className="w-full bg-transparent text-[14px] text-black outline-none md:text-[19px]"
                     />
                   </CreateFieldBox>
-                  <div className="mt-2 text-[13px] text-[#9999b1]">(記録に対応するYouTubeのリンクを入力)</div>
+                  <div className="mt-1.5 text-[11px] text-[#9999b1]">(記録に対応するYouTubeのリンクを入力)</div>
                   <FieldError message={errors["basicInfo.videoUrl"]} />
                 </label>
 
                 <label className="block">
                   <FieldTitle quiet>タイム</FieldTitle>
-                  <div className="mt-2 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2 md:gap-3 md:px-8">
+                  <div className="mt-2 grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-1.5 md:gap-2.5 md:px-6">
                     <CreateFieldBox className="min-w-0">
                       <input
                         value={timeInput.hours}
                         onChange={(event) => updateTimeInput("hours", event.target.value.replace(/[^\d]/g, "").slice(0, 2))}
                         inputMode="numeric"
                         placeholder="00"
-                        className="w-full bg-transparent text-center text-[20px] text-black outline-none md:text-[24px]"
+                        className="w-full bg-transparent text-center text-[16px] text-black outline-none md:text-[19px]"
                         aria-label="時間"
                       />
                     </CreateFieldBox>
-                    <span className="text-[24px] font-bold text-[#9999b1] md:text-[28px]">:</span>
+                    <span className="text-[19px] font-bold text-[#9999b1] md:text-[22px]">:</span>
                     <CreateFieldBox className="min-w-0">
                       <input
                         value={timeInput.minutes}
                         onChange={(event) => updateTimeInput("minutes", event.target.value.replace(/[^\d]/g, "").slice(0, 2))}
                         inputMode="numeric"
                         placeholder="00"
-                        className="w-full bg-transparent text-center text-[20px] text-black outline-none md:text-[24px]"
+                        className="w-full bg-transparent text-center text-[16px] text-black outline-none md:text-[19px]"
                         aria-label="分"
                       />
                     </CreateFieldBox>
-                    <span className="text-[24px] font-bold text-[#9999b1] md:text-[28px]">:</span>
+                    <span className="text-[19px] font-bold text-[#9999b1] md:text-[22px]">:</span>
                     <CreateFieldBox className="min-w-0">
                       <input
                         value={timeInput.seconds}
                         onChange={(event) => updateTimeInput("seconds", event.target.value.replace(/[^\d]/g, "").slice(0, 2))}
                         inputMode="numeric"
                         placeholder="00"
-                        className="w-full bg-transparent text-center text-[20px] text-black outline-none md:text-[24px]"
+                        className="w-full bg-transparent text-center text-[16px] text-black outline-none md:text-[19px]"
                         aria-label="秒"
                       />
                     </CreateFieldBox>
@@ -91,10 +91,10 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
                   <FieldError message={errors["basicInfo.time"]} />
                 </label>
 
-                <div className="flex flex-col gap-5">
-                  <div className="flex flex-col gap-3">
-                    <div className="text-[15px] font-bold text-[#9999b1] md:text-[18px]">プレイ人数</div>
-                    <div className="grid gap-3 md:grid-cols-2 md:px-8">
+                <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-2.5">
+                    <div className="text-[12px] font-bold text-[#9999b1] md:text-[14px]">プレイ人数</div>
+                    <div className="grid gap-2.5 md:grid-cols-2 md:px-6">
                       {[
                         { value: "solo", label: "Solo" },
                         { value: "multiplayer", label: "Multiplayer" },
@@ -113,7 +113,7 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
 
                   <div className="block">
                     <FieldTitle quiet>プレイしているプラットフォーム</FieldTitle>
-                    <div className="mt-4 grid gap-3 md:grid-cols-3 md:px-8">
+                    <div className="mt-3 grid gap-2.5 md:grid-cols-3 md:px-6">
                       {PLATFORM_OPTIONS.map((option) => (
                         <CreateChoiceButton
                           key={option}
@@ -130,7 +130,7 @@ export function StepBasic({ draft, errors, timeInput, updateBasicInfo, updateTim
                   {draft.basicInfo.playMode === "multiplayer" ? (
                     <div className="block">
                       <FieldTitle quiet>2人目のプラットフォーム</FieldTitle>
-                      <div className="mt-4 grid gap-3 md:grid-cols-3 md:px-8">
+                      <div className="mt-3 grid gap-2.5 md:grid-cols-3 md:px-6">
                         {PLATFORM_OPTIONS.map((option) => (
                           <CreateChoiceButton
                             key={`secondary-${option}`}

--- a/src/features/submit/sections/StepDetails.tsx
+++ b/src/features/submit/sections/StepDetails.tsx
@@ -29,17 +29,17 @@ export function StepDetails({
   const toggleMainAttacker = onToggleMainAttacker;
 
   return (
-<section className="mx-auto flex w-full max-w-[980px] flex-col gap-8">
+<section className="mx-auto flex w-full max-w-[784px] flex-col gap-6">
               <StepHeroHeader title="3.詳細情報・ガイドライン" description="検索で見つけてもらいやすくするための項目です。" />
 
-              <div className="flex flex-col gap-[44px]">
-                <div className="flex flex-col gap-8">
+              <div className="flex flex-col gap-[35px]">
+                <div className="flex flex-col gap-6">
                   <SectionDivider label="詳細情報  (任意)" />
 
-                  <div className="flex flex-col gap-[44px]">
-                    <div className="flex flex-col gap-4">
+                  <div className="flex flex-col gap-[35px]">
+                    <div className="flex flex-col gap-3">
                       <FieldTitle quiet>メインアタッカーを選択 (一番与ダメージが高いものを選択)</FieldTitle>
-                      <div className="flex flex-col gap-4">
+                      <div className="flex flex-col gap-3">
                         {availablePartyCharacters.length > 0 ? (
                           availablePartyCharacters.map((characterId) => {
                             const character = characterDb[characterId];
@@ -53,34 +53,34 @@ export function StepDetails({
                                 onClick={() => toggleMainAttacker(characterId)}
                                 role={isMultiSelect ? "checkbox" : "radio"}
                                 aria-checked={isSelected}
-                                className={`flex items-center gap-8 rounded-[8px] bg-[#f6f6f6] px-4 py-4 text-left ${
+                                className={`flex items-center gap-6 rounded-[8px] bg-[#f6f6f6] px-3 py-3 text-left ${
                                   isSelected ? "ring-2 ring-[#333333]" : ""
                                 }`}
                               >
                                 <AttackerSelectionIndicator selected={isSelected} multiSelect={isMultiSelect} />
-                                <div className="flex items-center gap-3 text-[20px] text-[#9999b1] md:text-[24px]">
-                                  <CharacterIcon characterId={characterId} alt={character.name} fallbackLabel={character.name} size={36} />
+                                <div className="flex items-center gap-2.5 text-[16px] text-[#9999b1] md:text-[19px]">
+                                  <CharacterIcon characterId={characterId} alt={character.name} fallbackLabel={character.name} size={30} />
                                   <span>{character.name}</span>
                                 </div>
                               </button>
                             );
                           })
                         ) : (
-                          <div className="rounded-[8px] bg-[#f6f6f6] px-4 py-4 text-[16px] text-[#9999b1]">
+                          <div className="rounded-[8px] bg-[#f6f6f6] px-3 py-3 text-[13px] text-[#9999b1]">
                             Step 2 で編成を入力すると、ここで候補を選択できます。
                           </div>
                         )}
                       </div>
-                      <div className="text-[13px] leading-[1.7] text-[#7b7b8d]">
+                      <div className="text-[11px] leading-[1.7] text-[#7b7b8d]">
                         {draft.basicInfo.playMode === "multiplayer"
                           ? "マルチ時は複数選択できます。通常時は単一選択です。"
                           : "通常時は単一選択です。未選択でも申請できます。"}
                       </div>
                     </div>
 
-                    <div className="flex flex-col gap-2">
+                    <div className="flex flex-col gap-1.5">
                       <FieldTitle quiet>検索用タグ</FieldTitle>
-                      <div className="flex flex-wrap gap-4 md:gap-6">
+                      <div className="flex flex-wrap gap-3 md:gap-5">
                         {SEARCH_TAG_OPTIONS.map((tag) => {
                           const isSelected = draft.details.tagIds.includes(tag);
 
@@ -89,7 +89,7 @@ export function StepDetails({
                               key={tag}
                               type="button"
                               onClick={() => onToggleTag(tag)}
-                              className={`rounded-[42px] px-4 py-3 text-[18px] md:text-[24px] ${
+                              className={`rounded-[42px] px-3 py-2.5 text-[14px] md:text-[19px] ${
                                 isSelected ? "bg-[#333333] text-white" : "bg-[#f2f2f2] text-[#9999b1]"
                               }`}
                             >
@@ -106,36 +106,36 @@ export function StepDetails({
                         value={draft.details.notes}
                         onChange={(event) => onNotesChange(event.target.value)}
                         placeholder="この記録でのコメントをどうぞ！"
-                        className="mt-2 min-h-[223px] w-full rounded-[8px] bg-[#f6f6f6] px-4 py-4 text-[18px] text-black outline-none placeholder:text-[#c2c2c2] md:text-[24px]"
+                        className="mt-2 min-h-[178px] w-full rounded-[8px] bg-[#f6f6f6] px-3 py-3 text-[14px] text-black outline-none placeholder:text-[#c2c2c2] md:text-[19px]"
                       />
                     </label>
                   </div>
                 </div>
 
-                <div className="flex flex-col gap-8">
+                <div className="flex flex-col gap-6">
                   <SectionDivider label="申請するにあたって" />
 
-                  <div className="flex flex-col gap-2">
+                  <div className="flex flex-col gap-1.5">
                     <FieldTitle quiet>ガイドライン</FieldTitle>
-                    <label className="rounded-[8px] bg-[#f6f6f6] px-4 py-4">
-                      <div className="flex items-center gap-8">
+                    <label className="rounded-[8px] bg-[#f6f6f6] px-3 py-3">
+                      <div className="flex items-center gap-6">
                         <input
                           type="checkbox"
                           checked={draft.details.guidelineAccepted}
                           onChange={(event) => onGuidelineAcceptedChange(event.target.checked)}
-                          className="h-5 w-5"
+                          className="h-4 w-4"
                         />
-                        <span className="text-[18px] font-bold text-[#333333] md:text-[24px]">ガイドラインに同意する</span>
+                        <span className="text-[14px] font-bold text-[#333333] md:text-[19px]">ガイドラインに同意する</span>
                       </div>
                     </label>
                     <button
                       type="button"
                       onClick={onOpenGuidelines}
-                      className="text-center text-[18px] text-[#4d49fc] md:text-[24px]"
+                      className="text-center text-[14px] text-[#4d49fc] md:text-[19px]"
                     >
                       ガイドラインを確認
                     </button>
-                    <div className="text-[13px] leading-[1.7] text-[#7b7b8d]">同意は submit 時のみ必須です。下書き保存では不要です。</div>
+                    <div className="text-[11px] leading-[1.7] text-[#7b7b8d]">同意は submit 時のみ必須です。下書き保存では不要です。</div>
                     <FieldError message={errors["details.guidelineAccepted"]} />
                   </div>
                 </div>

--- a/src/features/submit/sections/StepParty.tsx
+++ b/src/features/submit/sections/StepParty.tsx
@@ -50,15 +50,15 @@ export function StepParty(props: StepPartyProps) {
   } = props;
 
   return (
-<section className="mx-auto flex w-full max-w-[1180px] flex-col gap-8">
+<section className="mx-auto flex w-full max-w-[944px] flex-col gap-6">
               <StepHeroHeader title="2.編成情報の入力" description="申請する狩りの記録で使用した編成を入力してください。" />
 
-              <div className="flex flex-col gap-8 xl:flex-row xl:items-start xl:gap-16">
-                <div className="flex flex-1 flex-col gap-8 border-b-2 border-[#d9d9d9] pb-8 xl:min-h-[864px]">
+              <div className="flex flex-col gap-6 xl:flex-row xl:items-start xl:gap-[52px]">
+                <div className="flex flex-1 flex-col gap-6 border-b-2 border-[#d9d9d9] pb-6 xl:min-h-[691px]">
                   <div>
                     <form onSubmit={handleUidSearchSubmit} className="relative rounded-[8px] bg-[#f6f6f6]">
                       <div className="pointer-events-none absolute inset-0 rounded-[8px] border border-[rgba(0,0,0,0.4)]" />
-                      <div className="flex items-center gap-3 px-4 py-3">
+                      <div className="flex items-center gap-2.5 px-3 py-2.5">
                         <input
                           value={draft.basicInfo.uid}
                           onChange={(event) => {
@@ -67,16 +67,16 @@ export function StepParty(props: StepPartyProps) {
                           }}
                           inputMode="numeric"
                           placeholder="UID を入力"
-                          className="min-w-0 flex-1 bg-transparent text-[18px] text-black outline-none md:text-[20px]"
+                          className="min-w-0 flex-1 bg-transparent text-[14px] text-black outline-none md:text-[16px]"
                         />
                         <button
                           type="submit"
                           aria-label={"UID\u3092\u691c\u7d22"}
                           title={"UID\u3092\u691c\u7d22"}
-                          className="group inline-flex h-[44px] shrink-0 items-center justify-center gap-[10px] rounded-[8px] bg-[#ececf2] px-4 text-[#5f6373] shadow-[inset_0_0_0_1px_rgba(123,123,141,0.14)] transition duration-150 hover:-translate-y-[1px] hover:bg-[#e4e5ec] hover:text-[#4d5160] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#333333]/10"
+                          className="group inline-flex h-[35px] shrink-0 items-center justify-center gap-2 rounded-[8px] bg-[#ececf2] px-3 text-[#5f6373] shadow-[inset_0_0_0_1px_rgba(123,123,141,0.14)] transition duration-150 hover:-translate-y-[1px] hover:bg-[#e4e5ec] hover:text-[#4d5160] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#333333]/10"
                         >
                           <SearchActionIcon />
-                          <span className="text-[16px] font-medium leading-none md:text-[17px]">{"\u53d6\u5f97"}</span>
+                          <span className="text-[13px] font-medium leading-none md:text-[14px]">{"\u53d6\u5f97"}</span>
                         </button>
                       </div>
                     </form>
@@ -84,7 +84,7 @@ export function StepParty(props: StepPartyProps) {
                   </div>
 
                   <div className="border-b border-[#d9d9d9]">
-                    <div className="flex gap-4 overflow-x-auto">
+                    <div className="flex gap-3 overflow-x-auto">
                       {draft.party.map((slot, index) => {
                         const active = activeSlot === index;
                         const slotCharacter = slot.characterId ? characterDb[slot.characterId] : null;
@@ -94,57 +94,57 @@ export function StepParty(props: StepPartyProps) {
                             key={`slot-tab-${index}`}
                             type="button"
                             onClick={() => setActiveSlot(index)}
-                            className={`relative flex shrink-0 items-center gap-2 px-6 py-4 ${active ? "border-b-[6px] border-black" : ""}`}
+                            className={`relative flex shrink-0 items-center gap-1.5 px-5 py-3 ${active ? "border-b-[5px] border-black" : ""}`}
                           >
-                            <span className={`grid h-10 w-10 place-items-center overflow-hidden rounded-full ${slotCharacter ? "" : active ? "bg-black" : "bg-[#d9d9d9]"}`}>
+                            <span className={`grid h-8 w-8 place-items-center overflow-hidden rounded-full ${slotCharacter ? "" : active ? "bg-black" : "bg-[#d9d9d9]"}`}>
                               {slotCharacter ? (
                                 <CharacterIcon
                                   characterId={slot.characterId}
                                   alt={slotCharacter.name}
                                   fallbackLabel={slotCharacter.name}
-                                  size={40}
+                                  size={32}
                                 />
                               ) : null}
                             </span>
-                            <span className={`text-[32px] ${active ? "text-black" : "text-[#d9d9d9]"}`}>{index + 1}</span>
+                            <span className={`text-[26px] ${active ? "text-black" : "text-[#d9d9d9]"}`}>{index + 1}</span>
                           </button>
                         );
                       })}
                     </div>
                   </div>
 
-                  <div className="flex min-w-0 flex-1 flex-col gap-[44px]">
-                      <div className="flex flex-col gap-4">
-                        <div className="flex items-center gap-3">
-                          <div className="h-7 w-3 bg-[#9999b1]" />
+                  <div className="flex min-w-0 flex-1 flex-col gap-[35px]">
+                      <div className="flex flex-col gap-3">
+                        <div className="flex items-center gap-2.5">
+                          <div className="h-[22px] w-2.5 bg-[#9999b1]" />
                           <FieldTitle quiet>{`${activeSlot + 1}人目のキャラクター`}</FieldTitle>
                         </div>
 
-                        <div className="rounded-[8px] bg-[#f6f6f6] p-4">
-                          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-                          <div className="flex flex-col gap-6 md:flex-row md:items-center">
+                        <div className="rounded-[8px] bg-[#f6f6f6] p-3">
+                          <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+                          <div className="flex flex-col gap-5 md:flex-row md:items-center">
                             <button
                               type="button"
                               onClick={() => setShowCharacterPicker(true)}
-                              className="flex h-[154px] w-[154px] items-center justify-center rounded-[4px] bg-white"
+                              className="flex h-[123px] w-[123px] items-center justify-center rounded-[4px] bg-white"
                             >
                               {activePartySlot.characterId ? (
                                 <CharacterIcon
                                   characterId={activePartySlot.characterId}
                                   alt={activeCharacter?.name ?? activePartySlot.characterId}
                                   fallbackLabel={activeCharacter?.name ?? activePartySlot.characterId}
-                                  size={120}
+                                  size={96}
                                 />
                               ) : (
-                                <div className="text-[128px] leading-none text-[#c2c2c2]">+</div>
+                                <div className="text-[102px] leading-none text-[#c2c2c2]">+</div>
                               )}
                             </button>
 
-                            <div className="flex w-full flex-col gap-6 md:w-[160px]">
+                            <div className="flex w-full flex-col gap-5 md:w-[128px]">
                               <button
                                 type="button"
                                 onClick={() => setShowCharacterPicker(true)}
-                                className="block w-full appearance-none bg-transparent p-0 text-left text-[32px] font-bold leading-none text-[#9999b1]"
+                                className="block w-full appearance-none bg-transparent p-0 text-left text-[26px] font-bold leading-none text-[#9999b1]"
                               >
                                 {activeCharacter?.name ?? "キャラ未選択"}
                               </button>
@@ -153,7 +153,7 @@ export function StepParty(props: StepPartyProps) {
                                   value={activePartySlot.cons}
                                   onChange={(event) => updatePartySlot(activeSlot, { cons: Number(event.target.value) })}
                                   disabled={!activePartySlot.characterId}
-                                  className="w-full bg-transparent text-[20px] text-[#9999b1] outline-none md:text-[24px]"
+                                  className="w-full bg-transparent text-[16px] text-[#9999b1] outline-none md:text-[19px]"
                                 >
                                   {Array.from({ length: 7 }, (_, index) => (
                                     <option key={index} value={index}>
@@ -165,59 +165,59 @@ export function StepParty(props: StepPartyProps) {
                             </div>
                           </div>
 
-                          <div className="flex items-center gap-6">
-                            <div className="hidden h-[154px] w-px bg-[#c2c2c2] md:block" />
-                            <div className="text-[28px] font-bold text-[#9999b1] md:text-[32px]">Cost : {activeCharacterCost}</div>
+                          <div className="flex items-center gap-5">
+                            <div className="hidden h-[123px] w-px bg-[#c2c2c2] md:block" />
+                            <div className="text-[22px] font-bold text-[#9999b1] md:text-[26px]">Cost : {activeCharacterCost}</div>
                           </div>
                         </div>
                           <FieldError message={errors[`party.${activeSlot}.characterId`]} />
                         </div>
                       </div>
 
-                      <div className="flex flex-col gap-4">
-                        <div className="flex items-center gap-3">
-                          <div className="h-7 w-3 bg-[#9999b1]" />
+                      <div className="flex flex-col gap-3">
+                        <div className="flex items-center gap-2.5">
+                          <div className="h-[22px] w-2.5 bg-[#9999b1]" />
                           <FieldTitle quiet>{`${activeSlot + 1}人目の武器`}</FieldTitle>
                         </div>
 
-                        <div className="rounded-[8px] bg-[#f6f6f6] p-4">
-                          <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
-                          <div className="flex flex-col gap-6 md:flex-row md:items-center">
+                        <div className="rounded-[8px] bg-[#f6f6f6] p-3">
+                          <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
+                          <div className="flex flex-col gap-5 md:flex-row md:items-center">
                             <button
                               type="button"
                               onClick={() => setShowWeaponPicker(true)}
                               disabled={!activePartySlot.characterId}
-                              className="flex h-[154px] w-[154px] items-center justify-center rounded-[4px] bg-white disabled:cursor-not-allowed disabled:opacity-60"
+                              className="flex h-[123px] w-[123px] items-center justify-center rounded-[4px] bg-white disabled:cursor-not-allowed disabled:opacity-60"
                             >
                               {activeWeapon ? (
                                 <WeaponIcon
                                   imageUrl={activeWeapon.imageUrl}
                                   alt={activeWeapon.name}
                                   fallbackLabel={activeWeapon.shortLabel}
-                                  size={120}
-                                  className="rounded-[12px] p-2"
+                                  size={96}
+                                  className="rounded-[10px] p-1.5"
                                 />
                               ) : (
-                                <div className="text-[128px] leading-none text-[#c2c2c2]">+</div>
+                                <div className="text-[102px] leading-none text-[#c2c2c2]">+</div>
                               )}
                             </button>
 
-                            <div className="flex w-full flex-col gap-6 md:w-[160px]">
+                            <div className="flex w-full flex-col gap-5 md:w-[128px]">
                               <button
                                 type="button"
                                 onClick={() => setShowWeaponPicker(true)}
                                 disabled={!activePartySlot.characterId}
-                                className="block w-full appearance-none bg-transparent p-0 text-center text-[28px] font-bold leading-none text-[#9999b1] disabled:cursor-not-allowed disabled:opacity-60 md:text-[32px]"
+                                className="block w-full appearance-none bg-transparent p-0 text-center text-[22px] font-bold leading-none text-[#9999b1] disabled:cursor-not-allowed disabled:opacity-60 md:text-[26px]"
                               >
                                 {activeWeapon?.name ?? "武器未選択"}
                               </button>
-                              <div className="flex flex-col gap-3">
+                              <div className="flex flex-col gap-2.5">
                                 <CreateFieldBox className="bg-white">
                                   <select
                                     value={activePartySlot.refine}
                                     onChange={(event) => updatePartySlot(activeSlot, { refine: Number(event.target.value) })}
                                     disabled={!activePartySlot.weaponId}
-                                    className="w-full bg-transparent text-[20px] text-[#9999b1] outline-none md:text-[24px]"
+                                    className="w-full bg-transparent text-[16px] text-[#9999b1] outline-none md:text-[19px]"
                                   >
                                     {Array.from({ length: 5 }, (_, index) => (
                                       <option key={index} value={index + 1}>
@@ -230,9 +230,9 @@ export function StepParty(props: StepPartyProps) {
                             </div>
                           </div>
 
-                          <div className="flex items-center gap-6">
-                            <div className="hidden h-[154px] w-px bg-[#c2c2c2] md:block" />
-                            <div className="text-[28px] font-bold text-[#9999b1] md:text-[32px]">Cost : {activeWeaponCost}</div>
+                          <div className="flex items-center gap-5">
+                            <div className="hidden h-[123px] w-px bg-[#c2c2c2] md:block" />
+                            <div className="text-[22px] font-bold text-[#9999b1] md:text-[26px]">Cost : {activeWeaponCost}</div>
                           </div>
                         </div>
                           <FieldError message={errors[`party.${activeSlot}.weaponId`]} />
@@ -241,36 +241,36 @@ export function StepParty(props: StepPartyProps) {
                   </div>
                 </div>
 
-                <aside className="w-full self-start rounded-[8px] bg-[#f6f6f6] p-4 xl:w-[492px]">
+                <aside className="w-full self-start rounded-[8px] bg-[#f6f6f6] p-3 xl:w-[394px]">
                   <div className="rounded-[8px] bg-white">
-                    <div className="px-4 py-8 text-center">
-                      <div className={`text-[72px] font-bold md:text-[96px] ${BRACKET_META[summary.bracket].text}`}>
+                    <div className="px-3 py-6 text-center">
+                      <div className={`text-[58px] font-bold md:text-[77px] ${BRACKET_META[summary.bracket].text}`}>
                         {BRACKET_META[summary.bracket].label}
                       </div>
-                      <div className="mt-7 flex flex-col gap-6 text-left text-[22px] font-bold text-[#9999b1] md:text-[24px]">
+                      <div className="mt-6 flex flex-col gap-5 text-left text-[18px] font-bold text-[#9999b1] md:text-[19px]">
                         <div>キャラクターCost : {summary.charCost}</div>
                         <div>武器Cost : {summary.weaponCost}</div>
                       </div>
                     </div>
 
-                    <div className="mx-4 h-px bg-[#d9d9d9]" />
+                    <div className="mx-3 h-px bg-[#d9d9d9]" />
 
-                    <div className="p-4">
-                      <div className="grid gap-6 md:grid-cols-[118px_minmax(0,1fr)]">
-                        <div className="space-y-6 text-[20px] font-bold md:text-[24px]">
+                    <div className="p-3">
+                      <div className="grid gap-5 md:grid-cols-[94px_minmax(0,1fr)]">
+                        <div className="space-y-5 text-[16px] font-bold md:text-[19px]">
                           <div className={summary.bracket === 1 ? "text-[#333333]" : "text-[#9999b1]"}>Low</div>
                           <div className={summary.bracket === 2 ? "text-[#333333]" : "text-[#9999b1]"}>Middle</div>
                           <div className={summary.bracket === 3 ? "text-[#333333]" : "text-[#9999b1]"}>High</div>
                           <div className={summary.bracket === 4 ? "text-[#333333]" : "text-[#9999b1]"}>Unlimited</div>
                         </div>
-                        <div className="space-y-6 text-[20px] font-bold md:text-[24px]">
+                        <div className="space-y-5 text-[16px] font-bold md:text-[19px]">
                           <div className={summary.bracket === 1 ? "text-[#333333]" : "text-[#9999b1]"}>キャラ≤3 & 武器≤1</div>
                           <div className={summary.bracket === 2 ? "text-[#333333]" : "text-[#9999b1]"}>キャラ≤6 & 武器≤2</div>
                           <div className={summary.bracket === 3 ? "text-[#333333]" : "text-[#9999b1]"}>キャラ≤12 & 武器≤3</div>
                           <div className={summary.bracket === 4 ? "text-[#333333]" : "text-[#9999b1]"}>その他</div>
                         </div>
                       </div>
-                      <div className="mt-6 text-[14px] text-[#9999b1] md:text-[16px]">※限定星5の引いた数</div>
+                      <div className="mt-5 text-[11px] text-[#9999b1] md:text-[13px]">※限定星5の引いた数</div>
                     </div>
                   </div>
 

--- a/src/features/submit/ui/index.tsx
+++ b/src/features/submit/ui/index.tsx
@@ -11,7 +11,7 @@ export function FieldError({ message }: { message?: string }) {
     return null;
   }
 
-  return <p className="mt-2 text-[13px] leading-[1.5] text-[#d24b5a]">{message}</p>;
+  return <p className="mt-1.5 text-[11px] leading-[1.5] text-[#d24b5a]">{message}</p>;
 }
 
 export function SectionTitle({
@@ -24,10 +24,10 @@ export function SectionTitle({
   action?: ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-3 border-b border-[#ebebeb] pb-5 md:flex-row md:items-end md:justify-between">
+    <div className="flex flex-col gap-2.5 border-b border-[#ebebeb] pb-4 md:flex-row md:items-end md:justify-between">
       <div>
-        <h2 className="text-[24px] font-bold text-black md:text-[30px]">{title}</h2>
-        {description ? <p className="mt-2 text-[14px] text-[#7b7b8d] md:text-[15px]">{description}</p> : null}
+        <h2 className="text-[19px] font-bold text-black md:text-[24px]">{title}</h2>
+        {description ? <p className="mt-1.5 text-[12px] text-[#7b7b8d] md:text-[13px]">{description}</p> : null}
       </div>
       {action}
     </div>
@@ -36,10 +36,10 @@ export function SectionTitle({
 
 export function SearchActionIcon() {
   return (
-    <span className="inline-flex h-7 w-7 items-center justify-center text-current">
+    <span className="inline-flex h-6 w-6 items-center justify-center text-current">
       <svg
         viewBox="0 0 24 24"
-        className="h-6 w-6"
+        className="h-5 w-5"
         fill="none"
         stroke="currentColor"
         strokeWidth="2.1"
@@ -57,7 +57,7 @@ export function SearchActionIcon() {
 export function PlatformChoiceContent({ platform }: { platform: Platform }) {
   return (
     <>
-      <PlatformIcon platform={platform} className="h-5 w-5 md:h-6 md:w-6" />
+      <PlatformIcon platform={platform} className="h-4 w-4 md:h-5 md:w-5" />
       <span>{platform}</span>
     </>
   );
@@ -71,18 +71,18 @@ export function StepIndicator({ currentStep, onBack }: { currentStep: SubmitStep
   ] as const;
 
   return (
-    <div className="mx-auto grid w-full max-w-[980px] items-start gap-4 px-4 md:grid-cols-[auto_minmax(0,1fr)_auto] md:px-0">
-      <BackButton label="戻る" showLabel onClick={onBack} className="self-center text-[16px] md:justify-self-start" />
+    <div className="mx-auto grid w-full max-w-[784px] items-start gap-3 px-3 md:grid-cols-[auto_minmax(0,1fr)_auto] md:px-0">
+      <BackButton label="戻る" showLabel onClick={onBack} className="self-center text-[13px] md:justify-self-start" />
 
-      <div className="flex w-full max-w-[664px] flex-col gap-4 justify-self-center">
-        <div className="grid grid-cols-[64px_minmax(0,1fr)_64px_minmax(0,1fr)_64px] items-center">
+      <div className="flex w-full max-w-[426px] flex-col gap-2.5 justify-self-center">
+        <div className="grid grid-cols-[42px_minmax(0,1fr)_42px_minmax(0,1fr)_42px] items-center">
           {steps.flatMap((entry, index) => {
             const active = currentStep >= entry.step;
 
             return [
               <div
                 key={`step-no-${entry.step}`}
-                className={`text-center text-[28px] font-bold md:text-[32px] ${active ? "text-black" : "text-[#d9d9d9]"}`}
+                className={`text-center text-[18px] font-bold md:text-[21px] ${active ? "text-black" : "text-[#d9d9d9]"}`}
               >
                 {String(entry.step).padStart(2, "0")}
               </div>,
@@ -91,26 +91,26 @@ export function StepIndicator({ currentStep, onBack }: { currentStep: SubmitStep
           })}
         </div>
 
-        <div className="grid grid-cols-[64px_minmax(0,1fr)_64px_minmax(0,1fr)_64px] items-center">
+        <div className="grid grid-cols-[42px_minmax(0,1fr)_42px_minmax(0,1fr)_42px] items-center">
           {steps.flatMap((entry, index) => {
             const active = currentStep >= entry.step;
             const current = currentStep === entry.step;
 
             return [
               <div key={`step-circle-${entry.step}`} className="grid place-items-center">
-                <div className={`h-16 w-16 rounded-full ${current ? "bg-[#0f1419]" : active ? "bg-[#333333]" : "bg-[#d9d9d9]"}`} />
+                <div className={`h-[42px] w-[42px] rounded-full ${current ? "bg-[#0f1419]" : active ? "bg-[#333333]" : "bg-[#d9d9d9]"}`} />
               </div>,
-              index < steps.length - 1 ? <div key={`step-line-${entry.step}`} className="h-1 w-full bg-[#d9d9d9]" /> : null,
+              index < steps.length - 1 ? <div key={`step-line-${entry.step}`} className="h-[2px] w-full bg-[#d9d9d9]" /> : null,
             ];
           })}
         </div>
 
-        <div className="grid grid-cols-[64px_minmax(0,1fr)_64px_minmax(0,1fr)_64px] items-center text-[14px] md:text-[16px]">
+        <div className="grid grid-cols-[42px_minmax(0,1fr)_42px_minmax(0,1fr)_42px] items-center text-[10px] md:text-[11px]">
           {steps.flatMap((entry, index) => {
             const active = currentStep >= entry.step;
 
             return [
-              <div key={`step-label-${entry.step}`} className={`text-center ${active ? "text-black" : "text-[#d9d9d9]"}`}>
+              <div key={`step-label-${entry.step}`} className={`whitespace-nowrap text-center ${active ? "text-black" : "text-[#d9d9d9]"}`}>
                 {entry.label}
               </div>,
               index < steps.length - 1 ? <div key={`step-label-spacer-${entry.step}`} /> : null,
@@ -119,14 +119,14 @@ export function StepIndicator({ currentStep, onBack }: { currentStep: SubmitStep
         </div>
       </div>
 
-      <div className="hidden md:block md:w-[70px]" aria-hidden="true" />
+      <div className="hidden md:block md:w-[56px]" aria-hidden="true" />
     </div>
   );
 }
 
 export function EmptyCharacterBadge({ label }: { label: string }) {
   return (
-    <div className="grid h-[72px] w-[72px] place-items-center rounded-full bg-[#f2f2f2] text-[24px] font-medium text-[#b2b2c0]">
+    <div className="grid h-[58px] w-[58px] place-items-center rounded-full bg-[#f2f2f2] text-[19px] font-medium text-[#b2b2c0]">
       {label}
     </div>
   );
@@ -136,7 +136,7 @@ export function BracketBadge({ bracket }: { bracket: Bracket }) {
   const meta = BRACKET_META[bracket];
 
   return (
-    <span className={`inline-flex items-center rounded-full px-3 py-1 text-[13px] font-semibold ${meta.accent} ${meta.text}`}>
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-semibold ${meta.accent} ${meta.text}`}>
       {meta.label}
     </span>
   );
@@ -152,12 +152,12 @@ export function AttackerSelectionIndicator({
   if (multiSelect) {
     return (
       <span
-        className={`grid h-7 w-7 place-items-center rounded-full border-2 transition md:h-8 md:w-8 ${
+        className={`grid h-6 w-6 place-items-center rounded-full border-2 transition md:h-7 md:w-7 ${
           selected ? "border-[#333333] bg-[#333333] text-white" : "border-[#9999b1] bg-white text-transparent"
         }`}
         aria-hidden="true"
       >
-        <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+        <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
           <path d="M5 12.5L9.5 17L19 7.5" />
         </svg>
       </span>
@@ -166,37 +166,37 @@ export function AttackerSelectionIndicator({
 
   return (
     <span
-      className={`grid h-7 w-7 place-items-center rounded-full border-2 transition md:h-8 md:w-8 ${
+      className={`grid h-6 w-6 place-items-center rounded-full border-2 transition md:h-7 md:w-7 ${
         selected ? "border-[#333333]" : "border-[#9999b1]"
       }`}
       aria-hidden="true"
     >
-      <span className={`h-3 w-3 rounded-full transition md:h-3.5 md:w-3.5 ${selected ? "bg-[#333333]" : "bg-transparent"}`} />
+      <span className={`h-2.5 w-2.5 rounded-full transition md:h-3 md:w-3 ${selected ? "bg-[#333333]" : "bg-transparent"}`} />
     </span>
   );
 }
 
 export function StepHeroHeader({ title, description }: { title: string; description: string }) {
   return (
-    <div className="flex flex-col gap-2">
-      <h2 className="text-[28px] font-bold text-black md:text-[32px]">{title}</h2>
-      <p className="text-[16px] leading-[1.8] text-[#9999b1] md:text-[20px]">{description}</p>
+    <div className="flex flex-col gap-1.5">
+      <h2 className="text-[22px] font-bold text-black md:text-[26px]">{title}</h2>
+      <p className="text-[13px] leading-[1.8] text-[#9999b1] md:text-[16px]">{description}</p>
     </div>
   );
 }
 
 export function SectionDivider({ label }: { label: string }) {
   return (
-    <div className="relative py-2">
+    <div className="relative py-1.5">
       <div className="absolute inset-0 border-b border-[#d9d9d9]" />
-      <div className="relative inline-flex bg-white pr-4 text-[22px] font-bold text-black md:text-[24px]">{label}</div>
+      <div className="relative inline-flex bg-white pr-3 text-[18px] font-bold text-black md:text-[19px]">{label}</div>
     </div>
   );
 }
 
 export function FieldTitle({ children, quiet = false }: { children: ReactNode; quiet?: boolean }) {
   return (
-    <div className={`text-[20px] font-bold md:text-[24px] ${quiet ? "text-[#9999b1]" : "text-black"}`}>{children}</div>
+    <div className={`text-[16px] font-bold md:text-[19px] ${quiet ? "text-[#9999b1]" : "text-black"}`}>{children}</div>
   );
 }
 
@@ -210,7 +210,7 @@ export function CreateFieldBox({
   padded?: boolean;
 }) {
   return (
-    <FieldShell variant="create" className={`${padded ? "px-4 py-4 md:px-5 md:py-4" : "p-0"} ${className}`}>
+    <FieldShell variant="create" className={`${padded ? "px-3 py-3 md:px-4 md:py-3" : "p-0"} ${className}`}>
       {children}
     </FieldShell>
   );
@@ -253,9 +253,9 @@ export function BottomActionButtons({
   const primaryLabel = currentStep < 3 ? "次へ" : "記録申請";
 
   return (
-    <div className="mx-auto flex w-full max-w-[500px] flex-col gap-4">
+    <div className="mx-auto flex w-full max-w-[400px] flex-col gap-3">
       {currentStep === 3 ? (
-        <div className="flex flex-col gap-4 md:flex-row">
+        <div className="flex flex-col gap-3 md:flex-row">
           <Button
             onClick={onSave}
             variant="secondary"


### PR DESCRIPTION
﻿## 概要

このPRは、public-demo UI stabilization中のデザイン調整をまとめるPRです。主な目的は `#library` のフィルターエントランス刷新で、既存の検索機能・保存形式・検索結果ロジックは維持したまま、入口の見た目と操作導線を `docs/mocks/library-new.filterentrance.tsx` ベースへ置き換えました。

このブランチは、指示どおり当時の現在HEADから作成しているため、`AGENTS.md` と先行して入っていたLP/detail/submit/背景色系のUI調整コミットも含まれています。

## 変更内容

### Library フィルターエントランス

- 旧フィルターエントランスの黒帯ヘッダー、枠、旧カードバー、検索タイルを廃止しました。
- モックの5枚カード構成を実装へ反映しました。
  - `キャラ・編成`
  - `武器`
  - `凸・精錬`
  - `カテゴリ・期間`
  - `タグ`
- 入口位置は現行のフィルターエントランス位置を維持し、PCではモック基準の中央配置にしています。
- モック通り、フィルターエントランス内部だけ `transform: scale()` によるフィットを使っています。
- 「この条件で絞り込む」CTAは既存の検索実行処理を呼び出します。
- `#library` から `#home` へ戻る「全ランキング」CTAは維持しています。

### フィルターキーとモーダル分割

- Library内部のフィルター入口キーを `character / weapon / cost / category / tag / search` に整理しました。
- 既存の `buildFilters` のデータ形は変更していません。
- `武器` は武器指定モーダル、`凸・精錬` は最大凸数・最大精錬・Cost系条件のモーダルとして分けています。
- スマホでもカードタップでモーダルを開くようにし、旧スマホ用インライン展開パネルは使わない形にしました。
- 検索履歴復元時の優先表示を、カード順に合わせて `キャラ → 武器 → 凸・精錬/Cost → カテゴリ → タグ` に更新しました。

### 先行UI調整として含まれる変更

- `AGENTS.md` の更新を含めています。
- 非LP/Submitページの基本背景色をHome基準に寄せた調整を含みます。
- detailサイドブロックや周辺サーフェスの白系配色調整を含みます。
- submitフローの密度調整、ステップナビ縮小を含みます。
- LPの `What You Can Do` モバイル向け文字サイズ調整を含みます。
- Library新フィルターエントランス用モックを `docs/mocks/library-new.filterentrance.tsx` として含めています。

## 維持した挙動

- route/hash構造は変更していません。
- `LibrarySearchFilters` とlocalStorage保存形式は変更していません。
- 検索結果の絞り込みロジック、keyword検索、SearchResults表示は維持しています。
- カード、結果一覧、比較候補、あとで見る、閲覧履歴のデータフローは変更していません。
- submitモーダルやLibrary以外の機能追加はしていません。

## 非自明な判断

- 見た目再現を優先するため、今回のLibraryフィルターエントランス内部に限ってscale実装を許容しています。
- モック内のHoyoLab画像URLは、試験デザイン再現を優先して外部参照のまま使っています。
- `武器` と `凸・精錬` は入口上は分けていますが、検索条件の保存と検索適用は既存の `buildFilters` をそのまま使います。

## 検証

- `npm run lint`
  - 通過
  - 既存警告: `src/features/home/ui/icons.tsx` の `react-refresh/only-export-components`
- `npm run typecheck`
  - 通過
- `npm run test`
  - 通過: 7 files / 35 tests
- `npm run build`
  - 通過
  - 既存警告: Viteのchunk size warning
- Playwright smoke
  - `#library` desktop/mobileで5枚カード表示を確認
  - 5カードそれぞれのモーダル開閉を確認
  - 「この条件で絞り込む」CTAの表示を確認
  - 「全ランキング」CTAから `#home` へ遷移することを確認

## 使用したSkills

- `grill-with-docs`: 変更前の意図整理と設計確認
- `webapp-testing`: Library画面のPlaywright確認
- `verification-before-completion`: PR前の検証コマンド確認
