### PR TITLE
Library検索入口と結果一覧を調整

### DIFF
--- a/src/features/library/Page.tsx
+++ b/src/features/library/Page.tsx
@@ -1,11 +1,12 @@
+import { useRef } from "react";
+
 import { ChevronRightIcon, CrownIcon } from "../../components/UiIcons";
 import { AppFooter, AppFooterBottomSpacer } from "../../components/AppFooter";
 import { FloatingCta } from "../../components/ui";
-import { LIBRARY_COLORS, LIBRARY_HERO_IMAGE_URL, LIBRARY_LABELS } from "./config";
 import { useLibraryPageState } from "./hooks/useLibraryPageState";
 import { FilterEntrance } from "./sections/FilterEntrance";
-import { LibraryHero } from "./sections/Hero";
 import { LibrarySearchResults } from "./sections/SearchResults";
+import type { LibrarySearchFilters } from "./types";
 
 const FLOATING_CTA_CLASS = "w-[236px] justify-between";
 
@@ -16,22 +17,25 @@ type LibraryPageProps = {
 
 export function LibraryPage({ onOpenRankings, onSelectRun }: LibraryPageProps) {
   const libraryState = useLibraryPageState({ onSelectRun });
+  const resultsAnchorRef = useRef<HTMLDivElement | null>(null);
+
+  const handleFilterSearch = (filters: LibrarySearchFilters) => {
+    libraryState.handleFilterSearch(filters);
+    window.setTimeout(() => {
+      window.requestAnimationFrame(() => {
+        resultsAnchorRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    }, 0);
+  };
 
   return (
     <div className="min-h-full bg-[#EDECEC] text-[#111827]">
-      <LibraryHero
-        imageUrl={LIBRARY_HERO_IMAGE_URL}
-        backgroundColor={LIBRARY_COLORS.pageBackground}
-        ariaLabel={LIBRARY_LABELS.heroAriaLabel}
-        keyword={libraryState.inputKeyword}
-        onKeywordChange={libraryState.setInputKeyword}
-        onKeywordCommit={libraryState.handleKeywordCommit}
-      />
       <FilterEntrance
         onModalOpenChange={libraryState.setIsFilterModalOpen}
-        onSearch={libraryState.handleFilterSearch}
+        onSearch={handleFilterSearch}
         restoreRequest={libraryState.filterRestoreRequest}
       />
+      <div ref={resultsAnchorRef} className="scroll-mt-6" aria-hidden="true" />
       <LibrarySearchResults
         filters={libraryState.appliedFilters}
         keyword={libraryState.appliedKeyword}

--- a/src/features/library/hooks/useLibraryFilterEntrance.ts
+++ b/src/features/library/hooks/useLibraryFilterEntrance.ts
@@ -6,11 +6,13 @@ import {
   cloneLibraryBuildFilterState,
   cloneLibraryCategoryFilterState,
   cloneLibrarySearchFilters,
+  countActiveLibraryFilterSelections,
   createEmptyLibraryBuildFilterState,
   createEmptyLibraryCategoryFilterState,
   getFirstActivePanelFromFilters,
   isSelectableFilterKey,
 } from "../logic/searchFilters";
+import { hasActiveLibrarySearchFilters } from "../logic/searchResults";
 import type {
   LibraryBuildFilterState,
   LibraryCategoryFilterState,
@@ -51,6 +53,27 @@ export function useLibraryFilterEntrance({
     onSearch?.(createCurrentSearchFilters());
   };
 
+  const hasActiveSearchFilters = useMemo(
+    () =>
+      hasActiveLibrarySearchFilters({
+        characterFilters,
+        buildFilters,
+        categoryFilters,
+        selectedTags,
+      }),
+    [buildFilters, categoryFilters, characterFilters, selectedTags],
+  );
+  const activeSelectionCounts = useMemo(
+    () =>
+      countActiveLibraryFilterSelections({
+        characterFilters,
+        buildFilters,
+        categoryFilters,
+        selectedTags,
+      }),
+    [buildFilters, categoryFilters, characterFilters, selectedTags],
+  );
+
   const handlePanelClick = (key: LibraryFilterKey) => {
     if (key === "search") {
       handleSearch();
@@ -87,6 +110,8 @@ export function useLibraryFilterEntrance({
     categoryFilters,
     characterFilters,
     desktopModalKey,
+    activeSelectionCounts,
+    hasActiveSearchFilters,
     selectedTags,
     handleDesktopPanelClick: handlePanelClick,
     handleMobilePanelClick: handlePanelClick,

--- a/src/features/library/logic/libraryLogic.test.ts
+++ b/src/features/library/logic/libraryLogic.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { addRecentRunId, upsertLibrarySearchHistory, type LibrarySearchHistoryEntry } from "./actionStorage";
-import { cloneLibrarySearchFilters, createEmptyLibrarySearchFilters, getFirstActivePanelFromFilters } from "./searchFilters";
+import { cloneLibrarySearchFilters, countActiveLibraryFilterSelections, createEmptyLibrarySearchFilters, getFirstActivePanelFromFilters } from "./searchFilters";
 
 describe("library action storage logic", () => {
   it("records recent run ids without duplicates and ignores unknown ids", () => {
@@ -75,5 +75,34 @@ describe("library search filter logic", () => {
     const tagFilters = createEmptyLibrarySearchFilters();
     tagFilters.selectedTags.push("PC");
     expect(getFirstActivePanelFromFilters(tagFilters)).toBe("tag");
+  });
+
+  it("counts active selections by filter panel", () => {
+    const filters = createEmptyLibrarySearchFilters();
+
+    expect(countActiveLibraryFilterSelections(filters)).toEqual({
+      character: 0,
+      weapon: 0,
+      cost: 0,
+      category: 0,
+      tag: 0,
+    });
+
+    filters.characterFilters.partyCharacters.includeIds.push("chasca", "mavuika");
+    filters.characterFilters.mainAttackers.excludeIds.push("amber");
+    filters.buildFilters.weaponIds.include.push("favoniusWarbow");
+    filters.buildFilters.costBracket = 2;
+    filters.buildFilters.maxConstellation = 1;
+    filters.categoryFilters.version = "5.6";
+    filters.categoryFilters.device = "PC";
+    filters.selectedTags.push("High", "OffMeta");
+
+    expect(countActiveLibraryFilterSelections(filters)).toEqual({
+      character: 3,
+      weapon: 1,
+      cost: 2,
+      category: 2,
+      tag: 2,
+    });
   });
 });

--- a/src/features/library/logic/searchFilters.ts
+++ b/src/features/library/logic/searchFilters.ts
@@ -75,33 +75,58 @@ export function isDefaultRange(value: NumericRange, limit: NumericRange) {
 }
 
 export function getFirstActivePanelFromFilters(filters: LibrarySearchFilters): SelectableFilterKey | null {
-  const characterCount =
-    filters.characterFilters.partyCharacters.includeIds.length +
-    filters.characterFilters.partyCharacters.excludeIds.length +
-    filters.characterFilters.mainAttackers.includeIds.length +
-    filters.characterFilters.mainAttackers.excludeIds.length;
+  const activeCounts = countActiveLibraryFilterSelections(filters);
 
-  if (characterCount > 0) {
+  if (activeCounts.character > 0) {
     return "character";
   }
 
-  if (hasActiveWeaponFilters(filters.buildFilters)) {
+  if (activeCounts.weapon > 0) {
     return "weapon";
   }
 
-  if (hasActiveCostFilters(filters.buildFilters)) {
+  if (activeCounts.cost > 0) {
     return "cost";
   }
 
-  if (filters.categoryFilters.ruleset || filters.categoryFilters.version || filters.categoryFilters.playStyle || filters.categoryFilters.food || filters.categoryFilters.device) {
+  if (activeCounts.category > 0) {
     return "category";
   }
 
-  if (filters.selectedTags.length > 0) {
+  if (activeCounts.tag > 0) {
     return "tag";
   }
 
   return null;
+}
+
+export function countActiveLibraryFilterSelections(filters: LibrarySearchFilters): Record<SelectableFilterKey, number> {
+  return {
+    character:
+      filters.characterFilters.partyCharacters.includeIds.length +
+      filters.characterFilters.partyCharacters.excludeIds.length +
+      filters.characterFilters.mainAttackers.includeIds.length +
+      filters.characterFilters.mainAttackers.excludeIds.length,
+    weapon: filters.buildFilters.weaponIds.include.length + filters.buildFilters.weaponIds.exclude.length,
+    cost: countActiveCostFilterFields(filters.buildFilters),
+    category: countActiveCategoryFilterFields(filters.categoryFilters),
+    tag: filters.selectedTags.length,
+  };
+}
+
+function countActiveCostFilterFields(filters: LibraryBuildFilterState) {
+  return [
+    filters.costBracket !== null,
+    !isDefaultRange(filters.charCostRange, LIBRARY_BUILD_RANGE_LIMITS.charCost),
+    !isDefaultRange(filters.weaponCostRange, LIBRARY_BUILD_RANGE_LIMITS.weaponCost),
+    !isDefaultRange(filters.fiveStarWeaponCountRange, LIBRARY_BUILD_RANGE_LIMITS.fiveStarWeaponCount),
+    filters.maxConstellation !== null,
+    filters.maxFiveStarRefinement !== null,
+  ].filter(Boolean).length;
+}
+
+function countActiveCategoryFilterFields(filters: LibraryCategoryFilterState) {
+  return [filters.ruleset, filters.version, filters.playStyle, filters.food, filters.device].filter(Boolean).length;
 }
 
 export function hasActiveWeaponFilters(filters: LibraryBuildFilterState) {

--- a/src/features/library/sections/FilterEntrance.tsx
+++ b/src/features/library/sections/FilterEntrance.tsx
@@ -176,6 +176,11 @@ const FILTER_ENTRANCE_DESKTOP_LAYOUT = {
   gap: 12,
 } as const;
 
+const FILTER_ENTRANCE_MAX_SCALE = {
+  mobile: 1,
+  desktop: 1.16,
+} as const;
+
 export function FilterEntrance({
   onModalOpenChange,
   onSearch,
@@ -188,9 +193,20 @@ export function FilterEntrance({
   const filterEntranceState = useLibraryFilterEntrance({ onModalOpenChange, onSearch, restoreRequest });
 
   return (
-    <section className="relative z-10 mx-auto -mt-24 max-w-[1340px] px-4 md:-mt-56 lg:px-8" style={{ color: UI.textMain }}>
+    <section className="relative z-10 mx-auto max-w-[1340px] px-4 pt-10 md:pt-14 lg:px-8" style={{ color: UI.textMain }}>
       <ResponsiveStyle />
-      <FilterEntranceShowcase activeKey={filterEntranceState.activeKey} onPanelClick={filterEntranceState.handleDesktopPanelClick} />
+      <div className="mb-7 text-center md:mb-9">
+        <h1 className="max-w-full overflow-hidden whitespace-nowrap pt-1 text-[43px] font-normal leading-[1.08] text-black md:text-[50px] lg:text-[69px] [font-family:'Bebas_Neue','Arial_Narrow','Space_Grotesk',sans-serif]">
+          RECORDS SERCH
+        </h1>
+        <p className="mt-2 text-sm font-medium text-neutral-500">条件を選んで記録を探す。</p>
+      </div>
+      <FilterEntranceShowcase
+        activeKey={filterEntranceState.activeKey}
+        activeSelectionCounts={filterEntranceState.activeSelectionCounts}
+        hasActiveSearchFilters={filterEntranceState.hasActiveSearchFilters}
+        onPanelClick={filterEntranceState.handleDesktopPanelClick}
+      />
       <LibraryFilterModal
         activeKey={filterEntranceState.desktopModalKey}
         characterFilters={filterEntranceState.characterFilters}
@@ -219,11 +235,24 @@ export function FilterEntrance({
   );
 }
 
-function FilterEntranceShowcase({ activeKey, onPanelClick }: { activeKey: SelectableFilterKey | null; onPanelClick: (key: LibraryFilterKey) => void }) {
+function FilterEntranceShowcase({
+  activeKey,
+  activeSelectionCounts,
+  hasActiveSearchFilters,
+  onPanelClick,
+}: {
+  activeKey: SelectableFilterKey | null;
+  activeSelectionCounts: Record<SelectableFilterKey, number>;
+  hasActiveSearchFilters: boolean;
+  onPanelClick: (key: LibraryFilterKey) => void;
+}) {
   const scaleAreaRef = useRef<HTMLDivElement | null>(null);
   const isDesktop = useMediaQuery("(min-width: 640px)");
   const layout = isDesktop ? FILTER_ENTRANCE_DESKTOP_LAYOUT : FILTER_ENTRANCE_MOBILE_LAYOUT;
-  const scale = useFitScale(scaleAreaRef, layout.width, 1);
+  const maxScale = isDesktop ? FILTER_ENTRANCE_MAX_SCALE.desktop : FILTER_ENTRANCE_MAX_SCALE.mobile;
+  const scale = useFitScale(scaleAreaRef, layout.width, maxScale);
+  const activeSelectionTotal = Object.values(activeSelectionCounts).reduce((sum, count) => sum + count, 0);
+  const searchButtonLabel = `${activeSelectionTotal}件の条件で絞り込む`;
   const scaledStageStyle = useMemo<CSSProperties>(
     () => ({
       width: layout.width,
@@ -237,7 +266,7 @@ function FilterEntranceShowcase({ activeKey, onPanelClick }: { activeKey: Select
   );
 
   return (
-    <div className="mx-auto w-full max-w-[828px]" role="group" aria-label={LIBRARY_LABELS.searchTitle}>
+    <div className="mx-auto w-full max-w-[960px]" role="group" aria-label={LIBRARY_LABELS.searchTitle}>
       <div ref={scaleAreaRef} className="w-full">
         <div className="relative mx-auto overflow-visible" style={{ width: layout.width * scale, height: layout.height * scale }}>
           <div className="absolute" style={scaledStageStyle}>
@@ -256,6 +285,7 @@ function FilterEntranceShowcase({ activeKey, onPanelClick }: { activeKey: Select
                 <FilterEntranceSummaryCard
                   key={item.key}
                   item={item}
+                  selectionCount={activeSelectionCounts[item.key]}
                   isActive={activeKey === item.key}
                   isDesktop={isDesktop}
                   onClick={() => onPanelClick(item.key)}
@@ -265,38 +295,45 @@ function FilterEntranceShowcase({ activeKey, onPanelClick }: { activeKey: Select
           </div>
         </div>
       </div>
-      <div className="mt-[26px] flex w-full justify-center sm:mt-[30px]">
-        <button
-          type="button"
-          className="group mx-auto flex w-fit items-center justify-center gap-[16px] text-[#050505] transition duration-200 hover:-translate-y-[1px] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50"
-          aria-label="この条件で絞り込む"
-          onClick={() => onPanelClick("search")}
-        >
-          <span className="font-['Inter','Noto_Sans_JP',sans-serif] text-[18px] font-black leading-none tracking-[0] sm:text-[19px]">
-            この条件で絞り込む
-          </span>
-          <span className="flex h-[52px] w-[52px] shrink-0 items-center justify-center rounded-full bg-black text-white transition duration-200 group-hover:scale-[1.04] group-hover:bg-[#1a1a1a]">
-            <DownArrowIcon />
-          </span>
-        </button>
-      </div>
+      {hasActiveSearchFilters ? (
+        <div className="mt-[26px] flex w-full justify-center sm:mt-[30px]">
+          <button
+            type="button"
+            className="library-filter-submit group mx-auto flex w-fit items-center justify-center gap-[16px] text-[#050505] transition duration-200 hover:-translate-y-[1px] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50"
+            aria-label={searchButtonLabel}
+            onClick={() => onPanelClick("search")}
+          >
+            <span className="library-filter-submit-label font-['Inter','Noto_Sans_JP',sans-serif] text-[18px] font-black leading-none tracking-[0] sm:text-[19px]">
+              {searchButtonLabel}
+            </span>
+            <span className="library-filter-submit-icon flex h-[52px] w-[52px] shrink-0 items-center justify-center rounded-full bg-black text-white transition duration-200 group-hover:scale-[1.04] group-hover:bg-[#1a1a1a]">
+              <DownArrowIcon />
+            </span>
+          </button>
+        </div>
+      ) : (
+        <div className="h-[38px] sm:h-[42px]" aria-hidden="true" />
+      )}
     </div>
   );
 }
 
 function FilterEntranceSummaryCard({
   item,
+  selectionCount,
   isActive,
   isDesktop,
   onClick,
 }: {
   item: (typeof FILTER_ENTRANCE_CARDS)[number];
+  selectionCount: number;
   isActive: boolean;
   isDesktop: boolean;
   onClick: () => void;
 }) {
   const imageClass = isDesktop ? item.desktopImageClass : item.mobileImageClass;
   const layout = isDesktop ? FILTER_ENTRANCE_DESKTOP_LAYOUT : FILTER_ENTRANCE_MOBILE_LAYOUT;
+  const statusLabel = formatSelectionStatusLabel(selectionCount);
 
   return (
     <button
@@ -334,7 +371,7 @@ function FilterEntranceSummaryCard({
             <div className="mt-[8px] flex w-[126px] items-center justify-center gap-2">
               <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
               <span className="whitespace-nowrap font-['Arial_Narrow',Arial,sans-serif] text-[8px] font-black tracking-[0.08em] text-[#868787]">
-                {item.lead}
+                {statusLabel}
               </span>
               <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
             </div>
@@ -360,7 +397,7 @@ function FilterEntranceSummaryCard({
           <div className="mt-[9px] flex w-[124px] items-center justify-center gap-2">
             <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
             <span className="whitespace-nowrap font-['Arial_Narrow',Arial,sans-serif] text-[8px] font-black tracking-[0.08em] text-[#868787]">
-              {item.lead}
+              {statusLabel}
             </span>
             <span className="h-[1.5px] flex-1 bg-[#6f7070]" />
           </div>
@@ -368,6 +405,10 @@ function FilterEntranceSummaryCard({
       ) : null}
     </button>
   );
+}
+
+function formatSelectionStatusLabel(selectionCount: number) {
+  return selectionCount > 0 ? `${selectionCount}件選択中` : "未選択";
 }
 
 function DownArrowIcon() {
@@ -1276,6 +1317,36 @@ function ResponsiveStyle() {
       .library-range-input { pointer-events: none; }
       .library-range-input::-webkit-slider-thumb { pointer-events: auto; }
       .library-range-input::-moz-range-thumb { pointer-events: auto; }
+      .library-filter-submit-label {
+        display: inline-block;
+        transform-origin: center;
+        animation: library-filter-submit-vertical-groove 1.42s cubic-bezier(0.45, 0, 0.2, 1) infinite;
+      }
+      .library-filter-submit-icon {
+        animation: library-filter-submit-vertical-groove 1.42s cubic-bezier(0.45, 0, 0.2, 1) infinite;
+        box-shadow: 0 10px 22px rgba(0, 0, 0, 0.18);
+      }
+      .library-filter-submit:hover .library-filter-submit-label,
+      .library-filter-submit:focus-visible .library-filter-submit-label {
+        animation-duration: 1.08s;
+      }
+      .library-filter-submit:hover .library-filter-submit-icon,
+      .library-filter-submit:focus-visible .library-filter-submit-icon {
+        animation-duration: 1.08s;
+      }
+      @keyframes library-filter-submit-vertical-groove {
+        0%, 100% { transform: translateY(0); }
+        18% { transform: translateY(-3px); }
+        36% { transform: translateY(1px); }
+        56% { transform: translateY(-2px); }
+        74% { transform: translateY(1px); }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .library-filter-submit-label,
+        .library-filter-submit-icon {
+          animation: none;
+        }
+      }
     `}</style>
   );
 }

--- a/src/features/library/sections/SearchResults.tsx
+++ b/src/features/library/sections/SearchResults.tsx
@@ -3,7 +3,7 @@ import { useEffect, useMemo, useState } from "react";
 import { appRuns, getAppRunById } from "../../../data/appRuns";
 import type { RunRecord } from "../../../data/mockRuns";
 import { LIBRARY_COMPARE_CANDIDATE_LIMIT, type LibrarySearchHistoryEntry } from "../logic/actionStorage";
-import { filterLibraryRuns, hasActiveLibrarySearchFilters } from "../logic/searchResults";
+import { filterLibraryRuns } from "../logic/searchResults";
 import type { LibrarySearchFilters } from "../types";
 import { CompareCandidatePanel } from "./CompareCandidatePanel";
 import { LibraryCompareDrawer } from "./LibraryCompareDrawer";
@@ -49,9 +49,6 @@ export function LibrarySearchResults({
   const compareCandidates = useMemo(() => compareCandidateIds.map((runId) => getAppRunById(runId)).filter((run): run is RunRecord => Boolean(run)), [compareCandidateIds]);
   const watchLaterRuns = useMemo(() => watchLaterIds.map((runId) => getAppRunById(runId)).filter((run): run is RunRecord => Boolean(run)), [watchLaterIds]);
   const viewHistoryRuns = useMemo(() => viewHistoryIds.map((runId) => getAppRunById(runId)).filter((run): run is RunRecord => Boolean(run)), [viewHistoryIds]);
-  const hasSearchCriteria = hasActiveLibrarySearchFilters(filters) || keyword.trim().length > 0;
-  const heading = hasSearchCriteria ? "検索結果" : "最近の投稿";
-  const lead = hasSearchCriteria ? "指定した条件に一致する記録を新しい順に表示しています。" : "おすすめ機能が入るまでの代替として、新しい投稿から表示しています。";
   const canOpenCompare = compareCandidates.length === LIBRARY_COMPARE_CANDIDATE_LIMIT;
 
   useEffect(() => {
@@ -61,61 +58,52 @@ export function LibrarySearchResults({
   }, [canOpenCompare]);
 
   return (
-    <section className="mx-auto max-w-[1340px] px-4 pb-16 pt-8 lg:px-8">
+    <section className="mx-auto w-full px-4 pb-16 pt-8 lg:px-8">
       <div className="border-t border-[#d4d4d4] pt-7 md:pt-8">
-        <h2 className="max-w-full overflow-hidden whitespace-nowrap text-[43px] font-normal leading-[40px] text-black md:text-[50px] lg:text-[69px] lg:leading-[62px] [font-family:'Bebas_Neue','Arial_Narrow','Space_Grotesk',sans-serif]">
-          RECORDS
-        </h2>
-        <div className="mt-4 flex flex-wrap items-center gap-3">
-          <span className="text-[20px] font-black tracking-[-0.03em] text-[#111827] md:text-[24px]">{heading}</span>
-          <span className="inline-flex h-8 items-center rounded-full border border-[#d8dde6] bg-white px-3 text-[12px] font-black text-[#5f6678]">{visibleRuns.length}件</span>
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px] lg:items-start">
+          {visibleRuns.length > 0 ? (
+            <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(240px,1fr))]">
+              {visibleRuns.map((run) => (
+                <LibraryRecordCard
+                  key={run.id}
+                  run={run}
+                  candidateLimitReached={compareCandidateIds.length >= LIBRARY_COMPARE_CANDIDATE_LIMIT}
+                  isCandidate={compareCandidateIds.includes(run.id)}
+                  isWatchLater={watchLaterIds.includes(run.id)}
+                  onAddCandidate={onAddCandidate}
+                  onToggleWatchLater={onToggleWatchLater}
+                  onSelectRun={onSelectRun}
+                />
+              ))}
+            </div>
+          ) : (
+            <LibraryEmptyResults />
+          )}
+          <aside className="space-y-4 lg:sticky lg:top-24 lg:max-h-[calc(100vh-6rem)] lg:self-start lg:overflow-y-auto lg:pr-1">
+            <CompareCandidatePanel
+              candidates={compareCandidates}
+              canOpenCompare={canOpenCompare}
+              onSelectRun={onSelectRun}
+              onRemove={onRemoveCandidate}
+              onClear={onClearCandidates}
+              onOpenCompare={() => {
+                if (canOpenCompare) {
+                  setIsCompareOpen(true);
+                }
+              }}
+            />
+            <LibrarySearchActionAccordion
+              searchHistory={searchHistory}
+              viewHistoryRuns={viewHistoryRuns}
+              watchLaterRuns={watchLaterRuns}
+              onApplySearchHistory={onApplySearchHistory}
+              onRemoveSearchHistory={onRemoveSearchHistory}
+              onSelectRun={onSelectRun}
+              onRemoveViewHistory={onRemoveViewHistory}
+              onRemoveWatchLater={onToggleWatchLater}
+            />
+          </aside>
         </div>
-        <p className="mt-2 max-w-[560px] text-[12px] font-bold leading-5 text-[#7b8493] md:text-[13px]">{lead}</p>
-      </div>
-
-      <div className="mt-7 grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px] lg:items-start">
-        {visibleRuns.length > 0 ? (
-          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-            {visibleRuns.map((run) => (
-              <LibraryRecordCard
-                key={run.id}
-                run={run}
-                candidateLimitReached={compareCandidateIds.length >= LIBRARY_COMPARE_CANDIDATE_LIMIT}
-                isCandidate={compareCandidateIds.includes(run.id)}
-                isWatchLater={watchLaterIds.includes(run.id)}
-                onAddCandidate={onAddCandidate}
-                onToggleWatchLater={onToggleWatchLater}
-                onSelectRun={onSelectRun}
-              />
-            ))}
-          </div>
-        ) : (
-          <LibraryEmptyResults />
-        )}
-        <aside className="space-y-4 lg:sticky lg:top-24 lg:max-h-[calc(100vh-6rem)] lg:self-start lg:overflow-y-auto lg:pr-1">
-          <CompareCandidatePanel
-            candidates={compareCandidates}
-            canOpenCompare={canOpenCompare}
-            onSelectRun={onSelectRun}
-            onRemove={onRemoveCandidate}
-            onClear={onClearCandidates}
-            onOpenCompare={() => {
-              if (canOpenCompare) {
-                setIsCompareOpen(true);
-              }
-            }}
-          />
-          <LibrarySearchActionAccordion
-            searchHistory={searchHistory}
-            viewHistoryRuns={viewHistoryRuns}
-            watchLaterRuns={watchLaterRuns}
-            onApplySearchHistory={onApplySearchHistory}
-            onRemoveSearchHistory={onRemoveSearchHistory}
-            onSelectRun={onSelectRun}
-            onRemoveViewHistory={onRemoveViewHistory}
-            onRemoveWatchLater={onToggleWatchLater}
-          />
-        </aside>
       </div>
 
       <LibraryCompareDrawer


### PR DESCRIPTION
## 変更内容
- Library上部のヒーロー検索バーを廃止し、LPのRecords Sneak Peekに合わせた中央見出しに置き換えました。
- フィルター入口カードの下段ラベルを、未選択 / N件選択中の状態表示に変更しました。
- 条件がない場合は絞り込みボタンを非表示にし、条件がある場合はN件の条件で絞り込むとして表示します。
- 絞り込みボタン押下後に検索結果先頭へスクロールするようにしました。
- 検索結果カード一覧を画面幅に応じたauto-fillグリッドに変更し、広い画面で4列以上表示できるようにしました。

## 実装の分割
- src/features/library/Page.tsx: 結果一覧アンカーと絞り込み後スクロールを追加。
- src/features/library/sections/FilterEntrance.tsx: 見出し、フィルター入口表示、絞り込みボタン状態とアニメーションを調整。
- src/features/library/hooks/useLibraryFilterEntrance.ts: フィルター有無と選択数をUIへ渡す状態を追加。
- src/features/library/logic/searchFilters.ts: フィルター選択数カウントを純粋関数化。
- src/features/library/sections/SearchResults.tsx: 結果見出し文言を削除し、横幅可変のカードグリッドに変更。
- src/features/library/logic/libraryLogic.test.ts: 選択数カウントのテストを追加。

## 保持した挙動
- フィルター内容の意味、モーダル内の選択フロー、比較候補・あとで見る・検索アクションは維持しています。
- モーダルの適用ボタンだけでは検索結果へスクロールせず、絞り込みボタン押下時にスクロールします。
- モバイルのフィルター入口スケールは従来どおり最大1倍です。

## トレードオフ
- 検索結果カードはYouTube風に画面幅へ追従するため、カード幅をminmax(240px, 1fr)にしています。広い画面では一覧性を優先し、カード内テキストは既存の省略表示に任せています。
- フィルター入口の見出し文言は依頼どおりRECORDS SERCH表記のままです。

## 検証
- npm run lint: 成功。既存のFast Refresh warningが1件あります。
- npm run typecheck: 成功。
- npm run test: 36 passed。
- npm run build: 成功。既存のchunk size warningがあります。
- Playwright確認: Libraryのdesktop/mobile表示、初期未選択表示、絞り込みボタン押下スクロール、1920px幅で結果カード1行6件表示を確認しました。

## 使用したSkills
- webapp-testing
- verification-before-completion