### PR TITLE
Libraryフィルター入口に選択条件サマリーを追加

### DIFF
--- a/.tmp_qa/library_search_title_scale_check.py
+++ b/.tmp_qa/library_search_title_scale_check.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+
+from playwright.sync_api import expect, sync_playwright
+
+
+def attach_error_collectors(page, console_errors, page_errors):
+    page.on(
+        "console",
+        lambda msg: console_errors.append(msg.text)
+        if msg.type == "error" and not msg.text.startswith("Failed to load resource:")
+        else None,
+    )
+    page.on("pageerror", lambda error: page_errors.append(str(error)))
+
+
+def check_layout(page, screenshot_name):
+    page.goto("http://127.0.0.1:5173/#library")
+    page.wait_for_load_state("networkidle")
+
+    title = page.get_by_role("heading", name="RECORDS SEARCH")
+    expect(title).to_be_visible()
+    expect(page.locator(".entrance-plus")).to_have_count(5)
+
+    title_box = title.bounding_box()
+    viewport_width = page.viewport_size["width"]
+    if not title_box:
+        raise AssertionError("Missing title bounding box")
+    if title_box["x"] < 0 or title_box["x"] + title_box["width"] > viewport_width:
+        raise AssertionError(f"Title overflows viewport: {title_box}, viewport={viewport_width}")
+
+    screenshot_path = Path(f".tmp_qa/{screenshot_name}")
+    page.screenshot(path=str(screenshot_path), full_page=True)
+    return screenshot_path
+
+
+def check_filter_scroll(page):
+    page.goto("http://127.0.0.1:5173/#library")
+    page.wait_for_load_state("networkidle")
+
+    filter_button = page.locator(".library-filter-submit")
+    expect(filter_button).to_have_count(0)
+
+    tag_card = page.locator(".entrance-plus").nth(4).locator("xpath=ancestor::button[1]")
+    tag_card.click()
+    expect(page.locator(".fixed.inset-x-0")).to_be_visible()
+    page.locator(".fixed.inset-x-0 button").filter(has_text="#").first.click()
+    page.locator(".fixed.inset-x-0 footer button").nth(1).click()
+
+    expect(filter_button).to_be_visible()
+    before_scroll = page.evaluate("window.scrollY")
+    filter_button.click()
+    page.wait_for_function("window.scrollY > 500")
+    after_scroll = page.evaluate("window.scrollY")
+    if after_scroll <= before_scroll:
+        raise AssertionError(f"Expected filter button to scroll down, before={before_scroll}, after={after_scroll}")
+
+
+def main():
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        console_errors = []
+        page_errors = []
+        screenshots = []
+
+        for viewport, screenshot_name in [
+            ({"width": 1440, "height": 1200}, "library_search_title_scale_desktop.png"),
+            ({"width": 390, "height": 1200}, "library_search_title_scale_mobile.png"),
+        ]:
+            page = browser.new_page(viewport=viewport)
+            attach_error_collectors(page, console_errors, page_errors)
+            screenshots.append(check_layout(page, screenshot_name))
+            page.close()
+
+        page = browser.new_page(viewport={"width": 1440, "height": 1000})
+        attach_error_collectors(page, console_errors, page_errors)
+        check_filter_scroll(page)
+        page.close()
+
+        browser.close()
+
+        if console_errors or page_errors:
+            raise AssertionError("Browser errors:\n" + "\n".join(console_errors + page_errors))
+
+        print("Library search title scale check passed. Screenshots: " + ", ".join(str(path) for path in screenshots))
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/codex-skills.md
+++ b/docs/codex-skills.md
@@ -151,6 +151,12 @@ content.
   `$webapp-testing`, `$gh-fix-ci`, `$verification-before-completion`,
   `$grill-with-docs`, `$supabase`, `$supabase-postgres-best-practices`,
   `$security-threat-model`, or `$skill-scanner`.
+- Do not use external PR-publishing Skills such as `github:yeet` for this
+  repository. Their generic PR title/body conventions can conflict with the
+  repo requirement that PR titles and bodies be written naturally in Japanese.
+  For PR work, follow `AGENTS.md` directly: inspect the diff, stage only the
+  intended files, write a Japanese PR title/body, and avoid tool-added prefixes
+  such as `[codex]`.
 - Mention repo-local Skills directly from this repo, for example:
   `$elite-run-supabase-rls-security`,
   `$elite-run-admin-moderation-security`, or

--- a/src/features/library/logic/libraryLogic.test.ts
+++ b/src/features/library/logic/libraryLogic.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import { addRecentRunId, upsertLibrarySearchHistory, type LibrarySearchHistoryEntry } from "./actionStorage";
-import { cloneLibrarySearchFilters, countActiveLibraryFilterSelections, createEmptyLibrarySearchFilters, getFirstActivePanelFromFilters } from "./searchFilters";
+import {
+  buildSelectedFilterSummaryLabels,
+  cloneLibrarySearchFilters,
+  countActiveLibraryFilterSelections,
+  createEmptyLibrarySearchFilters,
+  getFirstActivePanelFromFilters,
+} from "./searchFilters";
 
 describe("library action storage logic", () => {
   it("records recent run ids without duplicates and ignores unknown ids", () => {
@@ -104,5 +110,48 @@ describe("library search filter logic", () => {
       category: 2,
       tag: 2,
     });
+  });
+
+  it("builds selected filter summary labels in entrance order", () => {
+    const filters = createEmptyLibrarySearchFilters();
+    filters.characterFilters.partyCharacters.includeIds.push("chasca");
+    filters.characterFilters.partyCharacters.excludeIds.push("missing-character");
+    filters.characterFilters.mainAttackers.includeIds.push("mav");
+    filters.characterFilters.mainAttackers.excludeIds.push("amber");
+    filters.buildFilters.weaponIds.include.push("favoniusWarbow");
+    filters.buildFilters.weaponIds.exclude.push("missing-weapon");
+    filters.buildFilters.costBracket = 1;
+    filters.buildFilters.charCostRange = { min: 0, max: 12 };
+    filters.buildFilters.weaponCostRange = { min: 0, max: 3 };
+    filters.buildFilters.fiveStarWeaponCountRange = { min: 0, max: 2 };
+    filters.buildFilters.maxConstellation = 1;
+    filters.buildFilters.maxFiveStarRefinement = 3;
+    filters.categoryFilters.ruleset = "高難度";
+    filters.categoryFilters.version = "5.6";
+    filters.categoryFilters.playStyle = "4人マルチ";
+    filters.categoryFilters.food = "なし";
+    filters.categoryFilters.device = "PC";
+    filters.selectedTags.push("OffMeta");
+
+    expect(buildSelectedFilterSummaryLabels(filters)).toEqual([
+      "編成キャラ: Chasca",
+      "編成キャラ除外: missing-character",
+      "メイン: Mavuika",
+      "メイン除外: Amber",
+      "武器: Favonius Warbow",
+      "武器除外: missing-weapon",
+      "コスト帯: Low",
+      "キャラCost: 0-12",
+      "武器Cost: 0-3",
+      "星5武器数: 0-2",
+      "最大凸: C1",
+      "最大精錬: R3",
+      "カテゴリ: 高難度",
+      "期間: 5.6",
+      "人数: 4人マルチ",
+      "飯バフ: なし",
+      "端末: PC",
+      "タグ: OffMeta",
+    ]);
   });
 });

--- a/src/features/library/logic/searchFilters.ts
+++ b/src/features/library/logic/searchFilters.ts
@@ -1,3 +1,4 @@
+import { characterDb, weaponDb, type Bracket } from "../../../data/mockRuns";
 import { cloneHomeFilterState, createEmptyHomeFilterState } from "../../home/logic";
 import {
   LIBRARY_BUILD_RANGE_LIMITS,
@@ -112,6 +113,82 @@ export function countActiveLibraryFilterSelections(filters: LibrarySearchFilters
     category: countActiveCategoryFilterFields(filters.categoryFilters),
     tag: filters.selectedTags.length,
   };
+}
+
+const COST_BRACKET_SUMMARY_LABELS: Record<Bracket, string> = {
+  1: "Low",
+  2: "Middle",
+  3: "High",
+  4: "Unlimited",
+};
+
+export function buildSelectedFilterSummaryLabels(filters: LibrarySearchFilters): string[] {
+  const labels: string[] = [];
+
+  filters.characterFilters.partyCharacters.includeIds.forEach((id) => {
+    labels.push(`編成キャラ: ${characterDb[id]?.name ?? id}`);
+  });
+  filters.characterFilters.partyCharacters.excludeIds.forEach((id) => {
+    labels.push(`編成キャラ除外: ${characterDb[id]?.name ?? id}`);
+  });
+  filters.characterFilters.mainAttackers.includeIds.forEach((id) => {
+    labels.push(`メイン: ${characterDb[id]?.name ?? id}`);
+  });
+  filters.characterFilters.mainAttackers.excludeIds.forEach((id) => {
+    labels.push(`メイン除外: ${characterDb[id]?.name ?? id}`);
+  });
+
+  filters.buildFilters.weaponIds.include.forEach((id) => {
+    labels.push(`武器: ${weaponDb[id]?.name ?? id}`);
+  });
+  filters.buildFilters.weaponIds.exclude.forEach((id) => {
+    labels.push(`武器除外: ${weaponDb[id]?.name ?? id}`);
+  });
+
+  if (filters.buildFilters.costBracket !== null) {
+    labels.push(`コスト帯: ${COST_BRACKET_SUMMARY_LABELS[filters.buildFilters.costBracket]}`);
+  }
+  if (!isDefaultRange(filters.buildFilters.charCostRange, LIBRARY_BUILD_RANGE_LIMITS.charCost)) {
+    labels.push(`キャラCost: ${formatSummaryRange(filters.buildFilters.charCostRange)}`);
+  }
+  if (!isDefaultRange(filters.buildFilters.weaponCostRange, LIBRARY_BUILD_RANGE_LIMITS.weaponCost)) {
+    labels.push(`武器Cost: ${formatSummaryRange(filters.buildFilters.weaponCostRange)}`);
+  }
+  if (!isDefaultRange(filters.buildFilters.fiveStarWeaponCountRange, LIBRARY_BUILD_RANGE_LIMITS.fiveStarWeaponCount)) {
+    labels.push(`星5武器数: ${formatSummaryRange(filters.buildFilters.fiveStarWeaponCountRange)}`);
+  }
+  if (filters.buildFilters.maxConstellation !== null) {
+    labels.push(`最大凸: C${filters.buildFilters.maxConstellation}`);
+  }
+  if (filters.buildFilters.maxFiveStarRefinement !== null) {
+    labels.push(`最大精錬: R${filters.buildFilters.maxFiveStarRefinement}`);
+  }
+
+  if (filters.categoryFilters.ruleset) {
+    labels.push(`カテゴリ: ${filters.categoryFilters.ruleset}`);
+  }
+  if (filters.categoryFilters.version) {
+    labels.push(`期間: ${filters.categoryFilters.version}`);
+  }
+  if (filters.categoryFilters.playStyle) {
+    labels.push(`人数: ${filters.categoryFilters.playStyle}`);
+  }
+  if (filters.categoryFilters.food) {
+    labels.push(`飯バフ: ${filters.categoryFilters.food}`);
+  }
+  if (filters.categoryFilters.device) {
+    labels.push(`端末: ${filters.categoryFilters.device}`);
+  }
+
+  filters.selectedTags.forEach((tag) => {
+    labels.push(`タグ: ${tag}`);
+  });
+
+  return labels;
+}
+
+function formatSummaryRange(range: NumericRange) {
+  return `${range.min}-${range.max}`;
 }
 
 function countActiveCostFilterFields(filters: LibraryBuildFilterState) {

--- a/src/features/library/sections/FilterEntrance.tsx
+++ b/src/features/library/sections/FilterEntrance.tsx
@@ -1,6 +1,7 @@
 
 import { useLibraryFilterEntrance } from '../hooks/useLibraryFilterEntrance';
 import type { LibraryFilterRestoreRequest } from '../logic/actionStorage';
+import { buildSelectedFilterSummaryLabels } from '../logic/searchFilters';
 import type { LibrarySearchFilters } from '../types';
 import { UI } from './filterEntrance/config';
 import { FilterEntranceShowcase } from './filterEntrance/FilterEntranceShowcase';
@@ -16,13 +17,19 @@ export function FilterEntrance({
   restoreRequest?: LibraryFilterRestoreRequest | null;
 }) {
   const filterEntranceState = useLibraryFilterEntrance({ onModalOpenChange, onSearch, restoreRequest });
+  const selectedFilterSummaryLabels = buildSelectedFilterSummaryLabels({
+    characterFilters: filterEntranceState.characterFilters,
+    buildFilters: filterEntranceState.buildFilters,
+    categoryFilters: filterEntranceState.categoryFilters,
+    selectedTags: filterEntranceState.selectedTags,
+  });
 
   return (
     <section className="relative z-10 mx-auto max-w-[1340px] px-4 pt-10 md:pt-14 lg:px-8" style={{ color: UI.textMain }}>
       <ResponsiveStyle />
       <div className="mb-7 text-center md:mb-9">
         <h1 className="max-w-full overflow-hidden whitespace-nowrap pt-1 text-[46px] font-normal leading-[1.02] text-black md:text-[78px] lg:text-[96px] [font-family:'Bebas_Neue','Arial_Narrow','Space_Grotesk',sans-serif]">
-          RECORDS SERCH
+          RECORDS SEARCH
         </h1>
         <div className="mx-auto mt-3 flex max-w-[320px] items-center justify-center gap-4 text-[#222222] md:mt-4">
           <span className="h-[2px] flex-1 bg-[#d7d7d7]" />
@@ -37,6 +44,7 @@ export function FilterEntrance({
         activeKey={filterEntranceState.activeKey}
         activeSelectionCounts={filterEntranceState.activeSelectionCounts}
         hasActiveSearchFilters={filterEntranceState.hasActiveSearchFilters}
+        selectedFilterSummaryLabels={selectedFilterSummaryLabels}
         onPanelClick={filterEntranceState.handleDesktopPanelClick}
       />
       <LibraryFilterModal
@@ -98,6 +106,81 @@ function ResponsiveStyle() {
       .library-filter-submit:focus-visible .library-filter-submit-icon {
         animation-duration: 1.08s;
       }
+      .entrance-plus {
+        position: absolute;
+        right: 10px;
+        top: 10px;
+        z-index: 25;
+        display: grid;
+        place-items: center;
+        width: 28px;
+        height: 28px;
+        border-radius: 999px;
+        border: none;
+        background: rgba(255, 255, 255, 0.34);
+        box-shadow: none;
+        color: rgba(62, 65, 68, 0.72);
+        pointer-events: none;
+        backdrop-filter: blur(2px);
+        transition: background-color 0.2s ease, color 0.2s ease;
+      }
+      .group:hover .entrance-plus,
+      .group:focus-visible .entrance-plus {
+        background: rgba(255, 255, 255, 0.48);
+        color: rgba(62, 65, 68, 0.84);
+      }
+      .entrance-plus-icon {
+        width: 14px;
+        height: 14px;
+      }
+      .selected-filter-summary {
+        display: flex;
+        width: min(760px, 100%);
+        max-width: calc(100vw - 64px);
+        margin: 22px auto 0;
+        padding: 0 8px;
+        align-items: baseline;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 0 6px;
+        text-align: center;
+        font-size: 11px;
+        font-weight: 700;
+        line-height: 1.9;
+        letter-spacing: 0.02em;
+        color: rgba(75, 85, 99, 0.68);
+        overflow: hidden;
+      }
+      .selected-filter-summary-label {
+        flex: 0 0 auto;
+        color: rgba(55, 65, 81, 0.76);
+        font-weight: 900;
+      }
+      .selected-filter-summary-list {
+        display: flex;
+        min-width: 0;
+        max-width: 100%;
+        align-items: baseline;
+        justify-content: center;
+        flex-wrap: wrap;
+        gap: 0 6px;
+        color: rgba(75, 85, 99, 0.62);
+      }
+      .selected-filter-summary-item {
+        display: inline-flex;
+        min-width: 0;
+        max-width: 100%;
+        align-items: baseline;
+        white-space: normal;
+        overflow-wrap: anywhere;
+        word-break: keep-all;
+      }
+      .selected-filter-summary-item:not(:last-child)::after {
+        content: "/";
+        flex: 0 0 auto;
+        margin-left: 6px;
+        color: rgba(107, 114, 128, 0.42);
+      }
       @keyframes library-filter-submit-vertical-groove {
         0%, 100% { transform: translateY(0); }
         18% { transform: translateY(-3px); }
@@ -109,6 +192,29 @@ function ResponsiveStyle() {
         .library-filter-submit-label,
         .library-filter-submit-icon {
           animation: none;
+        }
+      }
+      @media (max-width: 767px) {
+        .selected-filter-summary {
+          width: 100%;
+          max-width: calc(100vw - 32px);
+          margin-top: 18px;
+          padding: 0 4px;
+          flex-direction: column;
+          align-items: center;
+          gap: 2px;
+          font-size: 10px;
+          line-height: 1.8;
+        }
+        .selected-filter-summary-label {
+          width: 100%;
+          text-align: center;
+        }
+        .selected-filter-summary-list {
+          width: 100%;
+          max-width: 100%;
+          justify-content: center;
+          gap: 0 5px;
         }
       }
     `}</style>

--- a/src/features/library/sections/filterEntrance/FilterEntranceShowcase.tsx
+++ b/src/features/library/sections/filterEntrance/FilterEntranceShowcase.tsx
@@ -9,11 +9,13 @@ export function FilterEntranceShowcase({
   activeKey,
   activeSelectionCounts,
   hasActiveSearchFilters,
+  selectedFilterSummaryLabels,
   onPanelClick,
 }: {
   activeKey: SelectableFilterKey | null;
   activeSelectionCounts: Record<SelectableFilterKey, number>;
   hasActiveSearchFilters: boolean;
+  selectedFilterSummaryLabels: string[];
   onPanelClick: (key: LibraryFilterKey) => void;
 }) {
   const scaleAreaRef = useRef<HTMLDivElement | null>(null);
@@ -65,8 +67,20 @@ export function FilterEntranceShowcase({
           </div>
         </div>
       </div>
+      {selectedFilterSummaryLabels.length > 0 ? (
+        <div className="selected-filter-summary" aria-live="polite">
+          <span className="selected-filter-summary-label">選択中の条件：</span>
+          <span className="selected-filter-summary-list">
+            {selectedFilterSummaryLabels.map((label, index) => (
+              <span key={`${label}-${index}`} className="selected-filter-summary-item">
+                {label}
+              </span>
+            ))}
+          </span>
+        </div>
+      ) : null}
       {hasActiveSearchFilters ? (
-        <div className="mt-[26px] flex w-full justify-center sm:mt-[30px]">
+        <div className={selectedFilterSummaryLabels.length > 0 ? "mt-[18px] flex w-full justify-center sm:mt-[22px]" : "mt-[26px] flex w-full justify-center sm:mt-[30px]"}>
           <button
             type="button"
             className="library-filter-submit group mx-auto flex w-fit items-center justify-center gap-[16px] text-[#050505] transition duration-200 hover:-translate-y-[1px] focus:outline-none focus-visible:ring-2 focus-visible:ring-[#111116]/50"
@@ -148,6 +162,9 @@ function FilterEntranceSummaryCard({
         <div className="absolute left-[-2px] top-[-5px] z-20 font-['Arial_Narrow',Arial,sans-serif] text-[64px] font-black leading-[0.78] tracking-[0] text-white/92">
           {item.no}
         </div>
+        <span className="entrance-plus" aria-hidden="true">
+          <PlusIcon />
+        </span>
 
         {!isDesktop ? (
           <div className="absolute left-[86px] top-[25px] z-20 flex max-w-[150px] flex-col items-start">
@@ -193,6 +210,14 @@ function FilterEntranceSummaryCard({
         </div>
       ) : null}
     </button>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <svg className="entrance-plus-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" />
+    </svg>
   );
 }
 


### PR DESCRIPTION
## 変更内容
- Library の FilterEntrance 5カード右上に、控えめな丸背景つきの `+` アイコンを追加しました。
- 適用済みフィルター条件から表示用ラベルを生成し、カード群と絞り込みボタンの間に選択中条件サマリーを表示するようにしました。
- 条件サマリーの生成順とフォールバックをテストで固定しました。
- 未追跡だった `.tmp_qa/library_search_title_scale_check.py` もPRに含め、現行の `RECORDS SEARCH` 表示と `+` アイコン確認に合わせて整理しました。
- `docs/codex-skills.md` に、外部PR公開Skill（例: `github:yeet`）をこのリポジトリで使わないガードレールを追加しました。
- ブランチ上に既にあった `RECORDS SERCH` から `RECORDS SEARCH` への typo 修正も含みます。

## 変更理由
- フィルター入口カードが操作入口であることを視覚的に伝えつつ、選択済み条件を検索実行前に確認できるようにするためです。
- サマリー生成は既存の filter state から作り、検索処理・モーダル処理・適用処理の挙動は変えていません。
- QAスクリプトもPR内に残し、タイトル幅とフィルター入口の基本挙動を後から再確認できるようにしました。
- 汎用SkillのPRタイトル規約が repo の日本語PR運用と衝突しないよう、今後は `AGENTS.md` を直接優先する方針を明文化しました。

## 実装分割
- `searchFilters.ts` に `buildSelectedFilterSummaryLabels` を追加し、キャラ・武器名の解決、コスト範囲、カテゴリ、タグをまとめて表示用ラベル化しました。
- `FilterEntrance.tsx` で現在の state からサマリーを生成し、レスポンシブ用CSSを追加しました。
- `FilterEntranceShowcase.tsx` で `+` アイコンとサマリー表示を描画しました。
- `.tmp_qa/library_search_title_scale_check.py` を追加し、Libraryタイトル幅、入口カード、タグ適用後スクロールの確認を行えるようにしました。
- `docs/codex-skills.md` にPR公開Skillを避ける運用ルールを追加しました。

## 維持した挙動
- 既存のカードクリック、モーダル表示、フィルター適用、検索ボタンの処理は維持しています。
- `+` アイコンは装飾のみで、クリック対象は従来通りカード全体です。

## トレードオフ
- サマリー文言はユーザー指定に合わせ、日本語ラベルを使っています。既存の文字化けしているUI文言には寄せていません。
- 外部画像/CDNの読み込み失敗はローカル検証環境のネットワーク制限由来として、アプリ由来の console error とは分けて確認しました。
- 外部プラグインSkill自体は repo 外にあるため、PR差分では削除できません。代わりに repo 内の運用ドキュメントで使用禁止を明記しました。

## 検証
- `npm run typecheck` 成功
- `npm run test` 成功（7 files / 37 tests）
- `npm run lint` 成功（既存の Fast Refresh warning 1件のみ）
- `npm run build` 成功（既存の Vite chunk size warning あり）
- `webapp-testing` で以下を確認
  - `#library` 画面を表示できる
  - 5カードすべてに `+` アイコンが表示される
  - カードクリックで従来通りモーダルが開く
  - Chasca 選択後、カード下かつ絞り込みボタン上にサマリーが表示される
  - モバイル幅でサマリーが横にはみ出さない
  - アプリ由来の console error なし
- 追加した `.tmp_qa/library_search_title_scale_check.py` は `ast.parse` で構文確認済み
- `docs/codex-skills.md` 変更は docs-only のため追加テストなし

## 使用した Skills
- `webapp-testing`
- `verification-before-completion`